### PR TITLE
Replaced runtime.Wait() with runtime.Stop()

### DIFF
--- a/Libraries/Core/Library/Machine.cs
+++ b/Libraries/Core/Library/Machine.cs
@@ -695,7 +695,7 @@ namespace Microsoft.PSharp
 
             EventInfo nextEventInfo = null;
 
-            while (!this.IsHalted && !base.Runtime.IsFaulted)
+            while (!this.IsHalted && base.Runtime.IsRunning)
             {
                 var defaultHandling = false;
                 var dequeued = false;
@@ -1376,7 +1376,8 @@ namespace Microsoft.PSharp
                         }
                     }
                 }
-                // cache completed
+
+                // Cache completed.
                 lock(MachineStateCached)
                 {
                     MachineStateCached[machineType] = true;

--- a/Libraries/Core/Runtime/PSharpRuntime.cs
+++ b/Libraries/Core/Runtime/PSharpRuntime.cs
@@ -39,9 +39,9 @@ namespace Microsoft.PSharp
         internal long MachineIdCounter;
 
         /// <summary>
-        /// Records if the P# program has faulted.
+        /// Records if the runtime is running.
         /// </summary>
-        internal volatile bool IsFaulted;
+        internal volatile bool IsRunning;
 
         #endregion
 
@@ -126,7 +126,7 @@ namespace Microsoft.PSharp
             this.MachineIdCounter = 0;
             this.NetworkProvider = new LocalNetworkProvider(this);
             this.Logger = new ConsoleLogger();
-            this.IsFaulted = false;
+            this.IsRunning = true;
         }
 
         #endregion
@@ -301,10 +301,11 @@ namespace Microsoft.PSharp
         public abstract MachineId GetCurrentMachineId();
 
         /// <summary>
-        /// Waits until the runtime has reached quiescence. This is an experimental
-        /// feature, which should only be used for testing purposes.
+        /// Notifies each active machine to halt execution to allow the runtime
+        /// to reach quiescence. This is an experimental feature, which should
+        /// be used only for testing purposes.
         /// </summary>
-        public abstract void Wait();
+        public abstract void Stop();
 
         #endregion
 

--- a/Libraries/TestingServices/Runtime/BugFindingRuntime.cs
+++ b/Libraries/TestingServices/Runtime/BugFindingRuntime.cs
@@ -391,9 +391,14 @@ namespace Microsoft.PSharp.TestingServices
         }
 
         /// <summary>
-        /// Waits until all P# machines have finished execution.
+        /// Notifies each active machine to halt execution to allow the runtime
+        /// to reach quiescence. This is an experimental feature, which should
+        /// be used only for testing purposes.
         /// </summary>
-        public override void Wait() => this.Scheduler.Wait();
+        public override void Stop()
+        {
+            base.IsRunning = false;
+        }
 
         #endregion
 
@@ -438,6 +443,11 @@ namespace Microsoft.PSharp.TestingServices
             this.Scheduler.WaitForTaskToStart(task.Id);
             this.Scheduler.Schedule();
         }
+
+        /// <summary>
+        /// Waits until all P# machines have finished execution.
+        /// </summary>
+        internal void Wait() => this.Scheduler.Wait();
 
         /// <summary>
         /// Tries to create a new <see cref="Machine"/> of the specified <see cref="Type"/>.


### PR DESCRIPTION
- Replaced `runtime.Wait()` with `runtime.Stop()`
- `runtime.Wait()` is still available inside the bug-finding runtime (and is used internally during testing)
- updated integration and performance tests that were using the old `runtime.Wait()`