### PR TITLE
Tester is deterministic, given a seed

### DIFF
--- a/Libraries/TestingServices/Engines/BugFindingEngine.cs
+++ b/Libraries/TestingServices/Engines/BugFindingEngine.cs
@@ -245,14 +245,25 @@ namespace Microsoft.PSharp.TestingServices
         /// <returns>Task</returns>
         private Task CreateBugFindingTask()
         {
+            string options = "";
+            if (base.Configuration.SchedulingStrategy == SchedulingStrategy.Random ||
+                base.Configuration.SchedulingStrategy == SchedulingStrategy.ProbabilisticRandom ||
+                base.Configuration.SchedulingStrategy == SchedulingStrategy.RandomDelayBounding ||
+                base.Configuration.SchedulingStrategy == SchedulingStrategy.RandomOperationBounding ||
+                base.Configuration.SchedulingStrategy == SchedulingStrategy.PrioritizedOperationBounding ||
+                base.Configuration.SchedulingStrategy == SchedulingStrategy.PCT)
+            {
+                options = $" (seed:{base.Configuration.RandomSchedulingSeed})";
+            }
+
             if (base.Configuration.TestingProcessId >= 0)
             {
                 IO.Error.PrintLine($"... Task {this.Configuration.TestingProcessId} is " +
-                    $"using '{base.Configuration.SchedulingStrategy}' strategy.");
+                    $"using '{base.Configuration.SchedulingStrategy}' strategy{options}.");
             }
             else
             {
-                IO.PrintLine($"... Using '{base.Configuration.SchedulingStrategy}' strategy.");
+                IO.PrintLine($"... Using '{base.Configuration.SchedulingStrategy}' strategy{options}.");
             }
 
             Task task = new Task(() =>

--- a/Tools/Testing/Tester/Program.cs
+++ b/Tools/Testing/Tester/Program.cs
@@ -32,6 +32,12 @@ namespace Microsoft.PSharp
             // Parses the command line options to get the configuration.
             var configuration = new TesterCommandLineOptions(args).Parse();
 
+            if (configuration.RandomSchedulingSeed == null)
+            {
+                configuration.RandomSchedulingSeed = DateTime.Now.Millisecond;
+                IO.PrintLine(". Using random seed " + configuration.RandomSchedulingSeed);
+            }
+
             if (configuration.ParallelBugFindingTasks == 1 ||
                 configuration.TestingProcessId < 0)
             {

--- a/Tools/Testing/Tester/Program.cs
+++ b/Tools/Testing/Tester/Program.cs
@@ -32,12 +32,6 @@ namespace Microsoft.PSharp
             // Parses the command line options to get the configuration.
             var configuration = new TesterCommandLineOptions(args).Parse();
 
-            if (configuration.RandomSchedulingSeed == null)
-            {
-                configuration.RandomSchedulingSeed = DateTime.Now.Millisecond;
-                IO.PrintLine(". Using random seed " + configuration.RandomSchedulingSeed);
-            }
-
             if (configuration.ParallelBugFindingTasks == 1 ||
                 configuration.TestingProcessId < 0)
             {

--- a/Tools/Testing/Tester/Testing/TestingPortfolio.cs
+++ b/Tools/Testing/Tester/Testing/TestingPortfolio.cs
@@ -28,8 +28,7 @@ namespace Microsoft.PSharp.TestingServices
         /// testing process.
         /// </summary>
         /// <param name="configuration">Configuration</param>
-        internal static void ConfigureStrategyForCurrentProcess(
-            Configuration configuration)
+        internal static void ConfigureStrategyForCurrentProcess(Configuration configuration)
         {
             if (configuration.TestingProcessId % 2 == 0)
             {
@@ -39,11 +38,6 @@ namespace Microsoft.PSharp.TestingServices
             {
                 configuration.SchedulingStrategy = SchedulingStrategy.PCT;
                 configuration.PrioritySwitchBound = configuration.TestingProcessId;
-            }
-
-            if (configuration.RandomSchedulingSeed != null)
-            {
-                configuration.RandomSchedulingSeed = configuration.RandomSchedulingSeed + (673 * configuration.TestingProcessId);
             }
         }
 

--- a/Tools/Testing/Tester/Testing/TestingPortfolio.cs
+++ b/Tools/Testing/Tester/Testing/TestingPortfolio.cs
@@ -40,6 +40,11 @@ namespace Microsoft.PSharp.TestingServices
                 configuration.SchedulingStrategy = SchedulingStrategy.PCT;
                 configuration.PrioritySwitchBound = configuration.TestingProcessId;
             }
+
+            if (configuration.RandomSchedulingSeed != null)
+            {
+                configuration.RandomSchedulingSeed = configuration.RandomSchedulingSeed + (673 * configuration.TestingProcessId);
+            }
         }
 
         #endregion

--- a/Tools/Testing/Tester/Testing/TestingProcess.cs
+++ b/Tools/Testing/Tester/Testing/TestingProcess.cs
@@ -152,6 +152,11 @@ namespace Microsoft.PSharp.TestingServices
                 TestingPortfolio.ConfigureStrategyForCurrentProcess(configuration);
             }
 
+            if (configuration.RandomSchedulingSeed != null)
+            {
+                configuration.RandomSchedulingSeed = configuration.RandomSchedulingSeed + (673 * configuration.TestingProcessId);
+            }
+
             this.Configuration = configuration;
             this.TestingEngine = TestingEngineFactory.CreateBugFindingEngine(
                 this.Configuration);

--- a/Tools/Testing/Tester/Testing/TestingProcess.cs
+++ b/Tools/Testing/Tester/Testing/TestingProcess.cs
@@ -180,12 +180,8 @@ namespace Microsoft.PSharp.TestingServices
             this.NotificationService = new ServiceHost(this);
             this.NotificationService.AddServiceEndpoint(typeof(ITestingProcess), binding, address);
 
-            if (this.Configuration.EnableDebugging)
-            {
-                ServiceDebugBehavior debug = this.NotificationService.Description.
-                    Behaviors.Find<ServiceDebugBehavior>();
-                debug.IncludeExceptionDetailInFaults = true;
-            }
+            ServiceDebugBehavior debug = this.NotificationService.Description.Behaviors.Find<ServiceDebugBehavior>();
+            debug.IncludeExceptionDetailInFaults = true;
 
             try
             {

--- a/Tools/Testing/Tester/Testing/TestingProcessFactory.cs
+++ b/Tools/Testing/Tester/Testing/TestingProcessFactory.cs
@@ -95,6 +95,11 @@ namespace Microsoft.PSharp.TestingServices
                 arguments.Append($"/sch:{configuration.SchedulingStrategy} ");
             }
 
+            if (configuration.RandomSchedulingSeed != null)
+            {
+                arguments.Append($"/sch-seed:{configuration.RandomSchedulingSeed} ");
+            }
+
             if (configuration.ReportCodeCoverage)
             {
                 arguments.Append($"/coverage-report ");

--- a/Tools/Testing/Tester/Utilities/TesterCommandLineOptions.cs
+++ b/Tools/Testing/Tester/Utilities/TesterCommandLineOptions.cs
@@ -12,6 +12,8 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
+
 namespace Microsoft.PSharp.Utilities
 {
     public sealed class TesterCommandLineOptions : BaseCommandLineOptions
@@ -388,6 +390,11 @@ namespace Microsoft.PSharp.Utilities
                     base.Configuration.LivenessTemperatureThreshold =
                         base.Configuration.MaxFairSchedulingSteps / 2;
                 }
+            }
+
+            if (base.Configuration.RandomSchedulingSeed == null)
+            {
+                base.Configuration.RandomSchedulingSeed = DateTime.Now.Millisecond;
             }
         }
 


### PR DESCRIPTION
Hi Pantazis,
We should make `PSharpTester` (optionally) deterministic so that different people can execute it and get the exact same result. You already had the seed option. I just made sure that parallel testing tasks don't get the exact same seed (because they will then do the same thing). I also print the seed if its not supplied.

On the same machine, I get the exact same behavior once I fix the seed. But not across machines. This may be because the DLLs are different, but I don't see why that should affect the tester. For example, can you try to repro the following and see what you get:

```
C:\Users\akashl\Documents\work\PSharp\Samples\PSharpAsLibrary>..\..\Binaries\PSharpTester.exe /test:Binaries\Debug\Raft.dll /i:10 /parallel:2 /max-steps:100 /sch-seed:620
. Testing Binaries\Debug\Raft.dll
... Created '2' parallel testing tasks.
... Task 1 is using 'Random' strategy.
... Task 0 is using 'Random' strategy.
..... Iteration #1
..... Iteration #1
..... Iteration #2
..... Iteration #2
..... Iteration #3
..... Iteration #3
... Testing task '1' found a bug.
... Found 1 bug.
... Scheduling statistics:
..... Explored 3 schedules: 3 fair and 0 unfair.
..... Found 33.33% buggy schedules.
..... Number of scheduling points in fair terminating schedules: 262 (min), 201 (avg), 342 (max).
..... Exceeded the max-steps bound of '100' in 100.00% of the fair schedules.
... Writing C:\Users\akashl\Documents\work\PSharp\Samples\PSharpAsLibrary\Binaries\Debug\Output\Raft_8.txt
... Writing C:\Users\akashl\Documents\work\PSharp\Samples\PSharpAsLibrary\Binaries\Debug\Output\Raft_8.pstrace
... Writing C:\Users\akashl\Documents\work\PSharp\Samples\PSharpAsLibrary\Binaries\Debug\Output\Raft_8.schedule
... Elapsed 4.3183436 sec.
. Done
```

Thanks,
Akash
 