### PR TITLE
Added TestIterationDispose method

### DIFF
--- a/Libraries/Core/Library/Attributes/Test.cs
+++ b/Libraries/Core/Library/Attributes/Test.cs
@@ -31,15 +31,15 @@ namespace Microsoft.PSharp
     public sealed class TestInit : Attribute { }
 
     /// <summary>
-    /// Attribute for declaring a cleanup method
-    /// to be called when all test iteration terminate.
+    /// Attribute for declaring a cleanup method to be
+    /// called when all test iterations terminate.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method)]
     public sealed class TestDispose : Attribute { }
 
     /// <summary>
-    /// Attribute for declaring a cleanup method
-    /// to be called when each test iteration terminates.
+    /// Attribute for declaring a cleanup method to be
+    /// called when each test iteration terminates.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method)]
     public sealed class TestIterationDispose : Attribute { }

--- a/Libraries/Core/Library/Attributes/Test.cs
+++ b/Libraries/Core/Library/Attributes/Test.cs
@@ -32,9 +32,15 @@ namespace Microsoft.PSharp
 
     /// <summary>
     /// Attribute for declaring a cleanup method
-    /// to be called when test terminates.
+    /// to be called when all test iteration terminate.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method)]
     public sealed class TestDispose : Attribute { }
 
+    /// <summary>
+    /// Attribute for declaring a cleanup method
+    /// to be called when each test iteration terminates.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    public sealed class TestIterationDispose : Attribute { }
 }

--- a/Libraries/Core/Utilities/IOLogger.cs
+++ b/Libraries/Core/Utilities/IOLogger.cs
@@ -31,5 +31,14 @@ namespace Microsoft.PSharp.Utilities
         {
             IO.InstallCustomLogger(logger);
         }
+
+        /// <summary>
+        /// Remove the custom logger provided previously
+        /// (Defaults to the console)
+        /// </summary>
+        public static void RemoveCustomLogger()
+        {
+            IO.InstallCustomLogger(null);
+        }
     }
 }

--- a/Libraries/Core/Utilities/IOLogger.cs
+++ b/Libraries/Core/Utilities/IOLogger.cs
@@ -33,8 +33,7 @@ namespace Microsoft.PSharp.Utilities
         }
 
         /// <summary>
-        /// Remove the custom logger provided previously
-        /// (Defaults to the console)
+        /// Removes the custom logger. Defaults to the console.
         /// </summary>
         public static void RemoveCustomLogger()
         {

--- a/Libraries/TestingServices/Engines/AbstractTestingEngine.cs
+++ b/Libraries/TestingServices/Engines/AbstractTestingEngine.cs
@@ -60,6 +60,11 @@ namespace Microsoft.PSharp.TestingServices
         internal MethodInfo TestDisposeMethod;
 
         /// <summary>
+        /// The P# test dispose method per iteration.
+        /// </summary>
+        internal MethodInfo TestIterationDisposeMethod;
+
+        /// <summary>
         /// A P# test action.
         /// </summary>
         internal Action<PSharpRuntime> TestAction;
@@ -190,6 +195,7 @@ namespace Microsoft.PSharp.TestingServices
             this.FindEntryPoint();
             this.TestInitMethod = FindTestMethod(typeof(TestInit));
             this.TestDisposeMethod = FindTestMethod(typeof(TestDispose));
+            this.TestIterationDisposeMethod = FindTestMethod(typeof(TestIterationDispose));
             this.Initialize();
         }
 
@@ -207,6 +213,7 @@ namespace Microsoft.PSharp.TestingServices
             this.FindEntryPoint();
             this.TestInitMethod = FindTestMethod(typeof(TestInit));
             this.TestDisposeMethod = FindTestMethod(typeof(TestDispose));
+            this.TestIterationDisposeMethod = FindTestMethod(typeof(TestIterationDispose));
             this.Initialize();
         }
 

--- a/Libraries/TestingServices/Engines/BugFindingEngine.cs
+++ b/Libraries/TestingServices/Engines/BugFindingEngine.cs
@@ -265,6 +265,23 @@ namespace Microsoft.PSharp.TestingServices
                     // Wait for test to terminate.
                     runtime.Wait();
 
+                    // user-provided cleanup for the iteration
+                    try
+                    {
+                        if (base.TestIterationDisposeMethod != null)
+                        {
+                            // Disposes the test state.
+                            base.TestIterationDisposeMethod.Invoke(null, new object[] { });
+                        }
+                    }
+                    catch (TargetInvocationException ex)
+                    {
+                        if (!(ex.InnerException is TaskCanceledException))
+                        {
+                            ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+                        }
+                    }
+
                     if (base.Configuration.EnableVisualization)
                     {
                         base.Visualizer.Refresh();

--- a/Libraries/TestingServices/Engines/BugFindingEngine.cs
+++ b/Libraries/TestingServices/Engines/BugFindingEngine.cs
@@ -265,23 +265,6 @@ namespace Microsoft.PSharp.TestingServices
                     // Wait for test to terminate.
                     runtime.Wait();
 
-                    // user-provided cleanup for the iteration
-                    try
-                    {
-                        if (base.TestIterationDisposeMethod != null)
-                        {
-                            // Disposes the test state.
-                            base.TestIterationDisposeMethod.Invoke(null, new object[] { });
-                        }
-                    }
-                    catch (TargetInvocationException ex)
-                    {
-                        if (!(ex.InnerException is TaskCanceledException))
-                        {
-                            ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
-                        }
-                    }
-
                     if (base.Configuration.EnableVisualization)
                     {
                         base.Visualizer.Refresh();
@@ -290,6 +273,23 @@ namespace Microsoft.PSharp.TestingServices
                     if (this.Configuration.EnableDataRaceDetection)
                     {
                         this.EmitRaceInstrumentationTraces(runtime, i);
+                    }
+                    
+                    try
+                    {
+                        // Invokes user-provided cleanup for this iteration.
+                        if (base.TestIterationDisposeMethod != null)
+                        {
+                            // Disposes the test state.
+                            base.TestIterationDisposeMethod.Invoke(null, null);
+                        }
+                    }
+                    catch (TargetInvocationException ex)
+                    {
+                        if (!(ex.InnerException is TaskCanceledException))
+                        {
+                            ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+                        }
                     }
 
                     // Invoke the per iteration callbacks, if any.

--- a/Libraries/TestingServices/Engines/ReplayEngine.cs
+++ b/Libraries/TestingServices/Engines/ReplayEngine.cs
@@ -170,11 +170,6 @@ namespace Microsoft.PSharp.TestingServices
                         // Starts the test.
                         base.TestMethod.Invoke(null, new object[] { runtime });
 
-                        if (base.TestDisposeMethod != null)
-                        {
-                            // Disposes the test state.
-                            base.TestDisposeMethod.Invoke(null, new object[] { });
-                        }  
                     }
                     catch (TargetInvocationException ex)
                     {
@@ -191,6 +186,30 @@ namespace Microsoft.PSharp.TestingServices
                 if (base.Configuration.EnableVisualization)
                 {
                     base.Visualizer.Refresh();
+                }
+
+                try
+                {
+                    // user-provided cleanup for the iteration
+                    if (base.TestIterationDisposeMethod != null)
+                    {
+                        // Disposes the test state.
+                        base.TestIterationDisposeMethod.Invoke(null, new object[] { });
+                    }
+
+                    // user-provided cleanup for all iterations
+                    if (base.TestDisposeMethod != null)
+                    {
+                        // Disposes the test state.
+                        base.TestDisposeMethod.Invoke(null, new object[] { });
+                    }
+                }
+                catch (TargetInvocationException ex)
+                {
+                    if (!(ex.InnerException is TaskCanceledException))
+                    {
+                        ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+                    }
                 }
 
                 // Checks for any liveness property violations. Requires

--- a/Libraries/TestingServices/Engines/ReplayEngine.cs
+++ b/Libraries/TestingServices/Engines/ReplayEngine.cs
@@ -190,14 +190,14 @@ namespace Microsoft.PSharp.TestingServices
 
                 try
                 {
-                    // user-provided cleanup for the iteration
+                    // Invokes user-provided cleanup for this iteration.
                     if (base.TestIterationDisposeMethod != null)
                     {
                         // Disposes the test state.
                         base.TestIterationDisposeMethod.Invoke(null, new object[] { });
                     }
 
-                    // user-provided cleanup for all iterations
+                    // Invokes user-provided cleanup for all iterations.
                     if (base.TestDisposeMethod != null)
                     {
                         // Disposes the test state.


### PR DESCRIPTION
Also fixed a bug in ReplayEngine. The Dispose methods must be called after runtime.Wait.