### PR TITLE
Support reporting exceptions thrown in test entry point method method

### DIFF
--- a/Libraries/TestingServices/Runtime/BugFindingRuntime.cs
+++ b/Libraries/TestingServices/Runtime/BugFindingRuntime.cs
@@ -371,6 +371,10 @@ namespace Microsoft.PSharp.TestingServices
                 {
                     IO.Debug.WriteLine($"<Exception> ExecutionCanceledException was thrown in the test harness.");
                 }
+                catch (Exception ex)
+                {
+                    harness.ReportUnhandledException(ex);
+                }
             });
 
             this.Scheduler.NotifyNewTaskCreated(task.Id, harness);

--- a/Libraries/TestingServices/Runtime/TestHarnessMachine.cs
+++ b/Libraries/TestingServices/Runtime/TestHarnessMachine.cs
@@ -74,5 +74,34 @@ namespace Microsoft.PSharp.TestingServices
         }
 
         #endregion
+
+        #region error checking
+
+        /// <summary>
+        /// Wraps the unhandled exception inside an <see cref="AssertionFailureException"/>
+        /// exception, and throws it to the user.
+        /// </summary>
+        /// <param name="ex">Exception</param>
+        internal void ReportUnhandledException(Exception ex)
+        {
+            if (this.TestAction != null)
+            {
+                base.Runtime.WrapAndThrowException(ex, $"Exception '{ex.GetType()}' was thrown " +
+                    $"in anonymous test method, " +
+                    $"'{ex.Source}':\n" +
+                    $"   {ex.Message}\n" +
+                    $"The stack trace is:\n{ex.StackTrace}");
+            }
+            else
+            {
+                base.Runtime.WrapAndThrowException(ex, $"Exception '{ex.GetType()}' was thrown " +
+                    $"in test method '{this.TestMethod.DeclaringType}.{this.TestMethod.Name}', " +
+                    $"'{ex.Source}':\n" +
+                    $"   {ex.Message}\n" +
+                    $"The stack trace is:\n{ex.StackTrace}");
+            }
+        }
+
+        #endregion
     }
 }

--- a/Tests/TestingServices.Tests.Unit/EntryPoint/EntryPointThrowExceptionTest.cs
+++ b/Tests/TestingServices.Tests.Unit/EntryPoint/EntryPointThrowExceptionTest.cs
@@ -1,0 +1,52 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="EntryPointThrowExceptionTest.cs">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// 
+//      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+
+using Xunit;
+
+namespace Microsoft.PSharp.TestingServices.Tests.Unit
+{
+    public class EntryPointThrowExceptionTest : BaseTest
+    {
+        class M : Machine
+        {
+            [Start]
+            class Init : MachineState { }
+        }
+
+        [Fact]
+        public void TestEntryPointThrowException()
+        {
+            PSharpRuntime stored_runtime = null;
+            int counter = 0;
+
+            var test = new Action<PSharpRuntime>((r) => {
+                if (counter == 0)
+                {
+                    stored_runtime = r; 
+                    counter++;
+                }
+
+                // Fails in the second iteration, because logger is disposed.
+                stored_runtime.Logger.WriteLine("Starting iteration {0}", counter); 
+
+                MachineId m = r.CreateMachine(typeof(M));
+            });
+
+            var config = Configuration.Create().WithNumberOfIterations(2);
+            base.AssertFailedWithException(config, test, typeof(ObjectDisposedException));
+        }
+    }
+}

--- a/Tests/TestingServices.Tests.Unit/TestingServices.Tests.Unit.csproj
+++ b/Tests/TestingServices.Tests.Unit/TestingServices.Tests.Unit.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Asynchrony\ReceiveWaitTest.cs" />
     <Compile Include="BaseTest.cs" />
     <Compile Include="Concurrency\ExternalConcurrencyTest.cs" />
+    <Compile Include="EntryPoint\EntryPointThrowExceptionTest.cs" />
     <Compile Include="EntryPoint\EntryPointRandomChoiceTest.cs" />
     <Compile Include="EntryPoint\EntryPointEventSendingTest.cs" />
     <Compile Include="EntryPoint\EntryPointMachineExecutionTest.cs" />


### PR DESCRIPTION
The bug-finding runtime now catches and reports exceptions thrown in a test entry point method. Also added a unit test.