### PR TITLE
Watch for MachineId counter overflow. Fixes #123

### DIFF
--- a/Libraries/Core/Library/MachineId.cs
+++ b/Libraries/Core/Library/MachineId.cs
@@ -79,7 +79,7 @@ namespace Microsoft.PSharp
         /// </summary>
         static MachineId()
         {
-            IdCounter = 0;
+            IdCounter = 1;
         }
 
         /// <summary>
@@ -97,6 +97,9 @@ namespace Microsoft.PSharp
             this.EndPoint = this.Runtime.NetworkProvider.GetLocalEndPoint();
             
             this.Value = Interlocked.Increment(ref IdCounter);
+
+            // check for overflow
+            Runtime.Assert(this.Value != 0, "MachineId counter overflow detected");
 
             if (this.FriendlyName != null && this.FriendlyName.Length > 0)
             {

--- a/Libraries/Core/Library/MachineId.cs
+++ b/Libraries/Core/Library/MachineId.cs
@@ -53,7 +53,7 @@ namespace Microsoft.PSharp
         /// Unique id value.
         /// </summary>
         [DataMember]
-        internal readonly int Value;
+        internal readonly ulong Value;
 
         /// <summary>
         /// Endpoint.
@@ -68,7 +68,7 @@ namespace Microsoft.PSharp
         /// <summary>
         /// Monotonically increasing machine id counter.
         /// </summary>
-        private static int IdCounter;
+        private static long IdCounter;
 
         #endregion
 
@@ -79,7 +79,7 @@ namespace Microsoft.PSharp
         /// </summary>
         static MachineId()
         {
-            IdCounter = 1;
+            IdCounter = 0;
         }
 
         /// <summary>
@@ -96,10 +96,11 @@ namespace Microsoft.PSharp
             this.Type = type.FullName;
             this.EndPoint = this.Runtime.NetworkProvider.GetLocalEndPoint();
             
-            this.Value = Interlocked.Increment(ref IdCounter);
+            // Atomically increments and safely wraps into an unsigned long.
+            this.Value = (uint)Interlocked.Increment(ref IdCounter);
 
-            // check for overflow
-            Runtime.Assert(this.Value != 0, "MachineId counter overflow detected");
+            // Checks for overflow.
+            Runtime.Assert(this.Value != ulong.MaxValue, "Detected MachineId overflow.");
 
             if (this.FriendlyName != null && this.FriendlyName.Length > 0)
             {
@@ -117,7 +118,7 @@ namespace Microsoft.PSharp
         /// </summary>
         /// <param name="type">Machine type</param>
         /// <param name="value">Id value</param>
-        internal MachineId(string type, int value)
+        internal MachineId(string type, ulong value)
         {
             this.Type = type;
             this.Value = value;

--- a/Libraries/Core/Runtime/Runtime.cs
+++ b/Libraries/Core/Runtime/Runtime.cs
@@ -46,7 +46,7 @@ namespace Microsoft.PSharp
         /// <summary>
         /// Map from unique machine ids to machines.
         /// </summary>
-        protected ConcurrentDictionary<int, Machine> MachineMap;
+        protected ConcurrentDictionary<ulong, Machine> MachineMap;
 
         /// <summary>
         /// Map from task ids to machines.
@@ -472,7 +472,7 @@ namespace Microsoft.PSharp
         /// </summary>
         private void Initialize()
         {
-            this.MachineMap = new ConcurrentDictionary<int, Machine>();
+            this.MachineMap = new ConcurrentDictionary<ulong, Machine>();
             this.TaskMap = new ConcurrentDictionary<int, Machine>();
             this.MachineTasks = new ConcurrentBag<Task>();
             this.Monitors = new List<Monitor>();

--- a/Libraries/TestingServices/SchedulingStrategies/DFS/DFSStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/DFS/DFSStrategy.cs
@@ -438,14 +438,14 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         /// </summary>
         private class SChoice
         {
-            internal int Id;
+            internal ulong Id;
             internal bool IsDone;
 
             /// <summary>
             /// Constructor.
             /// </summary>
             /// <param name="id">Id</param>
-            internal SChoice(int id)
+            internal SChoice(ulong id)
             {
                 this.Id = id;
                 this.IsDone = false;

--- a/Libraries/TestingServices/Tracing/Machines/MachineActionInfo.cs
+++ b/Libraries/TestingServices/Tracing/Machines/MachineActionInfo.cs
@@ -39,13 +39,13 @@ namespace Microsoft.PSharp.TestingServices.Tracing.Machines
         /// The machine id.
         /// </summary>
         [DataMember]
-        public int MachineId { get; private set; }
+        public ulong MachineId { get; private set; }
 
         /// <summary>
         /// The send target machine id.
         /// </summary>
         [DataMember]
-        public int TargetMachineId { get; private set; }
+        public ulong TargetMachineId { get; private set; }
 
         /// <summary>
         /// The send event.

--- a/Libraries/TestingServices/Tracing/Schedules/ScheduleTrace.cs
+++ b/Libraries/TestingServices/Tracing/Schedules/ScheduleTrace.cs
@@ -92,7 +92,7 @@ namespace Microsoft.PSharp.TestingServices.Tracing.Schedule
                 else
                 {
                     string[] machineId = step.TrimEnd(')').Split('(');
-                    this.AddSchedulingChoice(new MachineId(machineId[0], int.Parse(machineId[1])));
+                    this.AddSchedulingChoice(new MachineId(machineId[0], ulong.Parse(machineId[1])));
                 }
             }
         }


### PR DESCRIPTION
Watches for the overflow and asserts false to stop the runtime.