### PR TITLE
Improved runtime wait during bug-finding mode

### DIFF
--- a/Libraries/Core/Runtime/Runtime.cs
+++ b/Libraries/Core/Runtime/Runtime.cs
@@ -347,7 +347,7 @@ namespace Microsoft.PSharp
         /// <summary>
         /// Waits until all P# machines have finished execution.
         /// </summary>
-        public void Wait()
+        public virtual void Wait()
         {
             Task[] taskArray = null;
 

--- a/Libraries/TestingServices/Runtime/BugFindingRuntime.cs
+++ b/Libraries/TestingServices/Runtime/BugFindingRuntime.cs
@@ -228,6 +228,11 @@ namespace Microsoft.PSharp.TestingServices
             this.Monitor<T>(null, e);
         }
 
+        /// <summary>
+        /// Waits until all P# machines have finished execution.
+        /// </summary>
+        public override void Wait() => this.Scheduler.Wait();
+
         #endregion
 
         #region internal methods


### PR DESCRIPTION
Using a `TaskCompletionSource` inside the bug-finding scheduler to wait for the serialized execution to finish when calling `Wait` from the bug-finding runtime. Also did various other minor improvements.