### PR TITLE
Send and execute event

### DIFF
--- a/Libraries/Core/Library/Machine.cs
+++ b/Libraries/Core/Library/Machine.cs
@@ -239,7 +239,7 @@ namespace Microsoft.PSharp
         /// <returns>MachineId</returns>
         protected MachineId CreateMachine(Type type, Event e = null)
         {
-            return base.Runtime.TryCreateMachine(this, type, null, e);
+            return base.Runtime.TryCreateMachine(type, null, e, this, false);
         }
 
         /// <summary>
@@ -253,7 +253,7 @@ namespace Microsoft.PSharp
         /// <returns>MachineId</returns>
         protected MachineId CreateMachine(Type type, string friendlyName, Event e = null)
         {
-            return base.Runtime.TryCreateMachine(this, type, friendlyName, e);
+            return base.Runtime.TryCreateMachine(type, friendlyName, e, this, false);
         }
 
         /// <summary>
@@ -267,7 +267,7 @@ namespace Microsoft.PSharp
         /// <returns>MachineId</returns>
         protected MachineId CreateRemoteMachine(Type type, string endpoint, Event e = null)
         {
-            return base.Runtime.TryCreateRemoteMachine(this, type, null, endpoint, e);
+            return base.Runtime.TryCreateRemoteMachine(type, null, endpoint, e, this);
         }
 
         /// <summary>
@@ -283,7 +283,7 @@ namespace Microsoft.PSharp
         protected MachineId CreateRemoteMachine(Type type, string friendlyName,
             string endpoint, Event e = null)
         {
-            return base.Runtime.TryCreateRemoteMachine(this, type, friendlyName, endpoint, e);
+            return base.Runtime.TryCreateRemoteMachine(type, friendlyName, endpoint, e, this);
         }
 
         /// <summary>
@@ -298,7 +298,7 @@ namespace Microsoft.PSharp
             this.Assert(mid != null, $"Machine '{base.Id}' is sending to a null machine.");
             // If the event is null, then report an error and exit.
             this.Assert(e != null, $"Machine '{base.Id}' is sending a null event.");
-            base.Runtime.Send(this, mid, e, isStarter);
+            base.Runtime.Send(mid, e, this, false, isStarter);
         }
 
         /// <summary>
@@ -313,7 +313,7 @@ namespace Microsoft.PSharp
             this.Assert(mid != null, $"Machine '{base.Id}' is sending to a null machine.");
             // If the event is null, then report an error and exit.
             this.Assert(e != null, $"Machine '{base.Id}' is sending a null event.");
-            base.Runtime.SendRemotely(this, mid, e, isStarter);
+            base.Runtime.SendRemotely(mid, e, this, isStarter);
         }
 
         /// <summary>

--- a/Libraries/Core/Runtime/PSharpRuntime.cs
+++ b/Libraries/Core/Runtime/PSharpRuntime.cs
@@ -155,6 +155,29 @@ namespace Microsoft.PSharp
         public abstract MachineId CreateMachine(Type type, string friendlyName, Event e = null);
 
         /// <summary>
+        /// Creates a new machine of the specified <see cref="Type"/> and with the
+        /// specified optional <see cref="Event"/>. This event can only be used to
+        /// access its payload, and cannot be handled. The method returns only when
+        /// the machine is initialized and the <see cref="Event"/> (if any) is handled.
+        /// </summary>
+        /// <param name="type">Type of the machine</param>
+        /// <param name="e">Event</param>
+        /// <returns>MachineId</returns>
+        public abstract MachineId CreateMachineAndExecute(Type type, Event e = null);
+
+        /// <summary>
+        /// Creates a new machine of the specified <see cref="Type"/> and name, and with
+        /// the specified optional <see cref="Event"/>. This event can only be used to
+        /// access its payload, and cannot be handled. The method returns only when the
+        /// machine is initialized and the <see cref="Event"/> (if any) is handled.
+        /// </summary>
+        /// <param name="type">Type of the machine</param>
+        /// <param name="friendlyName">Friendly machine name used for logging</param>
+        /// <param name="e">Event</param>
+        /// <returns>MachineId</returns>
+        public abstract MachineId CreateMachineAndExecute(Type type, string friendlyName, Event e = null);
+
+        /// <summary>
         /// Creates a new remote machine of the specified <see cref="Type"/> and with
         /// the specified optional <see cref="Event"/>. This event can only be used
         /// to access its payload, and cannot be handled.
@@ -184,6 +207,14 @@ namespace Microsoft.PSharp
         /// <param name="target">Target machine id</param>
         /// <param name="e">Event</param>
         public abstract void SendEvent(MachineId target, Event e);
+
+        /// <summary>
+        /// Synchronously delivers an <see cref="Event"/> to a machine
+        /// and executes it if the machine is available.
+        /// </summary>
+        /// <param name="target">Target machine id</param>
+        /// <param name="e">Event</param>
+        public abstract void SendEventAndExecute(MachineId target, Event e);
 
         /// <summary>
         /// Sends an asynchronous <see cref="Event"/> to a remote machine.
@@ -282,42 +313,45 @@ namespace Microsoft.PSharp
         /// <summary>
         /// Tries to create a new <see cref="Machine"/> of the specified <see cref="Type"/>.
         /// </summary>
-        /// <param name="creator">Creator machine</param>
         /// <param name="type">Type of the machine</param>
         /// <param name="friendlyName">Friendly machine name used for logging</param>
-        /// <param name="e">Event</param>
+        /// <param name="e">Event passed during machine construction</param>
+        /// <param name="creator">Creator machine</param>
+        /// <param name="executeSynchronously">If true, this operation executes synchronously</param> 
         /// <returns>MachineId</returns>
-        internal abstract MachineId TryCreateMachine(Machine creator, Type type, string friendlyName, Event e);
+        internal abstract MachineId TryCreateMachine(Type type, string friendlyName, Event e,
+            Machine creator, bool executeSynchronously);
 
         /// <summary>
         /// Tries to create a new remote <see cref="Machine"/> of the specified <see cref="System.Type"/>.
         /// </summary>
-        /// <param name="creator">Creator machine</param>
         /// <param name="type">Type of the machine</param>
         /// <param name="friendlyName">Friendly machine name used for logging</param>
         /// <param name="endpoint">Endpoint</param>
-        /// <param name="e">Event</param>
+        /// <param name="e">Event passed during machine construction</param>
+        /// <param name="creator">Creator machine</param>
         /// <returns>MachineId</returns>
-        internal abstract MachineId TryCreateRemoteMachine(Machine creator, Type type,
-            string friendlyName, string endpoint, Event e);
+        internal abstract MachineId TryCreateRemoteMachine(Type type, string friendlyName, string endpoint,
+            Event e, Machine creator);
 
         /// <summary>
         /// Sends an asynchronous <see cref="Event"/> to a machine.
         /// </summary>
-        /// <param name="sender">Sender machine</param>
         /// <param name="mid">MachineId</param>
         /// <param name="e">Event</param>
+        /// <param name="sender">Sender machine</param>
+        /// <param name="executeSynchronously">If true, this operation executes synchronously</param> 
         /// <param name="isStarter">Is starting a new operation</param>
-        internal abstract void Send(AbstractMachine sender, MachineId mid, Event e, bool isStarter);
+        internal abstract void Send(MachineId mid, Event e, AbstractMachine sender, bool executeSynchronously, bool isStarter);
 
         /// <summary>
         /// Sends an asynchronous <see cref="Event"/> to a remote machine.
         /// </summary>
-        /// <param name="sender">Sender machine</param>
         /// <param name="mid">MachineId</param>
         /// <param name="e">Event</param>
-        /// <param name="isStarter">Is starting a new operation</param>
-        internal abstract void SendRemotely(AbstractMachine sender, MachineId mid, Event e, bool isStarter);
+        /// <param name="sender">Sender machine</param>
+        /// <param name="isStarter">If true, the send is starting a new operation</param>
+        internal abstract void SendRemotely(MachineId mid, Event e, AbstractMachine sender, bool isStarter);
 
         #endregion
 

--- a/Tests/Core.Tests.Performance/Tests/CreateMachinesTest.cs
+++ b/Tests/Core.Tests.Performance/Tests/CreateMachinesTest.cs
@@ -37,7 +37,7 @@ namespace Microsoft.PSharp.Core.Tests.Performance
 
             for (int idx = 0; idx < Size; idx++)
             {
-                runtime.TryCreateMachine(null, typeof(Node), null, null);
+                runtime.TryCreateMachine(typeof(Node), null, null, null, false);
             }
 
             runtime.Wait();

--- a/Tests/Core.Tests.Performance/Tests/MailboxTest.cs
+++ b/Tests/Core.Tests.Performance/Tests/MailboxTest.cs
@@ -99,8 +99,9 @@ namespace Microsoft.PSharp.Core.Tests.Performance
         public void SendMessages()
         {
             var runtime = new StateMachineRuntime();
-            runtime.TryCreateMachine(null, typeof(Server), null,
-                new Server.Configure(this.Clients, this.EventsPerClient));
+            runtime.TryCreateMachine(typeof(Server), null,
+                new Server.Configure(this.Clients, this.EventsPerClient),
+                null, false);
             runtime.Wait();
         }
 


### PR DESCRIPTION
New APIs for synchronous (when available) delivery of messages and machine creation.
TODO: Fail if such synchronous execution calls a Receive. Lets create an issue to track this once we merge.