### PR TITLE
Additional assertions to make sure a machine reference isn't passed around

### DIFF
--- a/Tests/Core.Tests.Unit/Logging/CustomLoggerTest.cs
+++ b/Tests/Core.Tests.Unit/Logging/CustomLoggerTest.cs
@@ -143,12 +143,12 @@ namespace Microsoft.PSharp.Core.Tests.Unit
 <ActionLog> Machine 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+M()' in state 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+M.Init' invoked action 'InitOnEntry'.
 <CreateLog> Machine 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+N()' is created.
 <StateLog> Machine 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+N()' enters state 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+N.Init'.
-<SendLog> Operation Group <none>: Machine 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+M()' in state 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+M.Init' sent event 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+E' to machine 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+N()' in state 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+N.Init'.
-<EnqueueLog> Machine 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+N()' in state 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+N.Init' enqueued event 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+E'.
+<SendLog> Operation Group ----: Machine 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+M()' in state 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+M.Init' sent event 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+E' to machine 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+N()'.
+<EnqueueLog> Machine 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+N()' enqueued event 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+E'.
 <DequeueLog> Machine 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+N()' in state 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+N.Init' dequeued event 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+E'.
 <ActionLog> Machine 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+N()' in state 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+N.Init' invoked action 'Act'.
-<SendLog> Operation Group <none>: Machine 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+N()' in state 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+N.Init' sent event 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+E' to machine 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+M()' in state 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+M.Init'.
-<EnqueueLog> Machine 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+M()' in state 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+M.Init' enqueued event 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+E'.
+<SendLog> Operation Group ----: Machine 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+N()' in state 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+N.Init' sent event 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+E' to machine 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+M()'.
+<EnqueueLog> Machine 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+M()' enqueued event 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+E'.
 <DequeueLog> Machine 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+M()' in state 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+M.Init' dequeued event 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+E'.
 <ActionLog> Machine 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+M()' in state 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+M.Init' invoked action 'Act'.
 ";

--- a/Tests/TestingServices.Tests.Unit/Machines/Statements/PopTest.cs
+++ b/Tests/TestingServices.Tests.Unit/Machines/Statements/PopTest.cs
@@ -64,7 +64,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
         public void TestPopDuringOnExit()
         {
             var test = new Action<PSharpRuntime>((r) => { r.CreateMachine(typeof(N), "N"); });
-            var bugReport = "Machine 'N()' has called raise/goto/pop inside an OnExit method.";
+            var bugReport = "Machine 'N()' has called raise, goto or pop inside an OnExit method.";
             base.AssertFailed(test, bugReport, true);
         }
     }

--- a/Tests/TestingServices.Tests.Unit/Machines/Transitions/GotoTransitions/GotoStateMultipleInActionFailTest.cs
+++ b/Tests/TestingServices.Tests.Unit/Machines/Transitions/GotoTransitions/GotoStateMultipleInActionFailTest.cs
@@ -88,7 +88,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
             });
 
             var bugReport = "Machine 'Microsoft.PSharp.TestingServices.Tests.Unit.GotoStateTopLevelActionFailTest+Program()' " +
-                "has called multiple raise/goto/pop in the same action.";
+                "has called multiple raise, goto or pop in the same action.";
             base.AssertFailed(test, bugReport, true);
         }
 
@@ -100,7 +100,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
             });
 
             var bugReport = "Machine 'Microsoft.PSharp.TestingServices.Tests.Unit.GotoStateTopLevelActionFailTest+Program()' " +
-                "has called multiple raise/goto/pop in the same action.";
+                "has called multiple raise, goto or pop in the same action.";
             base.AssertFailed(test, bugReport, true);
         }
 
@@ -112,7 +112,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
             });
 
             var bugReport = "Machine 'Microsoft.PSharp.TestingServices.Tests.Unit.GotoStateTopLevelActionFailTest+Program()' " +
-                "cannot call API 'Send' after calling raise/goto/pop in the same action.";
+                "cannot call 'Send' after calling raise, goto or pop in the same action.";
             base.AssertFailed(test, bugReport, true);
         }
 
@@ -124,7 +124,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
             });
 
             var bugReport = "Machine 'Microsoft.PSharp.TestingServices.Tests.Unit.GotoStateTopLevelActionFailTest+Program()' " +
-                "has called raise/goto/pop inside an OnExit method.";
+                "has called raise, goto or pop inside an OnExit method.";
             base.AssertFailed(test, bugReport, true);
         }
 


### PR DESCRIPTION
This detects some obvious assertions in the code where one machine ends up calling a P# machine on another machine. This will never happen unless a machine reference is passed around.