### PR TITLE
Revised SendAndExecute semantics 

### DIFF
--- a/Libraries/Core/Library/Machine.cs
+++ b/Libraries/Core/Library/Machine.cs
@@ -662,7 +662,8 @@ namespace Microsoft.PSharp
         /// Runs the event handler. The handler terminates if there
         /// is no next event to process or if the machine is halted.
         /// </summary>
-        internal async Task RunEventHandler()
+        /// <param name="returnEarly">Returns after handling just one event</param>
+        internal async Task RunEventHandler(bool returnEarly = false)
         {
             if (this.IsHalted)
             {
@@ -670,7 +671,6 @@ namespace Microsoft.PSharp
             }
 
             EventInfo nextEventInfo = null;
-
             while (!this.IsHalted && base.Runtime.IsRunning)
             {
                 var defaultHandling = false;
@@ -724,6 +724,12 @@ namespace Microsoft.PSharp
                 if (defaultHandling)
                 {
                     base.Runtime.NotifyDefaultHandlerFired();
+                }
+
+                // Return after handling the first event?
+                if (returnEarly)
+                {
+                    return;
                 }
             }
         }

--- a/Libraries/Core/Runtime/StateMachineRuntime.cs
+++ b/Libraries/Core/Runtime/StateMachineRuntime.cs
@@ -436,13 +436,16 @@ namespace Microsoft.PSharp
                     await machine.GotoStartState(e);
                 }
 
-                await machine.RunEventHandler();
+                await machine.RunEventHandler(true);
             }
             catch (Exception ex)
             {
                 base.IsRunning = false;
                 base.RaiseOnFailureEvent(ex);
+                return;
             }
+
+            RunMachineEventHandler(machine, null, false);
         }
 
         #endregion

--- a/Libraries/TestingServices/Runtime/BugFindingRuntime.cs
+++ b/Libraries/TestingServices/Runtime/BugFindingRuntime.cs
@@ -648,8 +648,13 @@ namespace Microsoft.PSharp.TestingServices
                         await machine.GotoStartState(e);
                     }
 
-                    await machine.RunEventHandler();
+                    await machine.RunEventHandler(executeSynchronously);
                     machine.IsInsideSynchronousCall = false;
+
+                    if (executeSynchronously)
+                    {
+                        await machine.RunEventHandler();
+                    }
 
                     this.Scheduler.NotifyTaskCompleted();
                 }

--- a/Tests/TestingServices.Tests.Unit/RuntimeInterface/SendAndExecuteTest2.cs
+++ b/Tests/TestingServices.Tests.Unit/RuntimeInterface/SendAndExecuteTest2.cs
@@ -1,0 +1,94 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="SendAndExecuteTest.cs">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// 
+//      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace Microsoft.PSharp.TestingServices.Tests.Unit
+{
+    public class SendAndExecuteTest2: BaseTest
+    {
+        class E1 : Event { }
+        class E2 : Event
+        {
+            public MachineId Id;
+
+            public E2(MachineId id)
+            {
+                this.Id = id;
+            }
+        }
+        class E3 : Event { }
+
+        class A : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            class Init : MachineState { }
+
+            async Task InitOnEntry()
+            {
+                MachineId b = this.CreateMachine(typeof(B), "B");
+                MachineId c = this.CreateMachine(typeof(C), new E2(b));
+                await this.Runtime.SendEventAndExecute(b, new E1());
+            }
+        }
+
+        class B : Machine
+        {
+            [Start]
+            [OnEventDoAction(typeof(E1), nameof(HandleEventE1))]
+            [OnEventDoAction(typeof(E3), nameof(HandleEventE3))]
+            class Init : MachineState { }
+
+            void HandleEventE1() { }
+
+            async Task HandleEventE3()
+            {
+                await this.Receive(typeof(E1));
+            }
+        }
+
+        class C : Machine
+        {
+            MachineId Target;
+
+            [Start]
+            [OnEntry(nameof(Run))]
+            class Init : MachineState { }
+
+            void Run()
+            {
+                this.Target = (this.ReceivedEvent as E2).Id;
+                this.Send(this.Target, new E3());
+                this.Send(this.Target, new E1());
+                this.Send(this.Target, new E1());
+                this.Send(this.Target, new E1());
+            }
+        }
+
+        [Fact]
+        public void TestSendAndExecute2WithReceive()
+        {
+            var config = Configuration.Create().WithNumberOfIterations(100);
+            var test = new Action<PSharpRuntime>((r) => {
+                r.CreateMachine(typeof(A));
+            });
+
+            base.AssertSucceeded(test);
+        }
+    }
+}

--- a/Tests/TestingServices.Tests.Unit/TestingServices.Tests.Unit.csproj
+++ b/Tests/TestingServices.Tests.Unit/TestingServices.Tests.Unit.csproj
@@ -105,7 +105,8 @@
     <Compile Include="Liveness\StateCaching\Liveness2Test.cs" />
     <Compile Include="Liveness\HotStateTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="RuntimeInterface\SendAndExecuteTest.cs" />
+    <Compile Include="RuntimeInterface\SendAndExecuteTest1.cs" />
+    <Compile Include="RuntimeInterface\SendAndExecuteTest2.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
Now it does sync execution only for the first event. I think this matches more closely with the user expectation. The machine doing SendAndExecute will not block (if the target is available) but it will still spawn a task to handle the rest of the events in the target machine. I don't think this is easy to optimize.