### PR TITLE
Logging should qualify state names with the state groups.

### DIFF
--- a/Libraries/Core/Library/Monitor.cs
+++ b/Libraries/Core/Library/Monitor.cs
@@ -168,7 +168,7 @@ namespace Microsoft.PSharp
             // If the event is null, then report an error and exit.
             this.Assert(e != null, $"Monitor '{this.GetType().Name}' is raising a null event.");
             EventInfo raisedEvent = new EventInfo(e, new EventOriginInfo(
-                base.Id, this.GetType().Name, this.CurrentState.Name));
+                base.Id, this.GetType().Name, Machine.GetQualifiedStateName(this.CurrentState)));
             base.Runtime.NotifyRaisedEvent(this, raisedEvent, false);
             this.HandleEvent(e);
         }

--- a/Libraries/Core/Runtime/Runtime.cs
+++ b/Libraries/Core/Runtime/Runtime.cs
@@ -604,7 +604,7 @@ namespace Microsoft.PSharp
             {
                 originInfo = new EventOriginInfo(sender.Id,
                     (sender as Machine).GetType().Name,
-                    (sender as Machine).CurrentState.Name);
+                    Machine.GetQualifiedStateName((sender as Machine).CurrentState));
             }
 
             EventInfo eventInfo = new EventInfo(e, originInfo);

--- a/Libraries/TestingServices/Runtime/BugFindingRuntime.cs
+++ b/Libraries/TestingServices/Runtime/BugFindingRuntime.cs
@@ -504,7 +504,7 @@ namespace Microsoft.PSharp.TestingServices
             {
                 originInfo = new EventOriginInfo(sender.Id,
                     (sender as Machine).GetType().Name,
-                    (sender as Machine).CurrentState.Name);
+                    Machine.GetQualifiedStateName((sender as Machine).CurrentState));
             }
             else
             {
@@ -1052,7 +1052,7 @@ namespace Microsoft.PSharp.TestingServices
             string originState = eventInfo.OriginInfo.SenderStateName;
             string edgeLabel = eventInfo.EventType.Name;
             string destMachine = machine.GetType().Name;
-            string destState = machine.CurrentState.Name;
+            string destState = Machine.GetQualifiedStateName(machine.CurrentState);
 
             this.CoverageInfo.AddTransition(originMachine, originState, edgeLabel, destMachine, destState);
         }
@@ -1090,7 +1090,7 @@ namespace Microsoft.PSharp.TestingServices
         private void ReportCodeCoverageOfStateTransition(Machine machine, EventInfo eventInfo)
         {
             string originMachine = machine.GetType().Name;
-            string originState = machine.CurrentState.Name;
+            string originState = Machine.GetQualifiedStateName(machine.CurrentState);
             string destMachine = machine.GetType().Name;
 
             string edgeLabel = "";
@@ -1098,12 +1098,13 @@ namespace Microsoft.PSharp.TestingServices
             if (eventInfo.Event is GotoStateEvent)
             {
                 edgeLabel = "goto";
-                destState = (eventInfo.Event as GotoStateEvent).State.Name;
+                destState = Machine.GetQualifiedStateName((eventInfo.Event as GotoStateEvent).State);
             }
             else if (machine.GotoTransitions.ContainsKey(eventInfo.EventType))
             {
                 edgeLabel = eventInfo.EventType.Name;
-                destState = machine.GotoTransitions[eventInfo.EventType].TargetState.Name;
+                destState = Machine.GetQualifiedStateName(
+                    machine.GotoTransitions[eventInfo.EventType].TargetState);
             }
             else
             {


### PR DESCRIPTION
This was a request from Nar. The coverage report was using state names with qualifying the state groups, which can lead to ambiguity. I have fixed this. No tests because it is only for the coverage report. 

I think our logging (of send, etc) should also include qualified names.
