### PR TITLE
Extended unit tests to check for schedule replay

### DIFF
--- a/Libraries/Core/Configuration/Configuration.cs
+++ b/Libraries/Core/Configuration/Configuration.cs
@@ -126,12 +126,6 @@ namespace Microsoft.PSharp
         public string TestMethodName;
 
         /// <summary>
-        /// The schedule file to be replayed.
-        /// </summary>
-        [DataMember]
-        public string ScheduleFile;
-
-        /// <summary>
         /// Scheduling strategy to use with the P# tester.
         /// </summary>
         [DataMember]
@@ -304,6 +298,20 @@ namespace Microsoft.PSharp
 
         #endregion
 
+        #region trace replay options
+
+        /// <summary>
+        /// The schedule file to be replayed.
+        /// </summary>
+        internal string ScheduleFile;
+
+        /// <summary>
+        /// The schedule trace to be replayed.
+        /// </summary>
+        internal string ScheduleTrace;
+
+        #endregion
+
         #region data race detection options
 
         /// <summary>
@@ -395,26 +403,6 @@ namespace Microsoft.PSharp
         [DataMember]
         public bool KeepTemporaryFiles;
 
-        /// <summary>
-        /// If true, then the P# tester will print the trace
-        /// to a file, even if a bug is not found.
-        /// </summary>
-        [DataMember]
-        public bool PrintTrace;
-
-        /// <summary>
-        /// If true, then the P# tester will not output the
-        /// error trace to a file.
-        /// </summary>
-        [DataMember]
-        internal bool SuppressTrace;
-
-        /// <summary>
-        /// If true, then P# will throw any internal exceptions.
-        /// </summary>
-        [DataMember]
-        internal bool ThrowInternalExceptions;
-
         #endregion
 
         #region tooling options
@@ -422,8 +410,17 @@ namespace Microsoft.PSharp
         /// <summary>
         /// Enables colored console output.
         /// </summary>
-        [DataMember]
         internal bool EnableColoredConsoleOutput;
+
+        /// <summary>
+        /// If true, then P# will throw any internal exceptions.
+        /// </summary>
+        internal bool ThrowInternalExceptions;
+
+        /// <summary>
+        /// If true, then environment exit will be disabled.
+        /// </summary>
+        internal bool DisableEnvironmentExit;
 
         #endregion
 
@@ -456,7 +453,6 @@ namespace Microsoft.PSharp
 
             this.AssemblyToBeAnalyzed = "";
             this.TestMethodName = "";
-            this.ScheduleFile = "";
 
             this.SchedulingStrategy = SchedulingStrategy.Random;
             this.SchedulingIterations = 1;
@@ -486,6 +482,9 @@ namespace Microsoft.PSharp
 
             this.EnableMonitorsInProduction = false;
 
+            this.ScheduleFile = "";
+            this.ScheduleTrace = "";
+
             this.EnableDataRaceDetection = false;
 
             this.ReportCodeCoverage = false;
@@ -500,11 +499,10 @@ namespace Microsoft.PSharp
             this.EnableDebugging = false;
             this.EnableProfiling = false;
             this.KeepTemporaryFiles = false;
-            this.PrintTrace = false;
-            this.SuppressTrace = false;
-            this.ThrowInternalExceptions = false;
 
             this.EnableColoredConsoleOutput = false;
+            this.ThrowInternalExceptions = false;
+            this.DisableEnvironmentExit = true;
         }
 
         #endregion

--- a/Libraries/TestingServices/Engines/AbstractTestingEngine.cs
+++ b/Libraries/TestingServices/Engines/AbstractTestingEngine.cs
@@ -245,7 +245,16 @@ namespace Microsoft.PSharp.TestingServices
             }
             else if (this.Configuration.SchedulingStrategy == SchedulingStrategy.Replay)
             {
-                string[] scheduleDump = File.ReadAllLines(this.Configuration.ScheduleFile);
+                string[] scheduleDump;
+                if (this.Configuration.ScheduleTrace.Length > 0)
+                {
+                    scheduleDump = this.Configuration.ScheduleTrace.Split(new string[] { Environment.NewLine }, StringSplitOptions.None);
+                }
+                else
+                {
+                    scheduleDump = File.ReadAllLines(this.Configuration.ScheduleFile);
+                }
+
                 bool isFair = false;
 
                 foreach (var line in scheduleDump)
@@ -273,7 +282,6 @@ namespace Microsoft.PSharp.TestingServices
                         this.Configuration.TestMethodName =
                             line.Substring("--test-method:".Length);
                     }
-
                 }
 
                 ScheduleTrace schedule = new ScheduleTrace(scheduleDump);
@@ -337,12 +345,6 @@ namespace Microsoft.PSharp.TestingServices
             {
                 Error.ReportAndExit("Portfolio testing strategy in only " +
                     "available in parallel testing.");
-            }
-
-            if (this.Configuration.PrintTrace)
-            {
-                this.Configuration.SchedulingIterations = 1;
-                this.Configuration.PerformFullExploration = false;
             }
         }
 

--- a/Libraries/TestingServices/Engines/BugFindingEngine.cs
+++ b/Libraries/TestingServices/Engines/BugFindingEngine.cs
@@ -50,7 +50,7 @@ namespace Microsoft.PSharp.TestingServices
         /// <summary>
         /// The reproducable trace, if any.
         /// </summary>
-        private string ReproducableTrace;
+        internal string ReproducableTrace { get; private set; }
 
         #endregion
 
@@ -369,14 +369,16 @@ namespace Microsoft.PSharp.TestingServices
 
                 this.GatherIterationStatistics(runtime);
 
-                if (runtimeLogger != null && base.TestReport.NumOfFoundBugs > 0 &&
-                    !base.Configuration.PerformFullExploration && !base.Configuration.SuppressTrace)
+                if (base.TestReport.NumOfFoundBugs > 0)
                 {
-                    this.ConstructReproducableTrace(runtime, runtimeLogger);
-                }
-                else if (runtimeLogger != null && base.Configuration.PrintTrace)
-                {
-                    this.ConstructReproducableTrace(runtime, runtimeLogger);
+                    if (runtimeLogger != null)
+                    {
+                        this.ReadableTrace = runtimeLogger.ToString();
+                        this.ReadableTrace += this.TestReport.GetText(base.Configuration, "<StrategyLog>");
+                    }
+
+                    this.BugTrace = runtime.BugTrace;
+                    this.ConstructReproducableTrace(runtime);
                 }
             }
             finally
@@ -421,13 +423,8 @@ namespace Microsoft.PSharp.TestingServices
         /// Constructs a reproducable trace.
         /// </summary>
         /// <param name="runtime">BugFindingRuntime</param>
-        /// <param name="logger">InMemoryLogger</param>
-        private void ConstructReproducableTrace(BugFindingRuntime runtime, InMemoryLogger logger)
+        private void ConstructReproducableTrace(BugFindingRuntime runtime)
         {
-            this.ReadableTrace = logger.ToString();
-            this.ReadableTrace += this.TestReport.GetText(base.Configuration, "<StrategyLog>");
-            this.BugTrace = runtime.BugTrace;
-
             StringBuilder stringBuilder = new StringBuilder();
 
             if (this.Strategy.IsFair())

--- a/Libraries/TestingServices/Tracing/Schedules/ScheduleTrace.cs
+++ b/Libraries/TestingServices/Tracing/Schedules/ScheduleTrace.cs
@@ -73,7 +73,7 @@ namespace Microsoft.PSharp.TestingServices.Tracing.Schedule
             foreach (var step in traceDump)
             {
                 int intChoice;
-                if (step.StartsWith("--"))
+                if (step.StartsWith("--") || step.Length == 0)
                 {
                     continue;
                 }

--- a/Tests/SharedObjects.Tests.Unit/BaseTest.cs
+++ b/Tests/SharedObjects.Tests.Unit/BaseTest.cs
@@ -49,7 +49,7 @@ namespace Microsoft.PSharp.SharedObjects.Tests.Unit
             }
             catch (Exception ex)
             {
-                Assert.False(true, ex.Message);
+                Assert.False(true, ex.Message + "\n" + ex.StackTrace);
             }
             finally
             {
@@ -95,35 +95,50 @@ namespace Microsoft.PSharp.SharedObjects.Tests.Unit
 
             try
             {
-                var engine = BugFindingEngine.Create(configuration, test);
-                engine.SetLogger(logger);
-                engine.Run();
+                var bfEngine = BugFindingEngine.Create(configuration, test);
+                bfEngine.SetLogger(logger);
+                bfEngine.Run();
 
-                var numErrors = engine.TestReport.NumOfFoundBugs;
-                Assert.Equal(numExpectedErrors, numErrors);
+                CheckErrors(bfEngine, numExpectedErrors, expectedOutputs);
 
-                if (expectedOutputs.Count > 0)
+                if (!configuration.EnableCycleReplayingStrategy && !configuration.CacheProgramState)
                 {
-                    var bugReports = new HashSet<string>();
-                    foreach (var bugReport in engine.TestReport.BugReports)
-                    {
-                        var actual = this.RemoveNonDeterministicValuesFromReport(bugReport);
-                        bugReports.Add(actual);
-                    }
+                    var rEngine = ReplayEngine.Create(configuration, test, bfEngine.ReproducableTrace);
+                    rEngine.SetLogger(logger);
+                    rEngine.Run();
 
-                    foreach (var expected in expectedOutputs)
-                    {
-                        Assert.Contains(expected, bugReports);
-                    }
+                    Assert.True(rEngine.InternalError.Length == 0, rEngine.InternalError);
+                    CheckErrors(rEngine, numExpectedErrors, expectedOutputs);
                 }
             }
             catch (Exception ex)
             {
-                Assert.False(true, ex.Message);
+                Assert.False(true, ex.Message + "\n" + ex.StackTrace);
             }
             finally
             {
                 logger.Dispose();
+            }
+        }
+
+        private void CheckErrors(ITestingEngine engine, int numExpectedErrors, ISet<string> expectedOutputs)
+        {
+            var numErrors = engine.TestReport.NumOfFoundBugs;
+            Assert.Equal(numExpectedErrors, numErrors);
+
+            if (expectedOutputs.Count > 0)
+            {
+                var bugReports = new HashSet<string>();
+                foreach (var bugReport in engine.TestReport.BugReports)
+                {
+                    var actual = this.RemoveNonDeterministicValuesFromReport(bugReport);
+                    bugReports.Add(actual);
+                }
+
+                foreach (var expected in expectedOutputs)
+                {
+                    Assert.Contains(expected, bugReports);
+                }
             }
         }
 
@@ -146,25 +161,40 @@ namespace Microsoft.PSharp.SharedObjects.Tests.Unit
 
             try
             {
-                var engine = BugFindingEngine.Create(configuration, test);
-                engine.SetLogger(logger);
-                engine.Run();
+                var bfEngine = BugFindingEngine.Create(configuration, test);
+                bfEngine.SetLogger(logger);
+                bfEngine.Run();
 
-                var numErrors = engine.TestReport.NumOfFoundBugs;
-                Assert.Equal(1, numErrors);
+                CheckErrors(bfEngine, exceptionType);
 
-                var exception = this.RemoveNonDeterministicValuesFromReport(engine.TestReport.BugReports.First()).
-                    Split(new[] { '\r', '\n' }).FirstOrDefault();
-                Assert.Contains("'" + exceptionType.ToString() + "'", exception);
+                if (!configuration.EnableCycleReplayingStrategy && !configuration.CacheProgramState)
+                {
+                    var rEngine = ReplayEngine.Create(configuration, test, bfEngine.ReproducableTrace);
+                    rEngine.SetLogger(logger);
+                    rEngine.Run();
+
+                    Assert.True(rEngine.InternalError.Length == 0, rEngine.InternalError);
+                    CheckErrors(rEngine, exceptionType);
+                }
             }
             catch (Exception ex)
             {
-                Assert.False(true, ex.Message);
+                Assert.False(true, ex.Message + "\n" + ex.StackTrace);
             }
             finally
             {
                 logger.Dispose();
             }
+        }
+
+        private void CheckErrors(ITestingEngine engine, Type exceptionType)
+        {
+            var numErrors = engine.TestReport.NumOfFoundBugs;
+            Assert.Equal(1, numErrors);
+
+            var exception = this.RemoveNonDeterministicValuesFromReport(engine.TestReport.BugReports.First()).
+                Split(new[] { '\r', '\n' }).FirstOrDefault();
+            Assert.Contains("'" + exceptionType.ToString() + "'", exception);
         }
 
         #endregion
@@ -173,9 +203,7 @@ namespace Microsoft.PSharp.SharedObjects.Tests.Unit
 
         protected Configuration GetConfiguration()
         {
-            var configuration = Configuration.Create();
-            configuration.SuppressTrace = true;
-            return configuration;
+            return Configuration.Create();
         }
 
         private string RemoveNonDeterministicValuesFromReport(string report)

--- a/Tests/TestingServices.Tests.Integration/BaseTest.cs
+++ b/Tests/TestingServices.Tests.Integration/BaseTest.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
 using Microsoft.PSharp.IO;
+using Microsoft.PSharp.Utilities;
 
 using Xunit;
 
@@ -38,7 +39,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Integration
 
             try
             {
-                var engine = BugFindingEngine.Create(configuration, test);
+                BugFindingEngine engine = BugFindingEngine.Create(configuration, test);
                 engine.SetLogger(logger);
                 engine.Run();
 
@@ -47,7 +48,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Integration
             }
             catch (Exception ex)
             {
-                Assert.False(true, ex.Message);
+                Assert.False(true, ex.Message + "\n" + ex.StackTrace);
             }
             finally
             {
@@ -93,35 +94,50 @@ namespace Microsoft.PSharp.TestingServices.Tests.Integration
 
             try
             {
-                var engine = BugFindingEngine.Create(configuration, test);
-                engine.SetLogger(logger);
-                engine.Run();
+                var bfEngine = BugFindingEngine.Create(configuration, test);
+                bfEngine.SetLogger(logger);
+                bfEngine.Run();
 
-                var numErrors = engine.TestReport.NumOfFoundBugs;
-                Assert.Equal(numExpectedErrors, numErrors);
+                CheckErrors(bfEngine, numExpectedErrors, expectedOutputs);
 
-                if (expectedOutputs.Count > 0)
+                if (!configuration.EnableCycleReplayingStrategy && !configuration.CacheProgramState)
                 {
-                    var bugReports = new HashSet<string>();
-                    foreach (var bugReport in engine.TestReport.BugReports)
-                    {
-                        var actual = this.RemoveNonDeterministicValuesFromReport(bugReport);
-                        bugReports.Add(actual);
-                    }
+                    var rEngine = ReplayEngine.Create(configuration, test, bfEngine.ReproducableTrace);
+                    rEngine.SetLogger(logger);
+                    rEngine.Run();
 
-                    foreach (var expected in expectedOutputs)
-                    {
-                        Assert.Contains(expected, bugReports);
-                    }
+                    Assert.True(rEngine.InternalError.Length == 0, rEngine.InternalError);
+                    CheckErrors(rEngine, numExpectedErrors, expectedOutputs);
                 }
             }
             catch (Exception ex)
             {
-                Assert.False(true, ex.Message);
+                Assert.False(true, ex.Message + "\n" + ex.StackTrace);
             }
             finally
             {
                 logger.Dispose();
+            }
+        }
+
+        private void CheckErrors(ITestingEngine engine, int numExpectedErrors, ISet<string> expectedOutputs)
+        {
+            var numErrors = engine.TestReport.NumOfFoundBugs;
+            Assert.Equal(numExpectedErrors, numErrors);
+
+            if (expectedOutputs.Count > 0)
+            {
+                var bugReports = new HashSet<string>();
+                foreach (var bugReport in engine.TestReport.BugReports)
+                {
+                    var actual = this.RemoveNonDeterministicValuesFromReport(bugReport);
+                    bugReports.Add(actual);
+                }
+
+                foreach (var expected in expectedOutputs)
+                {
+                    Assert.Contains(expected, bugReports);
+                }
             }
         }
 
@@ -131,9 +147,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Integration
 
         protected Configuration GetConfiguration()
         {
-            var configuration = Configuration.Create();
-            configuration.SuppressTrace = true;
-            return configuration;
+            return Configuration.Create();
         }
 
         private string RemoveNonDeterministicValuesFromReport(string report)

--- a/Tests/TestingServices.Tests.Unit/EntryPoint/EntryPointThrowExceptionTest.cs
+++ b/Tests/TestingServices.Tests.Unit/EntryPoint/EntryPointThrowExceptionTest.cs
@@ -29,24 +29,22 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
         [Fact]
         public void TestEntryPointThrowException()
         {
-            PSharpRuntime stored_runtime = null;
-            int counter = 0;
-
             var test = new Action<PSharpRuntime>((r) => {
-                if (counter == 0)
-                {
-                    stored_runtime = r; 
-                    counter++;
-                }
-
-                // Fails in the second iteration, because logger is disposed.
-                stored_runtime.Logger.WriteLine("Starting iteration {0}", counter); 
-
                 MachineId m = r.CreateMachine(typeof(M));
+                throw new InvalidOperationException();
             });
 
-            var config = Configuration.Create().WithNumberOfIterations(2);
-            base.AssertFailedWithException(config, test, typeof(ObjectDisposedException));
+            base.AssertFailedWithException(test, typeof(InvalidOperationException));
+        }
+
+        [Fact]
+        public void TestEntryPointNoMachinesThrowException()
+        {
+            var test = new Action<PSharpRuntime>((r) => {
+                throw new InvalidOperationException();
+            });
+
+            base.AssertFailedWithException(test, typeof(InvalidOperationException));
         }
     }
 }

--- a/Tools/Testing/Replayer/ReplayingProcess.cs
+++ b/Tools/Testing/Replayer/ReplayingProcess.cs
@@ -68,8 +68,8 @@ namespace Microsoft.PSharp
         /// <param name="configuration">Configuration</param>
         private ReplayingProcess(Configuration configuration)
         {
-            configuration.SchedulingStrategy = SchedulingStrategy.Replay;
             configuration.EnableColoredConsoleOutput = true;
+            configuration.DisableEnvironmentExit = false;
             this.Configuration = configuration;
         }
 

--- a/Tools/Testing/Replayer/Utilities/ReplayerCommandLineOptions.cs
+++ b/Tools/Testing/Replayer/Utilities/ReplayerCommandLineOptions.cs
@@ -64,10 +64,6 @@ namespace Microsoft.PSharp.Utilities
             {
                 base.Configuration.AttachDebugger = true;
             }
-            else if (option.ToLower().Equals("/print-trace"))
-            {
-                base.Configuration.PrintTrace = true;
-            }
             else if (option.ToLower().Equals("/state-caching"))
             {
                 base.Configuration.CacheProgramState = true;

--- a/Tools/Testing/Tester/Scheduling/TestingProcessScheduler.cs
+++ b/Tools/Testing/Tester/Scheduling/TestingProcessScheduler.cs
@@ -100,7 +100,6 @@ namespace Microsoft.PSharp.TestingServices
             if (configuration.ParallelBugFindingTasks > 1)
             {
                 configuration.Verbose = 1;
-                configuration.PrintTrace = false;
                 configuration.EnableDataRaceDetection = false;
             }
 

--- a/Tools/Testing/Tester/Testing/TestingProcess.cs
+++ b/Tools/Testing/Tester/Testing/TestingProcess.cs
@@ -128,8 +128,7 @@ namespace Microsoft.PSharp.TestingServices
                     Output.WriteLine($"... Task {this.Configuration.TestingProcessId} found a bug.");
                 }
 
-                if (this.TestingEngine.TestReport.NumOfFoundBugs > 0 ||
-                    this.Configuration.PrintTrace)
+                if (this.TestingEngine.TestReport.NumOfFoundBugs > 0)
                 {
                     this.EmitTraces();
                 }

--- a/Tools/Testing/Tester/Utilities/TesterCommandLineOptions.cs
+++ b/Tools/Testing/Tester/Utilities/TesterCommandLineOptions.cs
@@ -307,10 +307,6 @@ namespace Microsoft.PSharp.Utilities
 
                 base.Configuration.SafetyPrefixBound = i;
             }
-            else if (option.ToLower().Equals("/print-trace"))
-            {
-                base.Configuration.PrintTrace = true;
-            }
             else if (option.ToLower().StartsWith("/liveness-temperature-threshold:") && option.Length > 32)
             {
                 int i = 0;


### PR DESCRIPTION
All unit tests for bug-finding that contain an injected bug, will now try to replay the bug and assert that the replayer can indeed successfully replay this bug. The only exception is state-caching/cycle-replay unit tests which have this additional assertions disabled (until we fix #89).

This should give us confidence that changes we make do not break the schedule replay engine of P#.