### PR TITLE
report number of times max-steps was hit

### DIFF
--- a/Libraries/TestingServices/Engines/BugFindingEngine.cs
+++ b/Libraries/TestingServices/Engines/BugFindingEngine.cs
@@ -55,6 +55,11 @@ namespace Microsoft.PSharp.TestingServices
         /// </summary>
         private string ReproducableTrace;
 
+        /// <summary>
+        /// Number of times max steps was it.
+        /// </summary>
+        private int MaxStepsHit;
+
         #endregion
 
         #region public API
@@ -199,6 +204,7 @@ namespace Microsoft.PSharp.TestingServices
             this.ExploredSchedules = 0;
             this.ReadableTrace = "";
             this.ReproducableTrace = "";
+            this.MaxStepsHit = 0;
         }
 
         #endregion
@@ -339,6 +345,11 @@ namespace Microsoft.PSharp.TestingServices
                     this.ExploredSchedules++;
                     base.ExploredDepth = runtime.BugFinder.ExploredSteps;
 
+                    if (runtime.BugFinder.HitMaxSteps)
+                    {
+                        this.MaxStepsHit++;
+                    }
+
                     if (runtime.BugFinder.BugFound)
                     {
                         base.NumOfFoundBugs++;
@@ -461,6 +472,10 @@ namespace Microsoft.PSharp.TestingServices
                 report.Append($"{prefix} Configured to explore up to " +
                     $"'{base.Configuration.MaxSchedulingSteps}' max steps.");
                 report.AppendLine();
+                report.AppendFormat("{0} Hit max-steps bound in {1}% schedules", prefix,
+                    (this.MaxStepsHit * 100 / this.ExploredSchedules));
+                report.AppendLine();
+
             }
 
             report.Append($"{prefix} Elapsed {base.Profiler.Results()} sec.");

--- a/Libraries/TestingServices/Engines/BugFindingEngine.cs
+++ b/Libraries/TestingServices/Engines/BugFindingEngine.cs
@@ -197,7 +197,7 @@ namespace Microsoft.PSharp.TestingServices
         }
 
         /// <summary>
-        /// Initialized the bug-finding engine.
+        /// Initializes the bug-finding engine.
         /// </summary>
         private void Initialize()
         {
@@ -345,7 +345,7 @@ namespace Microsoft.PSharp.TestingServices
                     this.ExploredSchedules++;
                     base.ExploredDepth = runtime.BugFinder.ExploredSteps;
 
-                    if (Strategy.HasReachedMaxSchedulingSteps())
+                    if (base.Strategy.HasReachedMaxSchedulingSteps())
                     {
                         this.MaxStepsHit++;
                     }

--- a/Libraries/TestingServices/Engines/BugFindingEngine.cs
+++ b/Libraries/TestingServices/Engines/BugFindingEngine.cs
@@ -345,7 +345,7 @@ namespace Microsoft.PSharp.TestingServices
                     this.ExploredSchedules++;
                     base.ExploredDepth = runtime.BugFinder.ExploredSteps;
 
-                    if (runtime.BugFinder.HitMaxSteps)
+                    if (Strategy.HasReachedMaxSchedulingSteps())
                     {
                         this.MaxStepsHit++;
                     }

--- a/Libraries/TestingServices/Scheduling/BugFindingScheduler.cs
+++ b/Libraries/TestingServices/Scheduling/BugFindingScheduler.cs
@@ -63,14 +63,6 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         }
 
         /// <summary>
-        /// True if max steps was hit.
-        /// </summary>
-        internal bool HitMaxSteps
-        {
-            get; private set;
-        }
-
-        /// <summary>
         /// Number of explored steps.
         /// </summary>
         internal int ExploredSteps
@@ -108,7 +100,6 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
             this.TaskMap = new ConcurrentDictionary<int, MachineInfo>();
             this.IsSchedulerRunning = true;
             this.BugFound = false;
-            this.HitMaxSteps = false;
             this.HasFullyExploredSchedule = false;
         }
 
@@ -512,8 +503,6 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
             {
                 var msg = IO.Format("Scheduling steps bound of " +
                     $"{this.Runtime.Configuration.MaxSchedulingSteps} reached.");
-
-                HitMaxSteps = true;
 
                 if (isSchedulingDecision &&
                     this.NumberOfAvailableMachinesToSchedule() == 0)

--- a/Libraries/TestingServices/Scheduling/BugFindingScheduler.cs
+++ b/Libraries/TestingServices/Scheduling/BugFindingScheduler.cs
@@ -63,6 +63,14 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         }
 
         /// <summary>
+        /// True if max steps was hit.
+        /// </summary>
+        internal bool HitMaxSteps
+        {
+            get; private set;
+        }
+
+        /// <summary>
         /// Number of explored steps.
         /// </summary>
         internal int ExploredSteps
@@ -100,6 +108,7 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
             this.TaskMap = new ConcurrentDictionary<int, MachineInfo>();
             this.IsSchedulerRunning = true;
             this.BugFound = false;
+            this.HitMaxSteps = false;
             this.HasFullyExploredSchedule = false;
         }
 
@@ -503,6 +512,8 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
             {
                 var msg = IO.Format("Scheduling steps bound of " +
                     $"{this.Runtime.Configuration.MaxSchedulingSteps} reached.");
+
+                HitMaxSteps = true;
 
                 if (isSchedulingDecision &&
                     this.NumberOfAvailableMachinesToSchedule() == 0)


### PR DESCRIPTION
Currently, a (liveness) bug caught at max-steps doesn't mean max-steps was hit.