### PR TITLE
A scheduler declares if it is fair (probabilistically).

### DIFF
--- a/Libraries/TestingServices/Liveness/LivenessChecker.cs
+++ b/Libraries/TestingServices/Liveness/LivenessChecker.cs
@@ -66,6 +66,11 @@ namespace Microsoft.PSharp.TestingServices.Liveness
         private int LivenessTemperature;
 
         /// <summary>
+        /// Are we using a fair scheduler
+        /// </summary>
+        private bool IsSchedulerFair;
+
+        /// <summary>
         /// The index of the last scheduling step in
         /// the currently detected cycle.
         /// </summary>
@@ -94,7 +99,8 @@ namespace Microsoft.PSharp.TestingServices.Liveness
         /// Constructor.
         /// </summary>
         /// <param name="runtime">PSharpBugFindingRuntime</param>
-        internal LivenessChecker(PSharpBugFindingRuntime runtime)
+        /// <param name="IsFair">Is scheduler fair</param>
+        internal LivenessChecker(PSharpBugFindingRuntime runtime, bool IsFair)
         {
             this.Runtime = runtime;
 
@@ -105,6 +111,7 @@ namespace Microsoft.PSharp.TestingServices.Liveness
             this.LivenessTemperature = 0;
             this.EndOfCycleIndex = 0;
             this.CurrentCycleIndex = 0;
+            this.IsSchedulerFair = IsFair;
 
             this.Seed = this.Runtime.Configuration.RandomSchedulingSeed ?? DateTime.Now.Millisecond;
             this.Random = new Random(this.Seed);
@@ -170,7 +177,7 @@ namespace Microsoft.PSharp.TestingServices.Liveness
                     this.Runtime.BugFinder.Stop();
                 }
             }
-            else if (!this.Runtime.Configuration.CacheProgramState)
+            else if (!this.Runtime.Configuration.CacheProgramState && IsSchedulerFair) 
             {
                 foreach (var monitor in this.Monitors)
                 {
@@ -654,6 +661,14 @@ namespace Microsoft.PSharp.TestingServices.Liveness
         string ISchedulingStrategy.GetDescription()
         {
             return this.BugFindingSchedulingStrategy.GetDescription();
+        }
+
+        /// <summary>
+        /// Is this a fair scheduler?
+        /// </summary>
+        public bool IsFair()
+        {
+            return true;
         }
 
         #endregion

--- a/Libraries/TestingServices/Runtime/BugFindingRuntime.cs
+++ b/Libraries/TestingServices/Runtime/BugFindingRuntime.cs
@@ -129,7 +129,7 @@ namespace Microsoft.PSharp.TestingServices
             this.MachineActionTraceMap = new ConcurrentDictionary<MachineId, MachineActionTrace>();
 
             this.StateCache = new StateCache(this);
-            this.LivenessChecker = new LivenessChecker(this, strategy.IsFair());
+            this.LivenessChecker = new LivenessChecker(this, strategy);
             this.Visualizer = visualizer;
 
             this.OperationIdCounter = 0;

--- a/Libraries/TestingServices/Runtime/BugFindingRuntime.cs
+++ b/Libraries/TestingServices/Runtime/BugFindingRuntime.cs
@@ -129,7 +129,7 @@ namespace Microsoft.PSharp.TestingServices
             this.MachineActionTraceMap = new ConcurrentDictionary<MachineId, MachineActionTrace>();
 
             this.StateCache = new StateCache(this);
-            this.LivenessChecker = new LivenessChecker(this);
+            this.LivenessChecker = new LivenessChecker(this, strategy.IsFair());
             this.Visualizer = visualizer;
 
             this.OperationIdCounter = 0;

--- a/Libraries/TestingServices/SchedulingStrategies/DFS/DFSStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/DFS/DFSStrategy.cs
@@ -275,6 +275,15 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         }
 
         /// <summary>
+        /// Checks if this a fair scheduling strategy.
+        /// </summary>
+        /// <returns>Boolean</returns>
+        public bool IsFair()
+        {
+            return false;
+        }
+
+        /// <summary>
         /// Configures the next scheduling iteration.
         /// </summary>
         public void ConfigureNextIteration()
@@ -370,14 +379,6 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         public string GetDescription()
         {
             return "";
-        }
-
-        /// <summary>
-        /// Is this a fair scheduler?
-        /// </summary>
-        public bool IsFair()
-        {
-            return false;
         }
 
         #endregion

--- a/Libraries/TestingServices/SchedulingStrategies/DFS/DFSStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/DFS/DFSStrategy.cs
@@ -372,6 +372,14 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
             return "";
         }
 
+        /// <summary>
+        /// Is this a fair scheduler?
+        /// </summary>
+        public bool IsFair()
+        {
+            return false;
+        }
+
         #endregion
 
         #region private methods

--- a/Libraries/TestingServices/SchedulingStrategies/DelayBounded/DelayBoundingStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/DelayBounded/DelayBoundingStrategy.cs
@@ -195,6 +195,15 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         }
 
         /// <summary>
+        /// Checks if this a fair scheduling strategy.
+        /// </summary>
+        /// <returns>Boolean</returns>
+        public bool IsFair()
+        {
+            return false;
+        }
+
+        /// <summary>
         /// Configures the next scheduling iteration.
         /// </summary>
         public abstract void ConfigureNextIteration();
@@ -215,14 +224,6 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         /// </summary>
         /// <returns>String</returns>
         public abstract string GetDescription();
-
-        /// <summary>
-        /// Is this a fair scheduler?
-        /// </summary>
-        public bool IsFair()
-        {
-            return false;
-        }
 
         #endregion
     }

--- a/Libraries/TestingServices/SchedulingStrategies/DelayBounded/DelayBoundingStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/DelayBounded/DelayBoundingStrategy.cs
@@ -216,6 +216,14 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         /// <returns>String</returns>
         public abstract string GetDescription();
 
+        /// <summary>
+        /// Is this a fair scheduler?
+        /// </summary>
+        public bool IsFair()
+        {
+            return false;
+        }
+
         #endregion
     }
 }

--- a/Libraries/TestingServices/SchedulingStrategies/Fuzzing/ProbabilisticRandomStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/Fuzzing/ProbabilisticRandomStrategy.cs
@@ -218,6 +218,14 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
             return "Random seed '" + this.Seed + "'.";
         }
 
+        /// <summary>
+        /// Is this a fair scheduler?
+        /// </summary>
+        public bool IsFair()
+        {
+            return true;
+        }
+
         #endregion
     }
 }

--- a/Libraries/TestingServices/SchedulingStrategies/Fuzzing/ProbabilisticRandomStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/Fuzzing/ProbabilisticRandomStrategy.cs
@@ -201,6 +201,15 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         }
 
         /// <summary>
+        /// Checks if this a fair scheduling strategy.
+        /// </summary>
+        /// <returns>Boolean</returns>
+        public bool IsFair()
+        {
+            return true;
+        }
+
+        /// <summary>
         /// Resets the scheduling strategy.
         /// </summary>
         public void Reset()
@@ -216,14 +225,6 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         public string GetDescription()
         {
             return "Random seed '" + this.Seed + "'.";
-        }
-
-        /// <summary>
-        /// Is this a fair scheduler?
-        /// </summary>
-        public bool IsFair()
-        {
-            return true;
         }
 
         #endregion

--- a/Libraries/TestingServices/SchedulingStrategies/Fuzzing/RandomStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/Fuzzing/RandomStrategy.cs
@@ -166,6 +166,15 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         }
 
         /// <summary>
+        /// Checks if this a fair scheduling strategy.
+        /// </summary>
+        /// <returns>Boolean</returns>
+        public bool IsFair()
+        {
+            return true;
+        }
+
+        /// <summary>
         /// Resets the scheduling strategy.
         /// </summary>
         public void Reset()
@@ -181,14 +190,6 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         public string GetDescription()
         {
             return "Random seed '" + this.Seed + "'.";
-        }
-
-        /// <summary>
-        /// Is this a fair scheduler?
-        /// </summary>
-        public bool IsFair()
-        {
-            return true;
         }
 
         #endregion

--- a/Libraries/TestingServices/SchedulingStrategies/Fuzzing/RandomStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/Fuzzing/RandomStrategy.cs
@@ -183,6 +183,14 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
             return "Random seed '" + this.Seed + "'.";
         }
 
+        /// <summary>
+        /// Is this a fair scheduler?
+        /// </summary>
+        public bool IsFair()
+        {
+            return true;
+        }
+
         #endregion
     }
 }

--- a/Libraries/TestingServices/SchedulingStrategies/ISchedulingStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/ISchedulingStrategy.cs
@@ -66,6 +66,12 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         bool HasFinished();
 
         /// <summary>
+        /// Checks if this a fair scheduling strategy.
+        /// </summary>
+        /// <returns>Boolean</returns>
+        bool IsFair();
+
+        /// <summary>
         /// Prepares the next scheduling iteration.
         /// </summary>
         void ConfigureNextIteration();
@@ -74,11 +80,6 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         /// Resets the scheduling strategy.
         /// </summary>
         void Reset();
-
-        /// <summary>
-        /// Is this a fair scheduler?
-        /// </summary>
-        bool IsFair();
 
         /// <summary>
         /// Returns a textual description of the scheduling strategy.

--- a/Libraries/TestingServices/SchedulingStrategies/ISchedulingStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/ISchedulingStrategy.cs
@@ -76,6 +76,11 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         void Reset();
 
         /// <summary>
+        /// Is this a fair scheduler?
+        /// </summary>
+        bool IsFair();
+
+        /// <summary>
         /// Returns a textual description of the scheduling strategy.
         /// </summary>
         /// <returns>String</returns>

--- a/Libraries/TestingServices/SchedulingStrategies/OperationBounded/OperationBoundingStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/OperationBounded/OperationBoundingStrategy.cs
@@ -216,6 +216,14 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         /// <returns>String</returns>
         public abstract string GetDescription();
 
+        /// <summary>
+        /// Is this a fair scheduler?
+        /// </summary>
+        public bool IsFair()
+        {
+            return false;
+        }
+
         #endregion
 
         #region protected methods

--- a/Libraries/TestingServices/SchedulingStrategies/OperationBounded/OperationBoundingStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/OperationBounded/OperationBoundingStrategy.cs
@@ -190,6 +190,15 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         }
 
         /// <summary>
+        /// Checks if this a fair scheduling strategy.
+        /// </summary>
+        /// <returns>Boolean</returns>
+        public bool IsFair()
+        {
+            return false;
+        }
+
+        /// <summary>
         /// Configures the next scheduling iteration.
         /// </summary>
         public virtual void ConfigureNextIteration()
@@ -215,14 +224,6 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         /// </summary>
         /// <returns>String</returns>
         public abstract string GetDescription();
-
-        /// <summary>
-        /// Is this a fair scheduler?
-        /// </summary>
-        public bool IsFair()
-        {
-            return false;
-        }
 
         #endregion
 

--- a/Libraries/TestingServices/SchedulingStrategies/Prioritized/PCTStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/Prioritized/PCTStrategy.cs
@@ -182,6 +182,15 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         }
 
         /// <summary>
+        /// Checks if this a fair scheduling strategy.
+        /// </summary>
+        /// <returns>Boolean</returns>
+        public bool IsFair()
+        {
+            return false;
+        }
+
+        /// <summary>
         /// Configures the next scheduling iteration.
         /// </summary>
         public void ConfigureNextIteration()
@@ -238,14 +247,6 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
 
             text += "]'.";
             return text;
-        }
-
-        /// <summary>
-        /// Is this a fair scheduler?
-        /// </summary>
-        public bool IsFair()
-        {
-            return false;
         }
 
         #endregion

--- a/Libraries/TestingServices/SchedulingStrategies/Prioritized/PCTStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/Prioritized/PCTStrategy.cs
@@ -240,6 +240,14 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
             return text;
         }
 
+        /// <summary>
+        /// Is this a fair scheduler?
+        /// </summary>
+        public bool IsFair()
+        {
+            return false;
+        }
+
         #endregion
 
         #region private methods

--- a/Libraries/TestingServices/SchedulingStrategies/Special/InteractiveStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/Special/InteractiveStrategy.cs
@@ -383,7 +383,16 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         {
             return false;
         }
-        
+
+        /// <summary>
+        /// Checks if this a fair scheduling strategy.
+        /// </summary>
+        /// <returns>Boolean</returns>
+        public bool IsFair()
+        {
+            return false;
+        }
+
         /// <summary>
         /// Configures the next scheduling iteration.
         /// </summary>
@@ -408,14 +417,6 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         public string GetDescription()
         {
             return "";
-        }
-
-        /// <summary>
-        /// Is this a fair scheduler?
-        /// </summary>
-        public bool IsFair()
-        {
-            return false;
         }
 
         #endregion

--- a/Libraries/TestingServices/SchedulingStrategies/Special/InteractiveStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/Special/InteractiveStrategy.cs
@@ -410,6 +410,14 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
             return "";
         }
 
+        /// <summary>
+        /// Is this a fair scheduler?
+        /// </summary>
+        public bool IsFair()
+        {
+            return false;
+        }
+
         #endregion
 
         #region private methods

--- a/Libraries/TestingServices/SchedulingStrategies/Special/MaceMCStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/Special/MaceMCStrategy.cs
@@ -154,6 +154,15 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         }
 
         /// <summary>
+        /// Checks if this a fair scheduling strategy.
+        /// </summary>
+        /// <returns>Boolean</returns>
+        public bool IsFair()
+        {
+            return true;
+        }
+
+        /// <summary>
         /// Configures the next scheduling iteration.
         /// </summary>
         public void ConfigureNextIteration()
@@ -179,16 +188,7 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         {
             return "";
         }
-
-        /// <summary>
-        /// Is this a fair scheduler?
-        /// </summary>
-        public bool IsFair()
-        {
-            return true;
-        }
-
-
+        
         #endregion
     }
 }

--- a/Libraries/TestingServices/SchedulingStrategies/Special/MaceMCStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/Special/MaceMCStrategy.cs
@@ -180,6 +180,15 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
             return "";
         }
 
+        /// <summary>
+        /// Is this a fair scheduler?
+        /// </summary>
+        public bool IsFair()
+        {
+            return true;
+        }
+
+
         #endregion
     }
 }

--- a/Libraries/TestingServices/SchedulingStrategies/Special/ReplayStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/Special/ReplayStrategy.cs
@@ -209,7 +209,16 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         {
             return true;
         }
-        
+
+        /// <summary>
+        /// Checks if this a fair scheduling strategy.
+        /// </summary>
+        /// <returns>Boolean</returns>
+        public bool IsFair()
+        {
+            return false;
+        }
+
         /// <summary>
         /// Configures the next scheduling iteration.
         /// </summary>
@@ -235,14 +244,6 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         public string GetDescription()
         {
             return "";
-        }
-
-        /// <summary>
-        /// Is this a fair scheduler?
-        /// </summary>
-        public bool IsFair()
-        {
-            return false;
         }
 
         #endregion

--- a/Libraries/TestingServices/SchedulingStrategies/Special/ReplayStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/Special/ReplayStrategy.cs
@@ -237,6 +237,14 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
             return "";
         }
 
+        /// <summary>
+        /// Is this a fair scheduler?
+        /// </summary>
+        public bool IsFair()
+        {
+            return false;
+        }
+
         #endregion
     }
 }


### PR DESCRIPTION
Liveness temperature detection is turned off when scheduler
is not fair.