### PR TITLE
Fix for AmbiguousMatchException in event handler invocation

### DIFF
--- a/Libraries/Core/Library/Machine.cs
+++ b/Libraries/Core/Library/Machine.cs
@@ -1563,9 +1563,10 @@ namespace Microsoft.PSharp
 
             do
             {
-                method = machineType.GetMethod(actionName, BindingFlags.Public |
-                    BindingFlags.NonPublic | BindingFlags.Instance |
-                    BindingFlags.FlattenHierarchy);
+                method = machineType.GetMethod(actionName,
+                    BindingFlags.Public | BindingFlags.NonPublic |
+                    BindingFlags.Instance | BindingFlags.FlattenHierarchy,
+                    Type.DefaultBinder, new Type[0], null);
                 machineType = machineType.BaseType;
             }
             while (method == null && machineType != typeof(Machine));

--- a/Libraries/Core/Library/Monitor.cs
+++ b/Libraries/Core/Library/Monitor.cs
@@ -757,9 +757,10 @@ namespace Microsoft.PSharp
 
             do
             {
-                method = monitorType.GetMethod(actionName, BindingFlags.Public |
-                    BindingFlags.NonPublic | BindingFlags.Instance |
-                    BindingFlags.FlattenHierarchy);
+                method = monitorType.GetMethod(actionName,
+                    BindingFlags.Public | BindingFlags.NonPublic |
+                    BindingFlags.Instance | BindingFlags.FlattenHierarchy,
+                    Type.DefaultBinder, new Type[0], null);
                 monitorType = monitorType.BaseType;
             }
             while (method == null && monitorType != typeof(Monitor));

--- a/Tests/TestingServices.Tests.Unit/Machines/Declarations/AmbiguousEventHandlerTest.cs
+++ b/Tests/TestingServices.Tests.Unit/Machines/Declarations/AmbiguousEventHandlerTest.cs
@@ -1,0 +1,77 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="AmbiguousEventHandlerTest.cs">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// 
+//      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+
+using Xunit;
+
+namespace Microsoft.PSharp.TestingServices.Tests.Unit
+{
+    public class AmbiguousEventHandlerTest : BaseTest
+    {
+        class E : Event { }
+
+        class Program : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            [OnEventDoAction(typeof(E), nameof(HandleE))]
+            public class Init : MachineState { }
+
+            void InitOnEntry()
+            {
+                this.Send(this.Id, new E());
+            }
+
+            void HandleE() { }
+            void HandleE(int k) { }
+        }
+
+        class Safety : Monitor
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            [OnEventDoAction(typeof(E), nameof(HandleE))]
+            public class Init : MonitorState { }
+
+            void InitOnEntry()
+            {
+                this.Raise(new E());
+            }
+
+            void HandleE() { }
+            void HandleE(int k) { }
+        }
+
+        [Fact]
+        public void TestAmbiguousMachineEventHandler()
+        {
+            var test = new Action<PSharpRuntime>((r) => {
+                r.CreateMachine(typeof(Program));
+            });
+
+            base.AssertSucceeded(test);
+        }
+
+        [Fact]
+        public void TestAmbiguousMonitorEventHandler()
+        {
+            var test = new Action<PSharpRuntime>((r) => {
+                r.RegisterMonitor(typeof(Safety));
+            });
+
+            base.AssertSucceeded(test);
+        }
+    }
+}

--- a/Tests/TestingServices.Tests.Unit/TestingServices.Tests.Unit.csproj
+++ b/Tests/TestingServices.Tests.Unit/TestingServices.Tests.Unit.csproj
@@ -67,6 +67,7 @@
     <Compile Include="EntryPoint\EntryPointEventSendingTest.cs" />
     <Compile Include="EntryPoint\EntryPointMachineExecutionTest.cs" />
     <Compile Include="EntryPoint\EntryPointMachineCreationTest.cs" />
+    <Compile Include="Machines\Declarations\AmbiguousEventHandlerTest.cs" />
     <Compile Include="Machines\Statements\MethodCallTest.cs" />
     <Compile Include="Machines\Declarations\GroupStateTest.cs" />
     <Compile Include="EventHandling\MaxInstances1FailTest.cs" />


### PR DESCRIPTION
`Machine` and `Monitor` could throw an `AmbiguousMatchException` when using reflection to get the event handler to invoke if there were multiple event handler actions with the same name. This fixes this issue.

Also added two unit tests for this.