### PR TITLE
Concurrent machine creation fix

### DIFF
--- a/Libraries/Core/Library/Machine.cs
+++ b/Libraries/Core/Library/Machine.cs
@@ -34,6 +34,11 @@ namespace Microsoft.PSharp
         #region fields
 
         /// <summary>
+        /// Is the machine state cached yet?
+        /// </summary>
+        private static ConcurrentDictionary<Type, bool> MachineStateCached;
+
+        /// <summary>
         /// Map from machine types to a set of all
         /// possible states types.
         /// </summary>
@@ -185,6 +190,7 @@ namespace Microsoft.PSharp
         /// </summary>
         static Machine()
         {
+            MachineStateCached = new ConcurrentDictionary<Type, bool>();
             StateTypeMap = new ConcurrentDictionary<Type, HashSet<Type>>();
             StateMap = new ConcurrentDictionary<Type, HashSet<MachineState>>();
             MachineActionMap = new ConcurrentDictionary<Type, Dictionary<string, MethodInfo>>();
@@ -1385,100 +1391,119 @@ namespace Microsoft.PSharp
         {
             Type machineType = this.GetType();
 
-            // Caches the available state types for this machine type.
-            if (StateTypeMap.TryAdd(machineType, new HashSet<Type>()))
+            if (MachineStateCached.TryAdd(machineType, false))
             {
-                Type baseType = machineType;
-                while (baseType != typeof(Machine))
+                // Caches the available state types for this machine type.
+                if (StateTypeMap.TryAdd(machineType, new HashSet<Type>()))
                 {
-                    foreach (var s in baseType.GetNestedTypes(BindingFlags.Instance |
-                        BindingFlags.NonPublic | BindingFlags.Public |
-                        BindingFlags.DeclaredOnly))
+                    Type baseType = machineType;
+                    while (baseType != typeof(Machine))
                     {
-                        this.ExtractStateTypes(s);
-                    }
-
-                    baseType = baseType.BaseType;
-                }
-            }
-
-            // Caches the available state instances for this machine type.
-            if (StateMap.TryAdd(machineType, new HashSet<MachineState>()))
-            {
-                foreach (var type in StateTypeMap[machineType])
-                {
-                    Type stateType = type;
-                    if (type.IsGenericType)
-                    {
-                        // If the state type is generic (only possible if inherited by a
-                        // generic machine declaration), then iterate through the base
-                        // machine classes to identify the runtime generic type, and use
-                        // it to instantiate the runtime state type. This type can be
-                        // then used to create the state constructor.
-                        Type declaringType = this.GetType();
-                        while (!declaringType.IsGenericType ||
-                            !type.DeclaringType.FullName.Equals(declaringType.FullName.Substring(
-                            0, declaringType.FullName.IndexOf('['))))
+                        foreach (var s in baseType.GetNestedTypes(BindingFlags.Instance |
+                            BindingFlags.NonPublic | BindingFlags.Public |
+                            BindingFlags.DeclaredOnly))
                         {
-                            declaringType = declaringType.BaseType;
+                            this.ExtractStateTypes(s);
                         }
 
-                        if (declaringType.IsGenericType)
-                        {
-                            stateType = type.MakeGenericType(declaringType.GetGenericArguments());
-                        }
-                    }
-
-                    ConstructorInfo constructor = stateType.GetConstructor(Type.EmptyTypes);
-                    var lambda = Expression.Lambda<Func<MachineState>>(
-                        Expression.New(constructor)).Compile();
-                    MachineState state = lambda();
-
-                    state.InitializeState();
-                    StateMap[machineType].Add(state);
-                }
-            }
-
-            // Caches the actions declarations for this machine type.
-            if (MachineActionMap.TryAdd(machineType, new Dictionary<string, MethodInfo>()))
-            {
-                foreach (var state in StateMap[machineType])
-                {
-                    if (state.EntryAction != null &&
-                        !MachineActionMap[machineType].ContainsKey(state.EntryAction))
-                    {
-                        MachineActionMap[machineType].Add(state.EntryAction,
-                            this.GetActionWithName(state.EntryAction));
-                    }
-
-                    if (state.ExitAction != null &&
-                        !MachineActionMap[machineType].ContainsKey(state.ExitAction))
-                    {
-                        MachineActionMap[machineType].Add(state.ExitAction,
-                            this.GetActionWithName(state.ExitAction));
-                    }
-
-                    foreach (var transition in state.GotoTransitions)
-                    {
-                        if (transition.Value.Lambda != null &&
-                            !MachineActionMap[machineType].ContainsKey(transition.Value.Lambda))
-                        {
-                            MachineActionMap[machineType].Add(transition.Value.Lambda,
-                                this.GetActionWithName(transition.Value.Lambda));
-                        }
-                    }
-
-                    foreach (var action in state.ActionBindings)
-                    {
-                        if (!MachineActionMap[machineType].ContainsKey(action.Value.Name))
-                        {
-                            MachineActionMap[machineType].Add(action.Value.Name,
-                                this.GetActionWithName(action.Value.Name));
-                        }
+                        baseType = baseType.BaseType;
                     }
                 }
+
+                // Caches the available state instances for this machine type.
+                if (StateMap.TryAdd(machineType, new HashSet<MachineState>()))
+                {
+                    foreach (var type in StateTypeMap[machineType])
+                    {
+                        Type stateType = type;
+                        if (type.IsGenericType)
+                        {
+                            // If the state type is generic (only possible if inherited by a
+                            // generic machine declaration), then iterate through the base
+                            // machine classes to identify the runtime generic type, and use
+                            // it to instantiate the runtime state type. This type can be
+                            // then used to create the state constructor.
+                            Type declaringType = this.GetType();
+                            while (!declaringType.IsGenericType ||
+                                !type.DeclaringType.FullName.Equals(declaringType.FullName.Substring(
+                                0, declaringType.FullName.IndexOf('['))))
+                            {
+                                declaringType = declaringType.BaseType;
+                            }
+
+                            if (declaringType.IsGenericType)
+                            {
+                                stateType = type.MakeGenericType(declaringType.GetGenericArguments());
+                            }
+                        }
+
+                        ConstructorInfo constructor = stateType.GetConstructor(Type.EmptyTypes);
+                        var lambda = Expression.Lambda<Func<MachineState>>(
+                            Expression.New(constructor)).Compile();
+                        MachineState state = lambda();
+
+                        state.InitializeState();
+                        StateMap[machineType].Add(state);
+                    }
+                }
+
+                // Caches the actions declarations for this machine type.
+                if (MachineActionMap.TryAdd(machineType, new Dictionary<string, MethodInfo>()))
+                {
+                    foreach (var state in StateMap[machineType])
+                    {
+                        if (state.EntryAction != null &&
+                            !MachineActionMap[machineType].ContainsKey(state.EntryAction))
+                        {
+                            MachineActionMap[machineType].Add(state.EntryAction,
+                                this.GetActionWithName(state.EntryAction));
+                        }
+
+                        if (state.ExitAction != null &&
+                            !MachineActionMap[machineType].ContainsKey(state.ExitAction))
+                        {
+                            MachineActionMap[machineType].Add(state.ExitAction,
+                                this.GetActionWithName(state.ExitAction));
+                        }
+
+                        foreach (var transition in state.GotoTransitions)
+                        {
+                            if (transition.Value.Lambda != null &&
+                                !MachineActionMap[machineType].ContainsKey(transition.Value.Lambda))
+                            {
+                                MachineActionMap[machineType].Add(transition.Value.Lambda,
+                                    this.GetActionWithName(transition.Value.Lambda));
+                            }
+                        }
+
+                        foreach (var action in state.ActionBindings)
+                        {
+                            if (!MachineActionMap[machineType].ContainsKey(action.Value.Name))
+                            {
+                                MachineActionMap[machineType].Add(action.Value.Name,
+                                    this.GetActionWithName(action.Value.Name));
+                            }
+                        }
+                    }
+                }
+                // cache completed
+                lock(MachineStateCached)
+                {
+                    MachineStateCached[machineType] = true;
+                    System.Threading.Monitor.PulseAll(MachineStateCached);
+                }
             }
-            
+            else if (!MachineStateCached[machineType])
+            {
+                lock (MachineStateCached)
+                {
+                    while (!MachineStateCached[machineType])
+                    {
+                        System.Threading.Monitor.Wait(MachineStateCached);
+                    }
+                }
+            }
+                        
             // Populates the map of actions for this machine instance.
             foreach (var kvp in MachineActionMap[machineType])
             {

--- a/Tests/TestingServices.Tests.Unit/Integration/DynamicError/Advanced/SendInterleavingsTest.cs
+++ b/Tests/TestingServices.Tests.Unit/Integration/DynamicError/Advanced/SendInterleavingsTest.cs
@@ -97,7 +97,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
             configuration.SuppressTrace = true;
             configuration.Verbose = 2;
             configuration.SchedulingStrategy = SchedulingStrategy.DFS;
-            configuration.SchedulingIterations = 60;
+            configuration.SchedulingIterations = 600;
 
             var engine = TestingEngineFactory.CreateBugFindingEngine(
                 configuration, TestProgram.Execute);


### PR DESCRIPTION
Stop the machines from using the state-information cache until it is populated. The fix still ensures that once machine information is cached, no extra synchronization is required.