### PR TITLE
updated P#-specific exceptions

### DIFF
--- a/Libraries/Core/Core.csproj
+++ b/Libraries/Core/Core.csproj
@@ -55,7 +55,9 @@
     <Reference Include="System.ServiceModel" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Exceptions\PSharpIOException.cs" />
+    <Compile Include="Runtime\Exceptions\RuntimeException.cs" />
+    <Compile Include="Runtime\Exceptions\ExecutionCanceledException.cs" />
+    <Compile Include="Runtime\Exceptions\LoggingException.cs" />
     <Compile Include="Library\Attributes\Cold.cs" />
     <Compile Include="Library\Attributes\IgnoreEvents.cs" />
     <Compile Include="Library\Attributes\EntryPoint.cs" />
@@ -79,7 +81,6 @@
     <Compile Include="Library\Events\Event.cs" />
     <Compile Include="Library\Events\GotoStateEvent.cs" />
     <Compile Include="Library\Events\Halt.cs" />
-    <Compile Include="Exceptions\PSharpException.cs" />
     <Compile Include="Library\StateGroup.cs" />
     <Compile Include="Net\NetworkProviders\DefaultNetworkProvider.cs" />
     <Compile Include="Options\OptimizationTarget.cs" />

--- a/Libraries/Core/Library/Machine.cs
+++ b/Libraries/Core/Library/Machine.cs
@@ -1124,9 +1124,9 @@ namespace Microsoft.PSharp
                     innerException = innerException.InnerException;
                 }
 
-                if (innerException is OperationCanceledException)
+                if (innerException is ExecutionCanceledException)
                 {
-                    IO.Debug("<Exception> OperationCanceledException was " +
+                    IO.Debug("<Exception> ExecutionCanceledException was " +
                         $"thrown from Machine '{base.Id}'.");
                 }
                 else if (innerException is TaskSchedulerException)
@@ -1282,9 +1282,9 @@ namespace Microsoft.PSharp
                     innerException = innerException.InnerException;
                 }
 
-                if (innerException is OperationCanceledException)
+                if (innerException is ExecutionCanceledException)
                 {
-                    IO.Debug("<Exception> OperationCanceledException was " +
+                    IO.Debug("<Exception> ExecutionCanceledException was " +
                         $"thrown from Machine '{base.Id}'.");
                 }
                 else if (innerException is TaskSchedulerException)
@@ -1357,9 +1357,9 @@ namespace Microsoft.PSharp
                     innerException = innerException.InnerException;
                 }
 
-                if (innerException is OperationCanceledException)
+                if (innerException is ExecutionCanceledException)
                 {
-                    IO.Debug("<Exception> OperationCanceledException was " +
+                    IO.Debug("<Exception> ExecutionCanceledException was " +
                         $"thrown from Machine '{base.Id}'.");
                 }
                 else if (innerException is TaskSchedulerException)

--- a/Libraries/Core/Library/Monitor.cs
+++ b/Libraries/Core/Library/Monitor.cs
@@ -409,7 +409,7 @@ namespace Microsoft.PSharp
             {
                 action.Invoke(this, null);
             }
-            catch (OperationCanceledException ex)
+            catch (ExecutionCanceledException ex)
             {
                 throw ex;
             }
@@ -449,7 +449,7 @@ namespace Microsoft.PSharp
                 // if there is one available.
                 entryAction?.Invoke(this, null);
             }
-            catch (OperationCanceledException ex)
+            catch (ExecutionCanceledException ex)
             {
                 throw ex;
             }
@@ -500,7 +500,7 @@ namespace Microsoft.PSharp
                     eventHandlerExitAction.Invoke(this, null);
                 }
             }
-            catch (OperationCanceledException ex)
+            catch (ExecutionCanceledException ex)
             {
                 throw ex;
             }

--- a/Libraries/Core/Runtime/Exceptions/ExecutionCanceledException.cs
+++ b/Libraries/Core/Runtime/Exceptions/ExecutionCanceledException.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="PSharpException.cs">
+// <copyright file="ExecutionCanceledException.cs">
 //      Copyright (c) Microsoft Corporation. All rights reserved.
 // 
 //      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
@@ -17,16 +17,15 @@ using System;
 namespace Microsoft.PSharp
 {
     /// <summary>
-    /// Implements the base P# exception.
+    /// The exception that is thrown in a P# machine upon cancellation
+    /// of execution by the P# runtime.
     /// </summary>
-    internal class PSharpException : Exception
+    internal sealed class ExecutionCanceledException : RuntimeException
     {
         /// <summary>
-        /// Constructor.
+        /// Initializes a new instance of the exception.
         /// </summary>
-        /// <param name="message">Message</param>
-        public PSharpException(string message)
-            : base(message)
+        public ExecutionCanceledException()
         {
 
         }

--- a/Libraries/Core/Runtime/Exceptions/LoggingException.cs
+++ b/Libraries/Core/Runtime/Exceptions/LoggingException.cs
@@ -1,0 +1,34 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="LoggingException.cs">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// 
+//      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+
+namespace Microsoft.PSharp
+{
+    /// <summary>
+    /// Represents errors that occur during logging.
+    /// </summary>
+    internal sealed class LoggingException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the exception.
+        /// </summary>
+        /// <param name="message">Message</param>
+        public LoggingException(string message)
+            : base(message)
+        {
+
+        }
+    }
+}

--- a/Libraries/Core/Runtime/Exceptions/RuntimeException.cs
+++ b/Libraries/Core/Runtime/Exceptions/RuntimeException.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="PSharpIOException.cs">
+// <copyright file="RuntimeException.cs">
 //      Copyright (c) Microsoft Corporation. All rights reserved.
 // 
 //      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
@@ -12,18 +12,27 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
+
 namespace Microsoft.PSharp
 {
     /// <summary>
-    /// Implements the P# IO exception.
+    /// An exception that is thrown by the P# runtime.
     /// </summary>
-    internal sealed class PSharpIOException : PSharpException
+    internal class RuntimeException : Exception
     {
         /// <summary>
-        /// Constructor.
+        /// Initializes a new instance of the exception.
         /// </summary>
-        /// <param name="message">Message</param>
-        public PSharpIOException(string message)
+        public RuntimeException()
+        {
+
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the exception.
+        /// </summary>
+        public RuntimeException(string message)
             : base(message)
         {
 

--- a/Libraries/Core/Utilities/IO.cs
+++ b/Libraries/Core/Utilities/IO.cs
@@ -438,7 +438,7 @@ namespace Microsoft.PSharp.Utilities
         {
             if (!IO.WriteToInstalledLogger)
             {
-                throw new PSharpIOException("Custom logger not installed.");
+                throw new LoggingException("Custom logger not installed.");
             }
 
             return IO.Logger.ToString();
@@ -451,8 +451,7 @@ namespace Microsoft.PSharp.Utilities
         {
             if (IO.WriteToInstalledLogger)
             {
-                throw new PSharpIOException("Remove the previous logger " +
-                    "before installing a new one.");
+                throw new LoggingException("Remove the previous logger before installing a new one.");
             }
 
             IO.WriteToInstalledLogger = true;

--- a/Libraries/LanguageServices/Compilation/CompilationContext.cs
+++ b/Libraries/LanguageServices/Compilation/CompilationContext.cs
@@ -254,7 +254,7 @@ namespace Microsoft.PSharp.LanguageServices.Compilation
         {
             if (!this.HasInitialized)
             {
-                throw new PSharpException("ProgramInfo has not been initialized.");
+                throw new Exception("ProgramInfo has not been initialized.");
             }
             
             var doc = project.Documents.First(val => val.FilePath.Equals(tree.FilePath));

--- a/Libraries/StaticAnalysis/StaticAnalysisEngine.cs
+++ b/Libraries/StaticAnalysis/StaticAnalysisEngine.cs
@@ -203,7 +203,7 @@ namespace Microsoft.PSharp.StaticAnalysis
 
                 if (this.CompilationContext.Configuration.ThrowInternalExceptions)
                 {
-                    throw new PSharpException(message);
+                    throw new Exception(message);
                 }
 
                 IO.Error.ReportAndExit(message);

--- a/Libraries/TestingServices/Scheduling/BugFindingScheduler.cs
+++ b/Libraries/TestingServices/Scheduling/BugFindingScheduler.cs
@@ -182,7 +182,7 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
 
                     if (!machineInfo.IsEnabled)
                     {
-                        throw new OperationCanceledException();
+                        throw new ExecutionCanceledException();
                     }
                 }
             }
@@ -205,7 +205,7 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
             {
                 IO.Debug("<ScheduleDebug> Schedule explored.");
                 this.KillRemainingMachines();
-                throw new OperationCanceledException();
+                throw new ExecutionCanceledException();
             }
 
             if (uniqueId == null)
@@ -253,7 +253,7 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
             {
                 IO.Debug("<ScheduleDebug> Schedule explored.");
                 this.KillRemainingMachines();
-                throw new OperationCanceledException();
+                throw new ExecutionCanceledException();
             }
 
             this.Runtime.ScheduleTrace.AddNondeterministicIntegerChoice(choice);
@@ -339,7 +339,7 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
 
                 if (!machineInfo.IsEnabled)
                 {
-                    throw new OperationCanceledException();
+                    throw new ExecutionCanceledException();
                 }
             }
         }
@@ -479,7 +479,7 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         {
             this.IsSchedulerRunning = false;
             this.KillRemainingMachines();
-            throw new OperationCanceledException();
+            throw new ExecutionCanceledException();
         }
 
         /// <summary>
@@ -582,7 +582,7 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
                 {
                     IO.Debug($"<ScheduleDebug> {msg}");
                     this.KillRemainingMachines();
-                    throw new OperationCanceledException();
+                    throw new ExecutionCanceledException();
                 }
             }
         }

--- a/Libraries/TestingServices/Scheduling/TaskAwareBugFindingScheduler.cs
+++ b/Libraries/TestingServices/Scheduling/TaskAwareBugFindingScheduler.cs
@@ -172,7 +172,7 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
 
                     if (!machineInfo.IsEnabled)
                     {
-                        throw new OperationCanceledException();
+                        throw new ExecutionCanceledException();
                     }
                 }
             }
@@ -240,7 +240,7 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
 
                 if (!machineInfo.IsEnabled)
                 {
-                    throw new OperationCanceledException();
+                    throw new ExecutionCanceledException();
                 }
             }
         }


### PR DESCRIPTION
Refactored P#-specific exceptions:
- Removed the previous `PSharpException` (I did not like the previous name because the namespace `Microsoft.PSharp` implied that its a P# exception).
- Introduced the new `Microsoft.PSharp.RuntimeException`, which is the base exception for P# runtime-related exceptions. The user should never catch these exceptions (future TODO).
- Introduced the new `Microsoft.PSharp.ExecutionCanceledException`, which is thrown when the P# runtime/scheduler decides to cancel the execution of a P# machine. This is now thrown instead of `OperationCanceledException` to make it clear that the exception was thrown by P# (and not by user code).
- Introduced the new `Microsoft.PSharp.LoggingException` which replaces the `Microsoft.PSharp.PSharpIOException` (name was weird anyway :-)). This is thrown by the logger.
- Replaced `PSharpException` with `Exception` in the two places in the compiler and static analyser. We can introduce compiler/static analysis specific exceptions later on.