### PR TITLE
Refactoring to abstract runtime

### DIFF
--- a/Libraries/Core/Core.csproj
+++ b/Libraries/Core/Core.csproj
@@ -55,6 +55,7 @@
     <Reference Include="System.ServiceModel" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Configuration\Configuration.cs" />
     <Compile Include="IO\Debugging\Debug.cs" />
     <Compile Include="IO\Debugging\Error.cs" />
     <Compile Include="IO\Debugging\ErrorReporter.cs" />
@@ -99,19 +100,19 @@
     <Compile Include="Library\StateGroup.cs" />
     <Compile Include="Networking\INetworkProvider.cs" />
     <Compile Include="Networking\NetworkProviders\LocalNetworkProvider.cs" />
-    <Compile Include="Utilities\Tooling\BaseCommandLineOptions.cs" />
-    <Compile Include="Utilities\Tooling\CompilationTarget.cs" />
-    <Compile Include="Configuration\Configuration.cs" />
-    <Compile Include="Utilities\Tooling\OptimizationTarget.cs" />
-    <Compile Include="Utilities\Tooling\SchedulingStrategy.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Runtime\Exceptions\AssertionFailureException.cs" />
     <Compile Include="Runtime\Exceptions\ExecutionCanceledException.cs" />
     <Compile Include="Runtime\Exceptions\RuntimeException.cs" />
-    <Compile Include="Runtime\Runtime.cs" />
+    <Compile Include="Runtime\PSharpRuntime.cs" />
+    <Compile Include="Runtime\StateMachineRuntime.cs" />
     <Compile Include="Utilities\Profiler.cs" />
     <Compile Include="Utilities\RandomNumberGenerators\DefaultRandomNumberGenerator.cs" />
     <Compile Include="Utilities\RandomNumberGenerators\IRandomNumberGenerator.cs" />
+    <Compile Include="Utilities\Tooling\BaseCommandLineOptions.cs" />
+    <Compile Include="Utilities\Tooling\CompilationTarget.cs" />
+    <Compile Include="Utilities\Tooling\OptimizationTarget.cs" />
+    <Compile Include="Utilities\Tooling\SchedulingStrategy.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="PSharp.snk" />

--- a/Libraries/Core/Runtime/PSharpRuntime.cs
+++ b/Libraries/Core/Runtime/PSharpRuntime.cs
@@ -1,0 +1,639 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="Runtime.cs">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// 
+//      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+using Microsoft.PSharp.IO;
+using Microsoft.PSharp.Net;
+
+namespace Microsoft.PSharp
+{
+    /// <summary>
+    /// Runtime for executing state-machines.
+    /// </summary>
+    public abstract class PSharpRuntime : IDisposable
+    {
+        #region fields
+
+        /// <summary>
+        /// The configuration used by the runtime.
+        /// </summary>
+        internal Configuration Configuration;
+
+        /// <summary>
+        /// Records if the P# program has faulted.
+        /// </summary>
+        internal volatile bool IsFaulted;
+
+        #endregion
+
+        #region properties
+
+        /// <summary>
+        /// Network provider used for remote communication.
+        /// </summary>
+        public INetworkProvider NetworkProvider { get; private set; }
+
+        /// <summary>
+        /// The installed logger.
+        /// </summary>
+        public ILogger Logger { get; private set; }
+
+        #endregion
+
+        #region events
+
+        /// <summary>
+        /// Event that is fired when the P# program throws an exception.
+        /// </summary>
+        public event OnFailureHandler OnFailure;
+
+        /// <summary>
+        /// Handles the <see cref="OnFailure"/> event.
+        /// </summary>
+        public delegate void OnFailureHandler(Exception ex);
+
+        #endregion
+
+        #region factory methods
+
+        /// <summary>
+        /// Creates a new state-machine runtime.
+        /// </summary>
+        /// <returns>Runtime</returns>
+        public static PSharpRuntime Create()
+        {
+            return new StateMachineRuntime();
+        }
+
+        /// <summary>
+        /// Creates a new state-machine runtime with the specified
+        /// <see cref="PSharp.Configuration"/>.
+        /// </summary>
+        /// <param name="configuration">Configuration</param>
+        /// <returns>Runtime</returns>
+        public static PSharpRuntime Create(Configuration configuration)
+        {
+            return new StateMachineRuntime(configuration);
+        }
+
+        #endregion
+
+        #region initialization
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        protected PSharpRuntime()
+        {
+            this.Configuration = Configuration.Create();
+            this.Initialize();
+        }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="configuration">Configuration</param>
+        protected PSharpRuntime(Configuration configuration)
+        {
+            this.Configuration = configuration;
+            this.Initialize();
+        }
+
+        /// <summary>
+        /// Initializes various components of the runtime.
+        /// </summary>
+        private void Initialize()
+        {
+            this.NetworkProvider = new LocalNetworkProvider(this);
+            this.Logger = new DefaultLogger();
+            this.IsFaulted = false;
+        }
+
+        #endregion
+
+        #region runtime interface
+
+        /// <summary>
+        /// Creates a new machine of the specified <see cref="Type"/> and with
+        /// the specified optional <see cref="Event"/>. This event can only be
+        /// used to access its payload, and cannot be handled.
+        /// </summary>
+        /// <param name="type">Type of the machine</param>
+        /// <param name="e">Event</param>
+        /// <returns>MachineId</returns>
+        public abstract MachineId CreateMachine(Type type, Event e = null);
+
+        /// <summary>
+        /// Creates a new machine of the specified <see cref="Type"/> and name, and
+        /// with the specified optional <see cref="Event"/>. This event can only be
+        /// used to access its payload, and cannot be handled.
+        /// </summary>
+        /// <param name="type">Type of the machine</param>
+        /// <param name="friendlyName">Friendly machine name used for logging</param>
+        /// <param name="e">Event</param>
+        /// <returns>MachineId</returns>
+        public abstract MachineId CreateMachine(Type type, string friendlyName, Event e = null);
+
+        /// <summary>
+        /// Creates a new remote machine of the specified <see cref="Type"/> and with
+        /// the specified optional <see cref="Event"/>. This event can only be used
+        /// to access its payload, and cannot be handled.
+        /// </summary>
+        /// <param name="type">Type of the machine</param>
+        /// <param name="endpoint">Endpoint</param>
+        /// <param name="e">Event</param>
+        /// <returns>MachineId</returns>
+        public abstract MachineId RemoteCreateMachine(Type type, string endpoint, Event e = null);
+
+        /// <summary>
+        /// Creates a new remote machine of the specified <see cref="Type"/> and name, and
+        /// with the specified optional <see cref="Event"/>. This event can only be used
+        /// to access its payload, and cannot be handled.
+        /// </summary>
+        /// <param name="type">Type of the machine</param>
+        /// <param name="friendlyName">Friendly machine name used for logging</param>
+        /// <param name="endpoint">Endpoint</param>
+        /// <param name="e">Event</param>
+        /// <returns>MachineId</returns>
+        public abstract MachineId RemoteCreateMachine(Type type, string friendlyName,
+            string endpoint, Event e = null);
+
+        /// <summary>
+        /// Sends an asynchronous <see cref="Event"/> to a machine.
+        /// </summary>
+        /// <param name="target">Target machine id</param>
+        /// <param name="e">Event</param>
+        public abstract void SendEvent(MachineId target, Event e);
+
+        /// <summary>
+        /// Sends an asynchronous <see cref="Event"/> to a remote machine.
+        /// </summary>
+        /// <param name="target">Target machine id</param>
+        /// <param name="e">Event</param>
+        public abstract void RemoteSendEvent(MachineId target, Event e);
+
+        /// <summary>
+        /// Waits to receive an <see cref="Event"/> of the specified types.
+        /// </summary>
+        /// <param name="eventTypes">Event types</param>
+        /// <returns>Received event</returns>
+        public abstract Event Receive(params Type[] eventTypes);
+
+        /// <summary>
+        /// Waits to receive an <see cref="Event"/> of the specified type
+        /// that satisfies the specified predicate.
+        /// </summary>
+        /// <param name="eventType">Event type</param>
+        /// <param name="predicate">Predicate</param>
+        /// <returns>Received event</returns>
+        public abstract Event Receive(Type eventType, Func<Event, bool> predicate);
+
+        /// <summary>
+        /// Waits to receive an <see cref="Event"/> of the specified types
+        /// that satisfy the specified predicates.
+        /// </summary>
+        /// <param name="events">Event types and predicates</param>
+        /// <returns>Received event</returns>
+        public abstract Event Receive(params Tuple<Type, Func<Event, bool>>[] events);
+
+        /// <summary>
+        /// Registers a new specification monitor of the specified <see cref="Type"/>.
+        /// </summary>
+        /// <param name="type">Type of the monitor</param>
+        public abstract void RegisterMonitor(Type type);
+
+        /// <summary>
+        /// Invokes the specified monitor with the specified <see cref="Event"/>.
+        /// </summary>
+        /// <typeparam name="T">Type of the monitor</typeparam>
+        /// <param name="e">Event</param>
+        public abstract void InvokeMonitor<T>(Event e);
+
+        /// <summary>
+        /// Returns a nondeterministic boolean choice, that can be controlled
+        /// during analysis or testing.
+        /// </summary>
+        /// <returns>Boolean</returns>
+        public bool Random()
+        {
+            return this.GetNondeterministicBooleanChoice(null, 2);
+        }
+
+        /// <summary>
+        /// Returns a nondeterministic boolean choice, that can be controlled
+        /// during analysis or testing. The value is used to generate a number
+        /// in the range [0..maxValue), where 0 triggers true.
+        /// </summary>
+        /// <param name="maxValue">Max value</param>
+        /// <returns>Boolean</returns>
+        public bool Random(int maxValue)
+        {
+            return this.GetNondeterministicBooleanChoice(null, maxValue);
+        }
+
+        /// <summary>
+        /// Returns a nondeterministic integer choice, that can be
+        /// controlled during analysis or testing. The value is used
+        /// to generate an integer in the range [0..maxValue).
+        /// </summary>
+        /// <param name="maxValue">Max value</param>
+        /// <returns>Integer</returns>
+        public int RandomInteger(int maxValue)
+        {
+            return this.GetNondeterministicIntegerChoice(null, maxValue);
+        }
+
+        /// <summary>
+        /// Gets the id of the currently executing <see cref="Machine"/>.
+        /// <returns>MachineId</returns>
+        /// </summary>
+        public abstract MachineId GetCurrentMachineId();
+
+        /// <summary>
+        /// Waits until the runtime has reached quiescence. This is an experimental
+        /// feature, which should only be used for testing purposes.
+        /// </summary>
+        public abstract void Wait();
+
+        #endregion
+
+        #region state-machine execution
+
+        /// <summary>
+        /// Tries to create a new <see cref="Machine"/> of the specified <see cref="Type"/>.
+        /// </summary>
+        /// <param name="creator">Creator machine</param>
+        /// <param name="type">Type of the machine</param>
+        /// <param name="friendlyName">Friendly machine name used for logging</param>
+        /// <param name="e">Event</param>
+        /// <returns>MachineId</returns>
+        internal abstract MachineId TryCreateMachine(Machine creator, Type type, string friendlyName, Event e);
+
+        /// <summary>
+        /// Tries to create a new remote <see cref="Machine"/> of the specified <see cref="System.Type"/>.
+        /// </summary>
+        /// <param name="creator">Creator machine</param>
+        /// <param name="type">Type of the machine</param>
+        /// <param name="friendlyName">Friendly machine name used for logging</param>
+        /// <param name="endpoint">Endpoint</param>
+        /// <param name="e">Event</param>
+        /// <returns>MachineId</returns>
+        internal abstract MachineId TryCreateRemoteMachine(Machine creator, Type type,
+            string friendlyName, string endpoint, Event e);
+
+        /// <summary>
+        /// Sends an asynchronous <see cref="Event"/> to a machine.
+        /// </summary>
+        /// <param name="sender">Sender machine</param>
+        /// <param name="mid">MachineId</param>
+        /// <param name="e">Event</param>
+        /// <param name="isStarter">Is starting a new operation</param>
+        internal abstract void Send(AbstractMachine sender, MachineId mid, Event e, bool isStarter);
+
+        /// <summary>
+        /// Sends an asynchronous <see cref="Event"/> to a remote machine.
+        /// </summary>
+        /// <param name="sender">Sender machine</param>
+        /// <param name="mid">MachineId</param>
+        /// <param name="e">Event</param>
+        /// <param name="isStarter">Is starting a new operation</param>
+        internal abstract void SendRemotely(AbstractMachine sender, MachineId mid, Event e, bool isStarter);
+
+        #endregion
+
+        #region specifications and error checking
+
+        /// <summary>
+        /// Tries to create a new <see cref="PSharp.Monitor"/> of the specified <see cref="Type"/>.
+        /// </summary>
+        /// <param name="type">Type of the monitor</param>
+        internal abstract void TryCreateMonitor(Type type);
+
+        /// <summary>
+        /// Invokes the specified <see cref="PSharp.Monitor"/> with the specified <see cref="Event"/>.
+        /// </summary>
+        /// <param name="sender">Sender machine</param>
+        /// <typeparam name="T">Type of the monitor</typeparam>
+        /// <param name="e">Event</param>
+        internal abstract void Monitor<T>(AbstractMachine sender, Event e);
+
+        /// <summary>
+        /// Checks if the assertion holds, and if not it throws an
+        /// <see cref="AssertionFailureException"/> exception.
+        /// </summary>
+        /// <param name="predicate">Predicate</param>
+        public virtual void Assert(bool predicate)
+        {
+            if (!predicate)
+            {
+                throw new AssertionFailureException("Detected an assertion failure.");
+            }
+        }
+
+        /// <summary>
+        /// Checks if the assertion holds, and if not it throws an
+        /// <see cref="AssertionFailureException"/> exception.
+        /// </summary>
+        /// <param name="predicate">Predicate</param>
+        /// <param name="s">Message</param>
+        /// <param name="args">Message arguments</param>
+        public virtual void Assert(bool predicate, string s, params object[] args)
+        {
+            if (!predicate)
+            {
+                string message = IO.Utilities.Format(s, args);
+                throw new AssertionFailureException(message);
+            }
+        }
+
+        #endregion
+
+        #region nondeterministic choices
+
+        /// <summary>
+        /// Returns a nondeterministic boolean choice, that can be
+        /// controlled during analysis or testing.
+        /// </summary>
+        /// <param name="machine">Machine</param>
+        /// <param name="maxValue">Max value</param>
+        /// <returns>Boolean</returns>
+        internal abstract bool GetNondeterministicBooleanChoice(AbstractMachine machine, int maxValue);
+
+        /// <summary>
+        /// Returns a fair nondeterministic boolean choice, that can be
+        /// controlled during analysis or testing.
+        /// </summary>
+        /// <param name="machine">Machine</param>
+        /// <param name="uniqueId">Unique id</param>
+        /// <returns>Boolean</returns>
+        internal abstract bool GetFairNondeterministicBooleanChoice(AbstractMachine machine, string uniqueId);
+
+        /// <summary>
+        /// Returns a nondeterministic integer choice, that can be
+        /// controlled during analysis or testing.
+        /// </summary>
+        /// <param name="machine">Machine</param>
+        /// <param name="maxValue">Max value</param>
+        /// <returns>Integer</returns>
+        internal abstract int GetNondeterministicIntegerChoice(AbstractMachine machine, int maxValue);
+
+        #endregion
+
+        #region notifications
+
+        /// <summary>
+        /// Notifies that a machine entered a state.
+        /// </summary>
+        /// <param name="machine">AbstractMachine</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal virtual void NotifyEnteredState(AbstractMachine machine)
+        {
+            // Override to implement the notification.
+        }
+
+        /// <summary>
+        /// Notifies that a machine exited a state.
+        /// </summary>
+        /// <param name="machine">AbstractMachine</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal virtual void NotifyExitedState(AbstractMachine machine)
+        {
+            // Override to implement the notification.
+        }
+
+        /// <summary>
+        /// Notifies that a machine invoked an action.
+        /// </summary>
+        /// <param name="machine">AbstractMachine</param>
+        /// <param name="action">Action</param>
+        /// <param name="receivedEvent">Event</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal virtual void NotifyInvokedAction(AbstractMachine machine, MethodInfo action, Event receivedEvent)
+        {
+            // Override to implement the notification.
+        }
+
+        /// <summary>
+        /// Notifies that a machine dequeued an <see cref="Event"/>.
+        /// </summary>
+        /// <param name="machine">Machine</param>
+        /// <param name="eventInfo">EventInfo</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal virtual void NotifyDequeuedEvent(Machine machine, EventInfo eventInfo)
+        {
+            // Override to implement the notification.
+        }
+
+        /// <summary>
+        /// Notifies that a machine called pop.
+        /// </summary>
+        /// <param name="machine">Machine</param>
+        /// <param name="fromState">Top of the stack state</param>
+        /// <param name="toState">Next to top state of the stack</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal virtual void NotifyPop(Machine machine, Type fromState, Type toState)
+        {
+            // Override to implement the notification.
+        }
+
+        /// <summary>
+        /// Notifies that a machine raised an <see cref="Event"/>.
+        /// </summary>
+        /// <param name="machine">AbstractMachine</param>
+        /// <param name="eventInfo">EventInfo</param>
+        /// <param name="isStarter">Is starting a new operation</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal virtual void NotifyRaisedEvent(AbstractMachine machine, EventInfo eventInfo, bool isStarter)
+        {
+            // Override to implement the notification.
+        }
+
+        /// <summary>
+        /// Notifies that a machine called Receive.
+        /// </summary>
+        /// <param name="machine">AbstractMachine</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal virtual void NotifyReceiveCalled(AbstractMachine machine)
+        {
+            // Override to implement the notification.
+        }
+
+        /// <summary>
+        /// Notifies that a machine is handling a raised <see cref="Event"/>.
+        /// </summary>
+        /// <param name="machine">Machine</param>
+        /// <param name="eventInfo">EventInfo</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal virtual void NotifyHandleRaisedEvent(Machine machine, EventInfo eventInfo)
+        {
+            // Override to implement the notification.
+        }
+
+        /// <summary>
+        /// Notifies that a machine is waiting to receive one or more events.
+        /// </summary>
+        /// <param name="machine">Machine</param>
+        /// <param name="events">Events</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal virtual void NotifyWaitEvents(Machine machine, string events)
+        {
+            // Override to implement the notification.
+        }
+
+        /// <summary>
+        /// Notifies that a machine received an <see cref="Event"/> that it was waiting for.
+        /// </summary>
+        /// <param name="machine">Machine</param>
+        /// <param name="eventInfo">EventInfo</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal virtual void NotifyReceivedEvent(Machine machine, EventInfo eventInfo)
+        {
+            // Override to implement the notification.
+        }
+
+        /// <summary>
+        /// Notifies that a machine has halted.
+        /// </summary>
+        /// <param name="machine">Machine</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal virtual void NotifyHalted(Machine machine)
+        {
+            // Override to implement the notification.
+        }
+
+        /// <summary>
+        /// Notifies that a default handler has been used.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal virtual void NotifyDefaultHandlerFired()
+        {
+            // Override to implement the notification.
+        }
+
+        #endregion
+
+        #region logging
+
+        /// <summary>
+        /// Logs the specified text.
+        /// </summary>
+        /// <param name="format">Text</param>
+        /// <param name="args">Arguments</param>
+        protected internal virtual void Log(string format, params object[] args)
+        {
+            if (this.Configuration.Verbose > 1)
+            {
+                this.Logger.WriteLine(format, args);
+            }
+        }
+
+        /// <summary>
+        /// Installs the specified <see cref="ILogger"/>.
+        /// </summary>
+        /// <param name="logger">TextWriter</param>
+        public void SetLogger(ILogger logger)
+        {
+            if (logger == null)
+            {
+                throw new InvalidOperationException("Cannot install a null logger.");
+            }
+
+            this.Logger.Dispose();
+            this.Logger = logger;
+        }
+
+        /// <summary>
+        /// Replaces the currently installed <see cref="ILogger"/> with
+        /// the default <see cref="ILogger"/>.
+        /// </summary>
+        public void RemoveLogger()
+        {
+            this.Logger.Dispose();
+            this.Logger = new DefaultLogger();
+        }
+
+        #endregion
+
+        #region networking
+
+        /// <summary>
+        /// Installs the specified <see cref="INetworkProvider"/>.
+        /// </summary>
+        /// <param name="networkProvider">INetworkProvider</param>
+        public void SetNetworkProvider(INetworkProvider networkProvider)
+        {
+            if (networkProvider == null)
+            {
+                throw new InvalidOperationException("Cannot install a null network provider.");
+            }
+
+            this.NetworkProvider.Dispose();
+            this.NetworkProvider = networkProvider;
+        }
+
+        /// <summary>
+        /// Replaces the currently installed <see cref="INetworkProvider"/>
+        /// with the default <see cref="INetworkProvider"/>.
+        /// </summary>
+        public void RemoveNetworkProvider()
+        {
+            this.NetworkProvider.Dispose();
+            this.NetworkProvider = new LocalNetworkProvider(this);
+        }
+
+        #endregion
+
+        #region exceptions
+
+        /// <summary>
+        /// Raises the <see cref="OnFailure"/> event with the specified <see cref="Exception"/> .
+        /// </summary>
+        /// <param name="exception">Exception</param>
+        protected void RaiseOnFailureEvent(Exception exception)
+        {
+            this.OnFailure?.Invoke(exception);
+        }
+
+        /// <summary>
+        /// Throws an <see cref="AssertionFailureException"/> exception
+        /// containing the specified exception.
+        /// </summary>
+        /// <param name="exception">Exception</param>
+        /// <param name="s">Message</param>
+        /// <param name="args">Message arguments</param>
+        internal virtual void WrapAndThrowException(Exception exception, string s, params object[] args)
+        {
+            string message = IO.Utilities.Format(s, args);
+            throw new AssertionFailureException(message, exception);
+        }
+
+        #endregion
+
+        #region cleanup
+
+        /// <summary>
+        /// Disposes runtime resources.
+        /// </summary>
+        public virtual void Dispose()
+        {
+            this.NetworkProvider.Dispose();
+            this.Logger.Dispose();
+        }
+
+        #endregion
+    }
+}

--- a/Libraries/TestingServices/Runtime/BugFindingRuntime.cs
+++ b/Libraries/TestingServices/Runtime/BugFindingRuntime.cs
@@ -31,19 +31,60 @@ namespace Microsoft.PSharp.TestingServices
     /// <summary>
     /// Class implementing the P# bug-finding runtime.
     /// </summary>
-    internal sealed class BugFindingRuntime : PSharpRuntime, IDisposable
+    internal sealed class BugFindingRuntime : PSharpRuntime
     {
         #region fields
+
+        /// <summary>
+        /// The bug-finding scheduler.
+        /// </summary>
+        internal BugFindingScheduler Scheduler;
+
+        /// <summary>
+        /// The P# liveness checker.
+        /// </summary>
+        internal LivenessChecker LivenessChecker;
 
         /// <summary>
         /// The P# program schedule trace.
         /// </summary>
         internal ScheduleTrace ScheduleTrace;
+        
+        /// <summary>
+        /// Data structure containing information
+        /// regarding testing coverage.
+        /// </summary>
+        internal CoverageInfo CoverageInfo;
+
+        /// <summary>
+        /// The P# program state cache.
+        /// </summary>
+        internal StateCache StateCache;
 
         /// <summary>
         /// The bug trace.
         /// </summary>
         internal BugTrace BugTrace;
+
+        /// <summary>
+        /// List of monitors in the program.
+        /// </summary>
+        private List<Monitor> Monitors;
+
+        /// <summary>
+        /// Map from unique machine ids to machines.
+        /// </summary>
+        private ConcurrentDictionary<ulong, Machine> MachineMap;
+
+        /// <summary>
+        /// Map from task ids to machines.
+        /// </summary>
+        private ConcurrentDictionary<int, Machine> TaskMap;
+
+        /// <summary>
+        /// Collection of machine tasks.
+        /// </summary>
+        private ConcurrentBag<Task> MachineTasks;
 
         /// <summary>
         /// A map from unique machine ids to action traces.
@@ -55,28 +96,7 @@ namespace Microsoft.PSharp.TestingServices
         /// The root task id.
         /// </summary>
         internal int? RootTaskId;
-
-        /// <summary>
-        /// The bug-finding scheduler.
-        /// </summary>
-        internal BugFindingScheduler Scheduler;
-
-        /// <summary>
-        /// The P# program state cache.
-        /// </summary>
-        internal StateCache StateCache;
-
-        /// <summary>
-        /// The P# liveness checker.
-        /// </summary>
-        internal LivenessChecker LivenessChecker;
-
-        /// <summary>
-        /// Data structure containing information
-        /// regarding testing coverage.
-        /// </summary>
-        internal CoverageInfo CoverageInfo;
-
+        
         /// <summary>
         /// Monotonically increasing machine id counter.
         /// </summary>
@@ -84,7 +104,7 @@ namespace Microsoft.PSharp.TestingServices
 
         #endregion
 
-        #region public API
+        #region initialization
 
         /// <summary>
         /// Constructor.
@@ -94,19 +114,35 @@ namespace Microsoft.PSharp.TestingServices
         internal BugFindingRuntime(Configuration configuration, ISchedulingStrategy strategy)
             : base(configuration)
         {
-            this.RootTaskId = Task.CurrentId;
+            this.Initialize();
 
             this.ScheduleTrace = new ScheduleTrace();
             this.BugTrace = new BugTrace();
-            this.MachineActionTraceMap = new ConcurrentDictionary<MachineId, MachineActionTrace>();
-
+            
             this.Scheduler = new BugFindingScheduler(this, strategy);
             this.LivenessChecker = new LivenessChecker(this, strategy);
             this.StateCache = new StateCache(this);
             this.CoverageInfo = new CoverageInfo();
+        }
 
+        /// <summary>
+        /// Initializes various components of the runtime.
+        /// </summary>
+        private void Initialize()
+        {
+            this.Monitors = new List<Monitor>();
+            this.MachineMap = new ConcurrentDictionary<ulong, Machine>();
+            this.TaskMap = new ConcurrentDictionary<int, Machine>();
+            this.MachineTasks = new ConcurrentBag<Task>();
+            this.MachineActionTraceMap = new ConcurrentDictionary<MachineId, MachineActionTrace>();
+
+            this.RootTaskId = Task.CurrentId;
             this.OperationIdCounter = 0;
         }
+
+        #endregion
+
+        #region runtime interface
 
         /// <summary>
         /// Creates a new machine of the specified type and with
@@ -201,7 +237,7 @@ namespace Microsoft.PSharp.TestingServices
             // If the event is null then report an error and exit.
             this.Assert(e != null, "Cannot send a null event.");
 
-            this.Send(base.GetCurrentMachine(), target, e, false);
+            this.Send(this.GetCurrentMachine(), target, e, false);
         }
 
         /// <summary>
@@ -216,6 +252,69 @@ namespace Microsoft.PSharp.TestingServices
         }
 
         /// <summary>
+        /// Waits to receive an <see cref="Event"/> of the specified types.
+        /// </summary>
+        /// <param name="eventTypes">Event types</param>
+        /// <returns>Received event</returns>
+        public override Event Receive(params Type[] eventTypes)
+        {
+            this.Assert(Task.CurrentId != null, "Only machines can " +
+                "wait to receive an event.");
+            this.Assert(this.TaskMap.ContainsKey((int)Task.CurrentId),
+                "Only machines can wait to receive an event; task " +
+                $"{(int)Task.CurrentId} does not correspond to a machine.");
+
+            Machine machine = this.TaskMap[(int)Task.CurrentId];
+            return machine.Receive(eventTypes);
+        }
+
+        /// <summary>
+        /// Waits to receive an <see cref="Event"/> of the specified type
+        /// that satisfies the specified predicate.
+        /// </summary>
+        /// <param name="eventType">Event type</param>
+        /// <param name="predicate">Predicate</param>
+        /// <returns>Received event</returns>
+        public override Event Receive(Type eventType, Func<Event, bool> predicate)
+        {
+            this.Assert(Task.CurrentId != null, "Only machines can " +
+                "wait to receive an event.");
+            this.Assert(this.TaskMap.ContainsKey((int)Task.CurrentId),
+                "Only machines can wait to receive an event; task " +
+                $"{(int)Task.CurrentId} does not belong to a machine.");
+
+            Machine machine = this.TaskMap[(int)Task.CurrentId];
+            return machine.Receive(eventType, predicate);
+        }
+
+        /// <summary>
+        /// Waits to receive an <see cref="Event"/> of the specified types
+        /// that satisfy the specified predicates.
+        /// </summary>
+        /// <param name="events">Event types and predicates</param>
+        /// <returns>Received event</returns>
+        public override Event Receive(params Tuple<Type, Func<Event, bool>>[] events)
+        {
+            this.Assert(Task.CurrentId != null, "Only machines can " +
+                "wait to receive an event.");
+            this.Assert(this.TaskMap.ContainsKey((int)Task.CurrentId),
+                "Only machines can wait to receive an event; task " +
+                $"{(int)Task.CurrentId} does not belong to a machine.");
+
+            Machine machine = this.TaskMap[(int)Task.CurrentId];
+            return machine.Receive(events);
+        }
+
+        /// <summary>
+        /// Registers a new specification monitor of the specified <see cref="Type"/>.
+        /// </summary>
+        /// <param name="type">Type of the monitor</param>
+        public override void RegisterMonitor(Type type)
+        {
+            this.TryCreateMonitor(type);
+        }
+
+        /// <summary>
         /// Invokes the specified monitor with the given event.
         /// </summary>
         /// <typeparam name="T">Type of the monitor</typeparam>
@@ -225,6 +324,21 @@ namespace Microsoft.PSharp.TestingServices
             // If the event is null then report an error and exit.
             this.Assert(e != null, "Cannot monitor a null event.");
             this.Monitor<T>(null, e);
+        }
+
+        /// <summary>
+        /// Gets the id of the currently executing <see cref="Machine"/>.
+        /// <returns>MachineId</returns>
+        /// </summary>
+        public override MachineId GetCurrentMachineId()
+        {
+            if (Task.CurrentId == null || !this.TaskMap.ContainsKey((int)Task.CurrentId))
+            {
+                return null;
+            }
+
+            Machine machine = this.TaskMap[(int)Task.CurrentId];
+            return machine.Id;
         }
 
         /// <summary>
@@ -262,7 +376,7 @@ namespace Microsoft.PSharp.TestingServices
             machine.SetMachineId(mid);
             machine.InitializeStateInformation();
 
-            if (this.Configuration.ReportCodeCoverage && !isMachineTypeCached)
+            if (base.Configuration.ReportCodeCoverage && !isMachineTypeCached)
             {
                 this.ReportCodeCoverageOfMachine(machine);
             }
@@ -273,7 +387,7 @@ namespace Microsoft.PSharp.TestingServices
             this.Log($"<CreateLog> Machine '{mid}' is created.");
             
             this.BugTrace.AddCreateMachineStep(creator, mid, e == null ? null : new EventInfo(e));
-            if (this.Configuration.EnableDataRaceDetection)
+            if (base.Configuration.EnableDataRaceDetection)
             {
                 // Traces machine actions, if data-race detection is enabled.
                 this.MachineActionTraceMap.Add(mid, new MachineActionTrace(mid));
@@ -313,31 +427,6 @@ namespace Microsoft.PSharp.TestingServices
         }
 
         /// <summary>
-        /// Tries to create a new monitor of the given type.
-        /// </summary>
-        /// <param name="type">Type of the monitor</param>
-        internal override void TryCreateMonitor(Type type)
-        {
-            this.Assert(type.IsSubclassOf(typeof(Monitor)), $"Type '{type.Name}' " +
-                "is not a subclass of Monitor.\n");
-
-            MachineId mid = new MachineId(type, null, this);
-            Object monitor = Activator.CreateInstance(type);
-            (monitor as Monitor).SetMachineId(mid);
-            (monitor as Monitor).InitializeStateInformation();
-
-            this.Log($"<CreateLog> Monitor '{type.Name}' is created.");
-
-            this.ReportCodeCoverageOfMachine(monitor as Monitor);
-            this.BugTrace.AddCreateMonitorStep(mid);
-
-            base.Monitors.Add(monitor as Monitor);
-            this.LivenessChecker.RegisterMonitor(monitor as Monitor);
-
-            (monitor as Monitor).GotoStartState();
-        }
-
-        /// <summary>
         /// Sends an asynchronous event to a machine.
         /// </summary>
         /// <param name="sender">Sender machine</param>
@@ -367,7 +456,7 @@ namespace Microsoft.PSharp.TestingServices
             EventInfo eventInfo = new EventInfo(e, originInfo);
             this.SetOperationIdForEvent(eventInfo, sender, isStarter);
 
-            if (this.Configuration.BoundOperations && sender != null)
+            if (base.Configuration.BoundOperations && sender != null)
             {
                 this.Log($"<SendLog> Machine '{sender.Id}' sent event " +
                     $"'{eventInfo.EventName}({eventInfo.OperationId})' to '{mid}'.");
@@ -386,7 +475,7 @@ namespace Microsoft.PSharp.TestingServices
             {
                 this.BugTrace.AddSendEventStep(sender.Id, this.GetStateNameOfMachine(sender),
                     eventInfo, mid);
-                if (this.Configuration.EnableDataRaceDetection)
+                if (base.Configuration.EnableDataRaceDetection)
                 {
                     // Traces machine actions, if data-race detection is enabled.
                     this.MachineActionTraceMap[sender.Id].AddSendActionInfo(mid, e);
@@ -423,6 +512,79 @@ namespace Microsoft.PSharp.TestingServices
         }
 
         /// <summary>
+		/// Runs a new asynchronous machine event handler.
+		/// This is a fire and forget invocation.
+		/// </summary>
+		/// <param name="machine">Machine</param>
+		/// <param name="e">Event</param>
+		/// <param name="isFresh">Is a new machine</param>
+		private void RunMachineEventHandler(Machine machine, Event e = null, bool isFresh = false)
+        {
+            Task task = new Task(() =>
+            {
+                try
+                {
+                    this.Scheduler.NotifyTaskStarted();
+
+                    if (isFresh)
+                    {
+                        machine.GotoStartState(e);
+                    }
+
+                    machine.RunEventHandler();
+
+                    this.Scheduler.NotifyTaskCompleted();
+                }
+                catch (ExecutionCanceledException)
+                {
+                    IO.Debug.WriteLine($"<Exception> ExecutionCanceledException was thrown from machine '{machine.Id}'.");
+                }
+                finally
+                {
+                    this.TaskMap.TryRemove(Task.CurrentId.Value, out machine);
+                }
+            });
+
+            this.MachineTasks.Add(task);
+            this.TaskMap.TryAdd(task.Id, machine);
+
+            this.Scheduler.NotifyNewTaskCreated(task.Id, machine);
+
+            task.Start();
+
+            this.Scheduler.WaitForTaskToStart(task.Id);
+        }
+
+        #endregion
+
+        #region specifications and error checking
+
+        /// <summary>
+        /// Tries to create a new monitor of the given type.
+        /// </summary>
+        /// <param name="type">Type of the monitor</param>
+        internal override void TryCreateMonitor(Type type)
+        {
+            this.Assert(type.IsSubclassOf(typeof(Monitor)), $"Type '{type.Name}' " +
+                "is not a subclass of Monitor.\n");
+
+            MachineId mid = new MachineId(type, null, this);
+            Object monitor = Activator.CreateInstance(type);
+            (monitor as Monitor).SetMachineId(mid);
+            (monitor as Monitor).InitializeStateInformation();
+
+            this.Log($"<CreateLog> Monitor '{type.Name}' is created.");
+
+            this.ReportCodeCoverageOfMachine(monitor as Monitor);
+            this.BugTrace.AddCreateMonitorStep(mid);
+
+            this.Monitors.Add(monitor as Monitor);
+            this.LivenessChecker.RegisterMonitor(monitor as Monitor);
+
+            (monitor as Monitor).GotoStartState();
+        }
+
+        /// <summary>
         /// Invokes the specified monitor with the given event.
         /// </summary>
         /// <param name="sender">Sender machine</param>
@@ -435,11 +597,11 @@ namespace Microsoft.PSharp.TestingServices
                 sender.AssertNoPendingRGP("Monitor");
             }
 
-            foreach (var m in base.Monitors)
+            foreach (var m in this.Monitors)
             {
                 if (m.GetType() == typeof(T))
                 {
-                    if(this.Configuration.ReportCodeCoverage)
+                    if (base.Configuration.ReportCodeCoverage)
                     {
                         this.ReportCodeCoverageOfMonitorEvent(sender, m, e);
                         this.ReportCodeCoverageOfMonitorTransition(m, e);
@@ -451,14 +613,47 @@ namespace Microsoft.PSharp.TestingServices
         }
 
         /// <summary>
+        /// Checks if the assertion holds, and if not it throws an
+        /// <see cref="AssertionFailureException"/> exception.
+        /// </summary>
+        /// <param name="predicate">Predicate</param>
+        public override void Assert(bool predicate)
+        {
+            if (!predicate)
+            {
+                string message = "Assertion failure.";
+                this.Scheduler.NotifyAssertionFailure(message);
+            }
+        }
+
+        /// <summary>
+        /// Checks if the assertion holds, and if not it throws an
+        /// <see cref="AssertionFailureException"/> exception.
+        /// </summary>
+        /// <param name="predicate">Predicate</param>
+        /// <param name="s">Message</param>
+        /// <param name="args">Message arguments</param>
+        public override void Assert(bool predicate, string s, params object[] args)
+        {
+            if (!predicate)
+            {
+                string message = IO.Utilities.Format(s, args);
+                this.Scheduler.NotifyAssertionFailure(message);
+            }
+        }
+
+        #endregion
+
+        #region nondeterministic choices
+
+        /// <summary>
         /// Returns a nondeterministic boolean choice, that can be
         /// controlled during analysis or testing.
         /// </summary>
         /// <param name="machine">Machine</param>
         /// <param name="maxValue">Max value</param>
         /// <returns>Boolean</returns>
-        internal override bool GetNondeterministicBooleanChoice(
-            AbstractMachine machine, int maxValue)
+        internal override bool GetNondeterministicBooleanChoice(AbstractMachine machine, int maxValue)
         {
             if (machine != null)
             {
@@ -488,8 +683,7 @@ namespace Microsoft.PSharp.TestingServices
         /// <param name="machine">Machine</param>
         /// <param name="uniqueId">Unique id</param>
         /// <returns>Boolean</returns>
-        internal override bool GetFairNondeterministicBooleanChoice(
-            AbstractMachine machine, string uniqueId)
+        internal override bool GetFairNondeterministicBooleanChoice(AbstractMachine machine, string uniqueId)
         {
             if (machine != null)
             {
@@ -519,8 +713,7 @@ namespace Microsoft.PSharp.TestingServices
         /// <param name="machine">Machine</param>
         /// <param name="maxValue">Max value</param>
         /// <returns>Integer</returns>
-        internal override int GetNondeterministicIntegerChoice(
-            AbstractMachine machine, int maxValue)
+        internal override int GetNondeterministicIntegerChoice(AbstractMachine machine, int maxValue)
         {
             if (machine != null)
             {
@@ -542,6 +735,10 @@ namespace Microsoft.PSharp.TestingServices
 
             return choice;
         }
+
+        #endregion
+
+        #region notifications
 
         /// <summary>
         /// Notifies that a machine entered a state.
@@ -629,7 +826,7 @@ namespace Microsoft.PSharp.TestingServices
                 this.Log($"<ActionLog> Machine '{machine.Id}' invoked action " +
                     $"'{action.Name}' in state '{machineState}'.");
 
-                if (this.Configuration.EnableDataRaceDetection)
+                if (base.Configuration.EnableDataRaceDetection)
                 {
                     // Traces machine actions, if data-race detection is enabled.
                     this.MachineActionTraceMap[machine.Id].AddInvocationActionInfo(action.Name, receivedEvent);
@@ -652,7 +849,7 @@ namespace Microsoft.PSharp.TestingServices
         /// <param name="eventInfo">EventInfo</param>
         internal override void NotifyDequeuedEvent(Machine machine, EventInfo eventInfo)
         {
-            if (this.Configuration.BoundOperations)
+            if (base.Configuration.BoundOperations)
             {
                 this.Log($"<DequeueLog> Machine '{machine.Id}' dequeued " +
                     $"event '{eventInfo.EventName}({eventInfo.OperationId})'.");
@@ -668,20 +865,20 @@ namespace Microsoft.PSharp.TestingServices
             var prevMachineOpId = machine.OperationId;
             machine.SetOperationId(eventInfo.OperationId);
             
-            if (this.Configuration.ReportCodeCoverage)
+            if (base.Configuration.ReportCodeCoverage)
             {
                 this.ReportCodeCoverageOfReceivedEvent(machine, eventInfo);
                 this.ReportCodeCoverageOfStateTransition(machine, eventInfo);
             }
 
-            //if (this.Configuration.BoundOperations && prevMachineOpId != machine.OperationId)
+            //if (base.Configuration.BoundOperations && prevMachineOpId != machine.OperationId)
             //{
             //    this.Scheduler.Schedule();
             //}
         }
 
         /// <summary>
-        /// Notifies that a machine called Pop.
+        /// Notifies that a machine called pop.
         /// </summary>
         /// <param name="machine">Machine</param>
         /// <param name="fromState">Top of the stack state</param>
@@ -690,7 +887,7 @@ namespace Microsoft.PSharp.TestingServices
         {
             machine.AssertCorrectRGPInvocation();
 
-            if(this.Configuration.ReportCodeCoverage)
+            if (base.Configuration.ReportCodeCoverage)
             {
                 this.ReportCodeCoverageOfPopTransition(machine, fromState, toState);
             }
@@ -714,7 +911,7 @@ namespace Microsoft.PSharp.TestingServices
                 string machineState = (machine as Machine).CurrentStateName;
                 this.BugTrace.AddRaiseEventStep(machine.Id, machineState, eventInfo);
 
-                if (this.Configuration.BoundOperations)
+                if (base.Configuration.BoundOperations)
                 {
                     this.Log($"<RaiseLog> Machine '{machine.Id}' raised " +
                         $"event '{eventInfo.EventName}({eventInfo.OperationId})'.");
@@ -733,7 +930,7 @@ namespace Microsoft.PSharp.TestingServices
                 this.Log($"<MonitorLog> Monitor '{machine.GetType().Name}' raised " +
                     $"event '{eventInfo.EventName}'.");
 
-                if (this.Configuration.ReportCodeCoverage)
+                if (base.Configuration.ReportCodeCoverage)
                 {
                     this.ReportCodeCoverageOfMonitorTransition(machine as Monitor, eventInfo.Event);
                 }
@@ -750,7 +947,7 @@ namespace Microsoft.PSharp.TestingServices
         }
 
         /// <summary>
-        /// Notifies that a machine handles a raised event.
+        /// Notifies that a machine is handling a raised event.
         /// </summary>
         /// <param name="machine">Machine</param>
         /// <param name="eventInfo">EventInfo</param>
@@ -759,12 +956,12 @@ namespace Microsoft.PSharp.TestingServices
             var prevMachineOpId = machine.OperationId;
             machine.SetOperationId(eventInfo.OperationId);
             
-            if (this.Configuration.ReportCodeCoverage)
+            if (base.Configuration.ReportCodeCoverage)
             {
                 this.ReportCodeCoverageOfStateTransition(machine, eventInfo);
             }
 
-            //if (this.Configuration.BoundOperations && prevMachineOpId != machine.OperationId)
+            //if (base.Configuration.BoundOperations && prevMachineOpId != machine.OperationId)
             //{
             //    this.Scheduler.Schedule();
             //}
@@ -796,7 +993,7 @@ namespace Microsoft.PSharp.TestingServices
         {
             this.BugTrace.AddReceivedEventStep(machine.Id, machine.CurrentStateName, eventInfo);
 
-            if (this.Configuration.BoundOperations)
+            if (base.Configuration.BoundOperations)
             {
                 this.Log($"<ReceiveLog> Machine '{machine.Id}' received " +
                     $"event '{eventInfo.EventName}({eventInfo.OperationId})' and unblocked.");
@@ -828,187 +1025,6 @@ namespace Microsoft.PSharp.TestingServices
         internal override void NotifyDefaultHandlerFired()
         {
             this.Scheduler.Schedule();
-        }
-
-        /// <summary>
-        /// Returns the fingerprint of the current program state.
-        /// </summary>
-        /// <returns>Fingerprint</returns>
-        internal Fingerprint GetProgramState()
-        {
-            Fingerprint fingerprint = null;
-
-            unchecked
-            {
-                int hash = 19;
-
-                foreach (var machine in this.MachineMap.Values)
-                {
-                    hash = hash + 31 * machine.GetCachedState();
-                }
-
-                foreach (var monitor in base.Monitors)
-                {
-                    hash = hash + 31 * monitor.GetCachedState();
-                }
-
-                fingerprint = new Fingerprint(hash);
-            }
-
-            return fingerprint;
-        }
-
-        #endregion
-
-        #region error checking
-
-        /// <summary>
-        /// Checks if the assertion holds, and if not it throws an
-        /// <see cref="AssertionFailureException"/> exception.
-        /// </summary>
-        /// <param name="predicate">Predicate</param>
-        public override void Assert(bool predicate)
-        {
-            if (!predicate)
-            {
-                string message = "Assertion failure.";
-                this.Scheduler.NotifyAssertionFailure(message);
-            }
-        }
-
-        /// <summary>
-        /// Checks if the assertion holds, and if not it throws an
-        /// <see cref="AssertionFailureException"/> exception.
-        /// </summary>
-        /// <param name="predicate">Predicate</param>
-        /// <param name="s">Message</param>
-        /// <param name="args">Message arguments</param>
-        public override void Assert(bool predicate, string s, params object[] args)
-        {
-            if (!predicate)
-            {
-                string message = IO.Utilities.Format(s, args);
-                this.Scheduler.NotifyAssertionFailure(message);
-            }
-        }
-
-        /// <summary>
-        /// Throws an <see cref="AssertionFailureException"/> exception
-        /// containing the specified exception.
-        /// </summary>
-        /// <param name="exception">Exception</param>
-        /// <param name="s">Message</param>
-        /// <param name="args">Message arguments</param>
-        internal override void WrapAndThrowException(Exception exception, string s, params object[] args)
-        {
-            string message = IO.Utilities.Format(s, args);
-            this.Scheduler.NotifyAssertionFailure(message);
-        }
-
-        #endregion
-
-        #region logging
-
-        /// <summary>
-        /// Logs the specified text.
-        /// </summary>
-        /// <param name="format">Text</param>
-        /// <param name="args">Arguments</param>
-        protected internal override void Log(string format, params object[] args)
-        {
-            this.Logger.WriteLine(format, args);
-        }
-
-        #endregion
-
-        #region private methods
-
-        /// <summary>
-		/// Runs a new asynchronous machine event handler.
-		/// This is a fire and forget invocation.
-		/// </summary>
-		/// <param name="machine">Machine</param>
-		/// <param name="e">Event</param>
-		/// <param name="isFresh">Is a new machine</param>
-		private void RunMachineEventHandler(Machine machine, Event e = null, bool isFresh = false)
-        {
-            Task task = new Task(() =>
-            {
-                try
-                {
-                    this.Scheduler.NotifyTaskStarted();
-
-                    if (isFresh)
-                    {
-                        machine.GotoStartState(e);
-                    }
-                    
-                    machine.RunEventHandler();
-
-                    this.Scheduler.NotifyTaskCompleted();
-                }
-                catch (ExecutionCanceledException)
-                {
-                    IO.Debug.WriteLine($"<Exception> ExecutionCanceledException was thrown from machine '{machine.Id}'.");
-                }
-                finally
-                {
-                    this.TaskMap.TryRemove(Task.CurrentId.Value, out machine);
-                }
-            });
-
-            this.MachineTasks.Add(task);
-            base.TaskMap.TryAdd(task.Id, machine);
-
-            this.Scheduler.NotifyNewTaskCreated(task.Id, machine);
-
-            task.Start();
-
-            this.Scheduler.WaitForTaskToStart(task.Id);
-        }
-
-        /// <summary>
-        /// Returns the state name of the specified machine,
-        /// if the machine is in such a state.
-        /// </summary>
-        /// <param name="machine">AbstractMachine</param>
-        /// <returns>StateName</returns>
-        private string GetStateNameOfMachine(AbstractMachine machine)
-        {
-            string machineState = null;
-            if (machine is Machine)
-            {
-                machineState = (machine as Machine).CurrentStateName;
-            }
-            else if (machine is Monitor)
-            {
-                machineState = (machine as Monitor).CurrentStateName;
-            }
-
-            return machineState;
-        }
-
-        /// <summary>
-        /// Sets the operation id for the given event.
-        /// </summary>
-        /// <param name="eventInfo">EventInfo</param>
-        /// <param name="sender">Sender machine</param>
-        /// <param name="isStarter">Is starting a new operation</param>
-        private void SetOperationIdForEvent(EventInfo eventInfo, AbstractMachine sender, bool isStarter)
-        {
-            if (isStarter)
-            {
-                this.OperationIdCounter++;
-                eventInfo.SetOperationId(this.OperationIdCounter);
-            }
-            else if (sender != null)
-            {
-                eventInfo.SetOperationId(sender.OperationId);
-            }
-            else
-            {
-                eventInfo.SetOperationId(0);
-            }
         }
 
         #endregion
@@ -1114,8 +1130,7 @@ namespace Microsoft.PSharp.TestingServices
 
             this.CoverageInfo.AddTransition(originMachine, originState, edgeLabel, destMachine, destState);
         }
-
-
+        
         /// <summary>
         /// Reports code coverage for a pop transition.
         /// </summary>
@@ -1167,14 +1182,142 @@ namespace Microsoft.PSharp.TestingServices
 
         #endregion
 
-        #region cleanup methods
+        #region utilities
+
+        /// <summary>
+        /// Returns the fingerprint of the current program state.
+        /// </summary>
+        /// <returns>Fingerprint</returns>
+        internal Fingerprint GetProgramState()
+        {
+            Fingerprint fingerprint = null;
+
+            unchecked
+            {
+                int hash = 19;
+
+                foreach (var machine in this.MachineMap.Values)
+                {
+                    hash = hash + 31 * machine.GetCachedState();
+                }
+
+                foreach (var monitor in this.Monitors)
+                {
+                    hash = hash + 31 * monitor.GetCachedState();
+                }
+
+                fingerprint = new Fingerprint(hash);
+            }
+
+            return fingerprint;
+        }
+
+        /// <summary>
+        /// Returns the state name of the specified machine,
+        /// if the machine is in such a state.
+        /// </summary>
+        /// <param name="machine">AbstractMachine</param>
+        /// <returns>StateName</returns>
+        private string GetStateNameOfMachine(AbstractMachine machine)
+        {
+            string machineState = null;
+            if (machine is Machine)
+            {
+                machineState = (machine as Machine).CurrentStateName;
+            }
+            else if (machine is Monitor)
+            {
+                machineState = (machine as Monitor).CurrentStateName;
+            }
+
+            return machineState;
+        }
+
+        /// <summary>
+        /// Gets the currently executing <see cref="Machine"/>.
+        /// </summary>
+        /// <returns>Machine or null, if not present</returns>
+        private Machine GetCurrentMachine()
+        {
+            //  The current task does not correspond to a machine.
+            if (Task.CurrentId == null)
+            {
+                return null;
+            }
+
+            // The current task does not correspond to a machine.
+            if (!this.TaskMap.ContainsKey((int)Task.CurrentId))
+            {
+                return null;
+            }
+
+            return this.TaskMap[(int)Task.CurrentId];
+        }
+
+        /// <summary>
+        /// Sets the operation id for the given event.
+        /// </summary>
+        /// <param name="eventInfo">EventInfo</param>
+        /// <param name="sender">Sender machine</param>
+        /// <param name="isStarter">Is starting a new operation</param>
+        private void SetOperationIdForEvent(EventInfo eventInfo, AbstractMachine sender, bool isStarter)
+        {
+            if (isStarter)
+            {
+                this.OperationIdCounter++;
+                eventInfo.SetOperationId(this.OperationIdCounter);
+            }
+            else if (sender != null)
+            {
+                eventInfo.SetOperationId(sender.OperationId);
+            }
+            else
+            {
+                eventInfo.SetOperationId(0);
+            }
+        }
+
+        #endregion
+
+        #region logging
+
+        /// <summary>
+        /// Logs the specified text.
+        /// </summary>
+        /// <param name="format">Text</param>
+        /// <param name="args">Arguments</param>
+        protected internal override void Log(string format, params object[] args)
+        {
+            base.Logger.WriteLine(format, args);
+        }
+
+        #endregion
+
+        #region exceptions
+
+        /// <summary>
+        /// Throws an <see cref="AssertionFailureException"/> exception
+        /// containing the specified exception.
+        /// </summary>
+        /// <param name="exception">Exception</param>
+        /// <param name="s">Message</param>
+        /// <param name="args">Message arguments</param>
+        internal override void WrapAndThrowException(Exception exception, string s, params object[] args)
+        {
+            string message = IO.Utilities.Format(s, args);
+            this.Scheduler.NotifyAssertionFailure(message);
+        }
+
+        #endregion
+
+        #region cleanup
 
         /// <summary>
         /// Disposes runtime resources.
         /// </summary>
-        public void Dispose()
+        public override void Dispose()
         {
-            base.Monitors.Clear();
+            this.Monitors.Clear();
             this.MachineActionTraceMap.Clear();
 
             this.LivenessChecker = null;

--- a/Tests/Core.Tests.Unit/Logging/Correct/CustomLoggerTest.cs
+++ b/Tests/Core.Tests.Unit/Logging/Correct/CustomLoggerTest.cs
@@ -124,17 +124,6 @@ namespace Microsoft.PSharp.Core.Tests.Unit
             }
         }
 
-        public static class Program
-        {
-            [Test]
-            public static void Execute(PSharpRuntime runtime)
-            {
-                var tcs = new TaskCompletionSource<bool>();
-                runtime.CreateMachine(typeof(M), new Configure(tcs));
-                tcs.Task.Wait();
-            }
-        }
-
         [TestMethod]
         public void TestCustomLogger()
         {
@@ -144,7 +133,9 @@ namespace Microsoft.PSharp.Core.Tests.Unit
             PSharpRuntime runtime = PSharpRuntime.Create(config);
             runtime.SetLogger(logger);
 
-            Program.Execute(runtime);
+            var tcs = new TaskCompletionSource<bool>();
+            runtime.CreateMachine(typeof(M), new Configure(tcs));
+            tcs.Task.Wait();
 
             string expected = @"<CreateLog> Machine 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+M()' is created.
 <StateLog> Machine 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+M()' enters state 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+M.Init'.
@@ -179,7 +170,9 @@ namespace Microsoft.PSharp.Core.Tests.Unit
             PSharpRuntime runtime = PSharpRuntime.Create();
             runtime.SetLogger(logger);
 
-            Program.Execute(runtime);
+            var tcs = new TaskCompletionSource<bool>();
+            runtime.CreateMachine(typeof(M), new Configure(tcs));
+            tcs.Task.Wait();
 
             Assert.AreEqual("", logger.ToString());
 


### PR DESCRIPTION
`PSharpRuntime` is now an abstract class. Internally, `StateMachineRuntime` and `BugFindingRuntime` inherit this abstract class and implement its methods accordingly. `PSharpRuntime` also provides basic functionality shared by all runtimes (e.g. logging).

This refactoring aims to ease the introduction of new runtimes.

The cool thing is that there are no changes required from a user's point of view. `PSharpRuntime` is the only publicly exposed runtime (and the user creates one exactly as before, using the factory method `PSharpRuntime.Create`).