### PR TITLE
Preserve the /method flag in the schedule file

### DIFF
--- a/Libraries/TestingServices/Engines/AbstractTestingEngine.cs
+++ b/Libraries/TestingServices/Engines/AbstractTestingEngine.cs
@@ -186,11 +186,11 @@ namespace Microsoft.PSharp.TestingServices
                 IO.Error.ReportAndExit(ex.Message);
             }
 
+            this.Initialize();
             this.FindEntryPoint();
             this.TestInitMethod = FindTestMethod(typeof(TestInit));
             this.TestDisposeMethod = FindTestMethod(typeof(TestDispose));
-            this.TestIterationDisposeMethod = FindTestMethod(typeof(TestIterationDispose));
-            this.Initialize();
+            this.TestIterationDisposeMethod = FindTestMethod(typeof(TestIterationDispose));           
         }
 
         /// <summary>
@@ -263,11 +263,17 @@ namespace Microsoft.PSharp.TestingServices
                     {
                         this.Configuration.CacheProgramState = true;
                     }
-                    else if (line.StartsWith("--liveness-temperature-threshold"))
+                    else if (line.StartsWith("--liveness-temperature-threshold:"))
                     {
                         this.Configuration.LivenessTemperatureThreshold =
-                            Int32.Parse(line.Substring(33));
+                            Int32.Parse(line.Substring("--liveness-temperature-threshold:".Length));
                     }
+                    else if (line.StartsWith("--test-method:"))
+                    {
+                        this.Configuration.TestMethodName =
+                            line.Substring("--test-method:".Length);
+                    }
+
                 }
 
                 ScheduleTrace schedule = new ScheduleTrace(scheduleDump);

--- a/Libraries/TestingServices/Engines/AbstractTestingEngine.cs
+++ b/Libraries/TestingServices/Engines/AbstractTestingEngine.cs
@@ -20,7 +20,6 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Microsoft.PSharp.TestingServices.Coverage;
 using Microsoft.PSharp.TestingServices.Scheduling;
 using Microsoft.PSharp.TestingServices.Tracing.Schedule;
 using Microsoft.PSharp.Utilities;

--- a/Libraries/TestingServices/Engines/BugFindingEngine.cs
+++ b/Libraries/TestingServices/Engines/BugFindingEngine.cs
@@ -618,7 +618,7 @@ namespace Microsoft.PSharp.TestingServices
                     Append(Environment.NewLine);
             }
 
-            if(base.Configuration.TestMethodName != "")
+            if (!base.Configuration.TestMethodName.Equals(""))
             {
                 stringBuilder.Append("--test-method:" + 
                     base.Configuration.TestMethodName).

--- a/Libraries/TestingServices/Engines/BugFindingEngine.cs
+++ b/Libraries/TestingServices/Engines/BugFindingEngine.cs
@@ -618,6 +618,13 @@ namespace Microsoft.PSharp.TestingServices
                     Append(Environment.NewLine);
             }
 
+            if(base.Configuration.TestMethodName != "")
+            {
+                stringBuilder.Append("--test-method:" + 
+                    base.Configuration.TestMethodName).
+                    Append(Environment.NewLine);
+            }
+
             for (int idx = 0; idx < runtime.ScheduleTrace.Count; idx++)
             {
                 ScheduleStep step = runtime.ScheduleTrace[idx];

--- a/Tools/Testing/Replayer/Program.cs
+++ b/Tools/Testing/Replayer/Program.cs
@@ -28,8 +28,6 @@ namespace Microsoft.PSharp
             AppDomain currentDomain = AppDomain.CurrentDomain;
             currentDomain.UnhandledException += new UnhandledExceptionEventHandler(UnhandledExceptionHandler);
 
-            System.Diagnostics.Debugger.Launch();
-
             // Parses the command line options to get the configuration.
             var configuration = new ReplayerCommandLineOptions(args).Parse();
 

--- a/Tools/Testing/Replayer/Program.cs
+++ b/Tools/Testing/Replayer/Program.cs
@@ -28,6 +28,8 @@ namespace Microsoft.PSharp
             AppDomain currentDomain = AppDomain.CurrentDomain;
             currentDomain.UnhandledException += new UnhandledExceptionEventHandler(UnhandledExceptionHandler);
 
+            System.Diagnostics.Debugger.Launch();
+
             // Parses the command line options to get the configuration.
             var configuration = new ReplayerCommandLineOptions(args).Parse();
 


### PR DESCRIPTION
Simple change, but required calling `Initialize` before the others:
```
            this.Initialize();
            this.FindEntryPoint();
            this.TestInitMethod = FindTestMethod(typeof(TestInit));
            this.TestDisposeMethod = FindTestMethod(typeof(TestDispose));
            this.TestIterationDisposeMethod = FindTestMethod(typeof(TestIterationDispose));           
```
Seems fine to me.