### PR TITLE
Refactored scheduling strategies to use the ISchedulable interface

### DIFF
--- a/Libraries/Core/Core.csproj
+++ b/Libraries/Core/Core.csproj
@@ -108,6 +108,8 @@
     <Compile Include="Runtime\Exceptions\RuntimeException.cs" />
     <Compile Include="Runtime\PSharpRuntime.cs" />
     <Compile Include="Runtime\StateMachineRuntime.cs" />
+    <Compile Include="Scheduling\ISchedulable.cs" />
+    <Compile Include="Scheduling\OperationType.cs" />
     <Compile Include="Utilities\ErrorReporter.cs" />
     <Compile Include="Utilities\Profiler.cs" />
     <Compile Include="Utilities\RandomNumberGenerators\DefaultRandomNumberGenerator.cs" />

--- a/Libraries/Core/Library/MachineInfo.cs
+++ b/Libraries/Core/Library/MachineInfo.cs
@@ -12,13 +12,15 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using Microsoft.PSharp.Scheduling;
+
 namespace Microsoft.PSharp
 {
     /// <summary>
     /// Stores machine-related information, which can used
     /// for scheduling and testing.
     /// </summary>
-    public sealed class MachineInfo
+    internal sealed class MachineInfo : ISchedulable
     {
         #region fields
 
@@ -48,7 +50,7 @@ namespace Microsoft.PSharp
         #region properties
 
         /// <summary>
-        /// Task id of the machine.
+        /// Unique id of the machine.
         /// </summary>
         public ulong Id => MachineId.Value;
 
@@ -86,6 +88,21 @@ namespace Microsoft.PSharp
         /// Is machine completed.
         /// </summary>
         public bool IsCompleted { get; internal set; }
+
+        /// <summary>
+        /// Type of the next operation of the machine.
+        /// </summary>
+        public OperationType NextOperationType { get; internal set; }
+
+        /// <summary>
+        /// Target id of the next operation of the machine.
+        /// </summary>
+        public int NextTargetId { get; internal set; }
+
+        /// <summary>
+        /// Monotonically increasing operation count.
+        /// </summary>
+        public int OperationCount { get; internal set; }
 
         #endregion
 
@@ -171,7 +188,7 @@ namespace Microsoft.PSharp
         }
 
         /// <summary>
-        /// Returns a string that represents the current machine id.
+        /// Returns a string that represents this machine.
         /// </summary>
         /// <returns>string</returns>
         public override string ToString()

--- a/Libraries/Core/Scheduling/ISchedulable.cs
+++ b/Libraries/Core/Scheduling/ISchedulable.cs
@@ -1,0 +1,71 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ISchedulable.cs">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// 
+//      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace Microsoft.PSharp.Scheduling
+{
+    /// <summary>
+    /// Interface of an entity that can be scheduled.
+    /// </summary>
+    public interface ISchedulable
+    {
+        #region properties
+
+        /// <summary>
+        /// Unique id of the entity.
+        /// </summary>
+        ulong Id { get; }
+
+        /// <summary>
+        /// Name of the entity.
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
+        /// Is the entity enabled.
+        /// </summary>
+        bool IsEnabled { get; }
+
+        /// <summary>
+        /// Is the entity active.
+        /// </summary>
+        bool IsActive { get; }
+
+        /// <summary>
+        /// Has the entity started.
+        /// </summary>
+        bool HasStarted { get; }
+
+        /// <summary>
+        /// Is the entity completed.
+        /// </summary>
+        bool IsCompleted { get; }
+
+        /// <summary>
+        /// Type of the next operation of the entity.
+        /// </summary>
+        OperationType NextOperationType { get; }
+
+        /// <summary>
+        /// Target id of the next operation of the entity.
+        /// </summary>
+        int NextTargetId { get; }
+
+        /// <summary>
+        /// Monotonically increasing operation count.
+        /// </summary>
+        int OperationCount { get; }
+
+        #endregion
+    }
+}

--- a/Libraries/Core/Scheduling/OperationType.cs
+++ b/Libraries/Core/Scheduling/OperationType.cs
@@ -1,0 +1,43 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="OperationType.cs">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// 
+//      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace Microsoft.PSharp.Scheduling
+{
+    /// <summary>
+    /// Operation type used during scheduling.
+    /// </summary>
+    public enum OperationType
+    {
+        /// <summary>
+        /// The 'start' operation type.
+        /// </summary>
+        Start = 0,
+        /// <summary>
+        /// The 'create' operation type.
+        /// </summary>
+        Create,
+        /// <summary>
+        /// The 'send' operation type.
+        /// </summary>
+        Send,
+        /// <summary>
+        /// The 'receive' operation type.
+        /// </summary>
+        Receive,
+        /// <summary>
+        /// The 'halt' operation type.
+        /// </summary>
+        Halt
+    }
+}

--- a/Libraries/TestingServices/Engines/BugFindingEngine.cs
+++ b/Libraries/TestingServices/Engines/BugFindingEngine.cs
@@ -247,12 +247,10 @@ namespace Microsoft.PSharp.TestingServices
                             break;
                         }
 
-                        if (base.Strategy.HasFinished())
+                        if (!base.Strategy.PrepareForNextIteration())
                         {
                             break;
                         }
-
-                        base.Strategy.ConfigureNextIteration();
 
                         // Increases iterations if there is a specified timeout
                         // and the default iteration given.

--- a/Libraries/TestingServices/Engines/BugFindingEngine.cs
+++ b/Libraries/TestingServices/Engines/BugFindingEngine.cs
@@ -456,8 +456,7 @@ namespace Microsoft.PSharp.TestingServices
                 ScheduleStep step = runtime.ScheduleTrace[idx];
                 if (step.Type == ScheduleStepType.SchedulingChoice)
                 {
-                    stringBuilder.Append($"{step.ScheduledMachineId.Type}" +
-                        $"({step.ScheduledMachineId.Value})");
+                    stringBuilder.Append($"({step.ScheduledMachineId})");
                 }
                 else if (step.BooleanChoice != null)
                 {

--- a/Libraries/TestingServices/Liveness/LivenessChecker.cs
+++ b/Libraries/TestingServices/Liveness/LivenessChecker.cs
@@ -657,15 +657,6 @@ namespace Microsoft.PSharp.TestingServices.Liveness
         }
 
         /// <summary>
-        /// Returns true if the scheduling has finished.
-        /// </summary>
-        /// <returns>Boolean</returns>
-        bool ISchedulingStrategy.HasFinished()
-        {
-            return false;
-        }
-
-        /// <summary>
         /// Checks if this a fair scheduling strategy.
         /// </summary>
         /// <returns>Boolean</returns>
@@ -675,11 +666,13 @@ namespace Microsoft.PSharp.TestingServices.Liveness
         }
 
         /// <summary>
-        /// Configures the next scheduling iteration.
+        /// Prepares the next scheduling iteration.
         /// </summary>
-        void ISchedulingStrategy.ConfigureNextIteration()
+        /// <returns>False if all schedules have been explored</returns>
+        bool ISchedulingStrategy.PrepareForNextIteration()
         {
             this.CurrentCycleIndex = 0;
+            return true;
         }
 
         /// <summary>

--- a/Libraries/TestingServices/Liveness/LivenessChecker.cs
+++ b/Libraries/TestingServices/Liveness/LivenessChecker.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.PSharp.IO;
+using Microsoft.PSharp.Scheduling;
 using Microsoft.PSharp.TestingServices.Scheduling;
 using Microsoft.PSharp.TestingServices.StateCaching;
 using Microsoft.PSharp.TestingServices.Tracing.Schedule;
@@ -395,8 +396,8 @@ namespace Microsoft.PSharp.TestingServices.Liveness
         {
             var result = false;
 
-            var enabledMachines = new HashSet<MachineId>();
-            var scheduledMachines = new HashSet<MachineId>();
+            var enabledMachines = new HashSet<ulong>();
+            var scheduledMachines = new HashSet<ulong>();
 
             var schedulingChoiceSteps= cycle.Where(
                 val => val.Item1.Type == ScheduleStepType.SchedulingChoice);
@@ -407,7 +408,7 @@ namespace Microsoft.PSharp.TestingServices.Liveness
 
             foreach(var state in cycle)
             {
-                enabledMachines.UnionWith(state.Item2.EnabledMachines);
+                enabledMachines.UnionWith(state.Item2.EnabledMachineIds);
             }
 
             foreach (var m in enabledMachines)
@@ -507,24 +508,19 @@ namespace Microsoft.PSharp.TestingServices.Liveness
         #region scheduling strategy methods
 
         /// <summary>
-        /// Returns the next machine to schedule.
+        /// Returns the next choice to schedule.
         /// </summary>
         /// <param name="next">Next</param>
         /// <param name="choices">Choices</param>
         /// <param name="current">Curent</param>
         /// <returns>Boolean</returns>
-        bool ISchedulingStrategy.TryGetNext(out MachineInfo next, IEnumerable<MachineInfo> choices, MachineInfo current)
+        bool ISchedulingStrategy.TryGetNext(out ISchedulable next, List<ISchedulable> choices, ISchedulable current)
         {
-            var availableMachines = choices.Where(
-                m => m.IsEnabled && !m.IsWaitingToReceive).ToList();
-            if (availableMachines.Count == 0)
+            var enabledChoices = choices.Where(choice => choice.IsEnabled).ToList();
+            if (enabledChoices.Count == 0)
             {
-                availableMachines = choices.Where(m => m.IsWaitingToReceive).ToList();
-                if (availableMachines.Count == 0)
-                {
-                    next = null;
-                    return false;
-                }
+                next = null;
+                return false;
             }
 
             if (this.Runtime.Configuration.EnableCycleReplayingStrategy)
@@ -539,13 +535,10 @@ namespace Microsoft.PSharp.TestingServices.Liveness
 
                 Debug.WriteLine($"<LivenessDebug> Replaying '{nextStep.Index}' '{nextStep.ScheduledMachineId}'.");
 
-                next = availableMachines.FirstOrDefault(m => m.MachineId.Type.Equals(
-                    nextStep.ScheduledMachineId.Type) &&
-                    m.MachineId.Value == nextStep.ScheduledMachineId.Value);
+                next = enabledChoices.FirstOrDefault(choice => choice.Id == nextStep.ScheduledMachineId);
                 if (next == null)
                 {
-                    Debug.WriteLine("<LivenessDebug> Trace is not reproducible: cannot detect machine with type " +
-                        $"'{nextStep.ScheduledMachineId.Type}' and id '{nextStep.ScheduledMachineId.Value}'.");
+                    Debug.WriteLine($"<LivenessDebug> Trace is not reproducible: cannot detect machine with id '{nextStep.ScheduledMachineId}'.");
                     this.EscapeCycle();
                     return this.SchedulingStrategy.TryGetNext(out next, choices, current);
                 }
@@ -558,8 +551,8 @@ namespace Microsoft.PSharp.TestingServices.Liveness
             }
             else
             {
-                int idx = this.Random.Next(availableMachines.Count);
-                next = availableMachines[idx];
+                int idx = this.Random.Next(enabledChoices.Count);
+                next = enabledChoices[idx];
             }
             
             return true;

--- a/Libraries/TestingServices/Runtime/AsynchronousTaskScheduler.cs
+++ b/Libraries/TestingServices/Runtime/AsynchronousTaskScheduler.cs
@@ -79,9 +79,9 @@ namespace Microsoft.PSharp.TestingServices
                 this.TaskMap.TryRemove(Runtime.Scheduler.ScheduledMachine.TaskId, out machine);
                 this.TaskMap.TryAdd(task.Id, machine);
 
-                // Notify the bug-finding scheduler to change the task previously
-                // associated with the machine to the new task.
-                this.Runtime.Scheduler.NotifyScheduledMachineTaskChanged(task.Id);
+                // Change the task previously associated with the machine to the new task.
+                machine.Info.TaskId = task.Id;
+                IO.Debug.WriteLine($"<ScheduleDebug> '{machine.Id}' changed task '{machine.Info.TaskId}' to {task.Id}.");
 
                 // Execute the new task.
                 this.Execute(task);

--- a/Libraries/TestingServices/SchedulingStrategies/DFS/DFSStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/DFS/DFSStrategy.cs
@@ -264,15 +264,6 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         }
 
         /// <summary>
-        /// Returns true if the scheduling has finished.
-        /// </summary>
-        /// <returns>Boolean</returns>
-        public bool HasFinished()
-        {
-            return this.ScheduleStack.All(scs => scs.All(val => val.IsDone));
-        }
-
-        /// <summary>
         /// Checks if this a fair scheduling strategy.
         /// </summary>
         /// <returns>Boolean</returns>
@@ -282,10 +273,16 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         }
 
         /// <summary>
-        /// Configures the next scheduling iteration.
+        /// Prepares the next scheduling iteration.
         /// </summary>
-        public void ConfigureNextIteration()
+        /// <returns>False if all schedules have been explored</returns>
+        public virtual bool PrepareForNextIteration()
         {
+            if (this.ScheduleStack.All(scs => scs.All(val => val.IsDone)))
+            {
+                return false;
+            }
+
             //this.PrintSchedule();
 
             this.ExploredSteps = 0;
@@ -355,6 +352,8 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
                     previousChoice.IsDone = false;
                 }
             }
+
+            return true;
         }
 
         /// <summary>

--- a/Libraries/TestingServices/SchedulingStrategies/DFS/IterativeDeepeningDFSStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/DFS/IterativeDeepeningDFSStrategy.cs
@@ -20,7 +20,7 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
     /// Class representing a depth-first search scheduling strategy
     /// that incorporates iterative deepening.
     /// </summary>
-    public class IterativeDeepeningDFSStrategy : DFSStrategy, ISchedulingStrategy
+    public sealed class IterativeDeepeningDFSStrategy : DFSStrategy, ISchedulingStrategy
     {
         #region fields
 
@@ -61,29 +61,24 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         }
 
         /// <summary>
-        /// Returns true if the scheduling has finished.
+        /// Prepares the next scheduling iteration.
         /// </summary>
-        /// <returns>Boolean</returns>
-        public new bool HasFinished()
+        /// <returns>False if all schedules have been explored</returns>
+        public override bool PrepareForNextIteration()
         {
-            return base.HasFinished() && this.CurrentDepth == this.MaxDepth;
-        }
-
-        /// <summary>
-        /// Configures the next scheduling iteration.
-        /// </summary>
-        public new void ConfigureNextIteration()
-        {
-            if (!base.HasFinished())
-            {
-                base.ConfigureNextIteration();
-            }
-            else
+            bool doNext = base.PrepareForNextIteration();
+            if (!doNext)
             {
                 base.Reset();
                 this.CurrentDepth++;
-                Debug.WriteLine("<IterativeDeepeningDFSLog> Depth bound increased to {0}", this.CurrentDepth);
+                if (this.CurrentDepth <= this.MaxDepth)
+                {
+                    Debug.WriteLine($"<IterativeDeepeningDFSLog> Depth bound increased to {this.CurrentDepth} (max is {this.MaxDepth}).");
+                    doNext = true;
+                }
             }
+
+            return doNext;
         }
 
         /// <summary>
@@ -92,7 +87,7 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         /// <returns>String</returns>
         public new string GetDescription()
         {
-            return "DFS with iterative deepening";
+            return $"DFS with iterative deepening (max depth is {this.MaxDepth})";
         }
 
         #endregion

--- a/Libraries/TestingServices/SchedulingStrategies/DelayBounded/DelayBoundingStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/DelayBounded/DelayBoundingStrategy.cs
@@ -184,15 +184,6 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         }
 
         /// <summary>
-        /// Returns true if the scheduling has finished.
-        /// </summary>
-        /// <returns>Boolean</returns>
-        public bool HasFinished()
-        {
-            return false;
-        }
-
-        /// <summary>
         /// Checks if this a fair scheduling strategy.
         /// </summary>
         /// <returns>Boolean</returns>
@@ -202,9 +193,10 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         }
 
         /// <summary>
-        /// Configures the next scheduling iteration.
+        /// Prepares the next scheduling iteration.
         /// </summary>
-        public abstract void ConfigureNextIteration();
+        /// <returns>False if all schedules have been explored</returns>
+        public abstract bool PrepareForNextIteration();
 
         /// <summary>
         /// Resets the scheduling strategy.

--- a/Libraries/TestingServices/SchedulingStrategies/DelayBounded/DelayBoundingStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/DelayBounded/DelayBoundingStrategy.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.PSharp.IO;
+using Microsoft.PSharp.Scheduling;
 using Microsoft.PSharp.Utilities;
 
 namespace Microsoft.PSharp.TestingServices.Scheduling
@@ -84,44 +85,37 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         }
 
         /// <summary>
-        /// Returns the next machine to schedule.
+        /// Returns the next choice to schedule.
         /// </summary>
         /// <param name="next">Next</param>
         /// <param name="choices">Choices</param>
         /// <param name="current">Curent</param>
         /// <returns>Boolean</returns>
-        public virtual bool TryGetNext(out MachineInfo next, IEnumerable<MachineInfo> choices, MachineInfo current)
+        public virtual bool TryGetNext(out ISchedulable next, List<ISchedulable> choices, ISchedulable current)
         {
-            var machines = choices.OrderBy(mi => mi.MachineId.Value).ToList();
-
-            var currentMachineIdx = machines.IndexOf(current);
-            var orderedMachines = machines.GetRange(currentMachineIdx, machines.Count - currentMachineIdx);
+            var currentMachineIdx = choices.IndexOf(current);
+            var orderedMachines = choices.GetRange(currentMachineIdx, choices.Count - currentMachineIdx);
             if (currentMachineIdx != 0)
             {
-                orderedMachines.AddRange(machines.GetRange(0, currentMachineIdx));
+                orderedMachines.AddRange(choices.GetRange(0, currentMachineIdx));
             }
 
-            var availableMachines = orderedMachines.Where(
-                mi => mi.IsEnabled && !mi.IsWaitingToReceive).ToList();
-            if (availableMachines.Count == 0)
+            var enabledChoices = orderedMachines.Where(choice => choice.IsEnabled).ToList();
+            if (enabledChoices.Count == 0)
             {
-                availableMachines = choices.Where(m => m.IsWaitingToReceive).ToList();
-                if (availableMachines.Count == 0)
-                {
-                    next = null;
-                    return false;
-                }
+                next = null;
+                return false;
             }
 
             int idx = 0;
             while (this.RemainingDelays.Count > 0 && this.ExploredSteps == this.RemainingDelays[0])
             {
-                idx = (idx + 1) % availableMachines.Count;
+                idx = (idx + 1) % enabledChoices.Count;
                 this.RemainingDelays.RemoveAt(0);
                 Debug.WriteLine("<DelayLog> Inserted delay, '{0}' remaining.", this.RemainingDelays.Count);
             }
 
-            next = availableMachines[idx];
+            next = enabledChoices[idx];
 
             this.ExploredSteps++;
 

--- a/Libraries/TestingServices/SchedulingStrategies/DelayBounded/ExhaustiveDelayBoundingStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/DelayBounded/ExhaustiveDelayBoundingStrategy.cs
@@ -21,7 +21,7 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
     /// <summary>
     /// Class representing an exhaustive delay-bounding scheduling strategy.
     /// </summary>
-    public class ExhaustiveDelayBoundingStrategy : DelayBoundingStrategy, ISchedulingStrategy
+    public sealed class ExhaustiveDelayBoundingStrategy : DelayBoundingStrategy, ISchedulingStrategy
     {
         #region fields
 
@@ -46,13 +46,14 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         }
 
         /// <summary>
-        /// Configures the next scheduling iteration.
+        /// Prepares the next scheduling iteration.
         /// </summary>
-        public override void ConfigureNextIteration()
+        /// <returns>False if all schedules have been explored</returns>
+        public override bool PrepareForNextIteration()
         {
             base.MaxExploredSteps = Math.Max(base.MaxExploredSteps, base.ExploredSteps);
             base.ExploredSteps = 0;
-            
+
             var bound = Math.Min(
                 (base.IsFair() ? base.Configuration.MaxFairSchedulingSteps :
                 base.Configuration.MaxUnfairSchedulingSteps),
@@ -71,6 +72,8 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
             base.RemainingDelays.Clear();
             base.RemainingDelays.AddRange(this.DelaysCache);
             base.RemainingDelays.Sort();
+
+            return true;
         }
 
         /// <summary>

--- a/Libraries/TestingServices/SchedulingStrategies/DelayBounded/RandomDelayBoundingStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/DelayBounded/RandomDelayBoundingStrategy.cs
@@ -20,7 +20,7 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
     /// <summary>
     /// Class representing a random delay-bounding scheduling strategy.
     /// </summary>
-    public class RandomDelayBoundingStrategy : DelayBoundingStrategy, ISchedulingStrategy
+    public sealed class RandomDelayBoundingStrategy : DelayBoundingStrategy, ISchedulingStrategy
     {
         #region fields
 
@@ -45,9 +45,10 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         }
 
         /// <summary>
-        /// Configures the next scheduling iteration.
+        /// Prepares the next scheduling iteration.
         /// </summary>
-        public override void ConfigureNextIteration()
+        /// <returns>False if all schedules have been explored</returns>
+        public override bool PrepareForNextIteration()
         {
             base.MaxExploredSteps = Math.Max(base.MaxExploredSteps, base.ExploredSteps);
             base.ExploredSteps = 0;
@@ -62,6 +63,8 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
 
             this.CurrentIterationDelays.Clear();
             this.CurrentIterationDelays.AddRange(base.RemainingDelays);
+
+            return true;
         }
 
         /// <summary>

--- a/Libraries/TestingServices/SchedulingStrategies/Fuzzing/ProbabilisticRandomStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/Fuzzing/ProbabilisticRandomStrategy.cs
@@ -25,7 +25,7 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
     /// Class representing a probabilistic random-walk
     /// scheduling strategy.
     /// </summary>
-    public class ProbabilisticRandomStrategy : ISchedulingStrategy
+    public sealed class ProbabilisticRandomStrategy : ISchedulingStrategy
     {
         #region fields
 
@@ -182,28 +182,21 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         }
 
         /// <summary>
-        /// Returns true if the scheduling has finished.
-        /// </summary>
-        /// <returns>Boolean</returns>
-        public bool HasFinished()
-        {
-            return false;
-        }
-        
-        /// <summary>
-        /// Configures the next scheduling iteration.
-        /// </summary>
-        public void ConfigureNextIteration()
-        {
-            this.ExploredSteps = 0;
-        }
-
-        /// <summary>
         /// Checks if this a fair scheduling strategy.
         /// </summary>
         /// <returns>Boolean</returns>
         public bool IsFair()
         {
+            return true;
+        }
+
+        /// <summary>
+        /// Prepares the next scheduling iteration.
+        /// </summary>
+        /// <returns>False if all schedules have been explored</returns>
+        public bool PrepareForNextIteration()
+        {
+            this.ExploredSteps = 0;
             return true;
         }
 

--- a/Libraries/TestingServices/SchedulingStrategies/Fuzzing/ProbabilisticRandomStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/Fuzzing/ProbabilisticRandomStrategy.cs
@@ -16,6 +16,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+using Microsoft.PSharp.Scheduling;
 using Microsoft.PSharp.Utilities;
 
 namespace Microsoft.PSharp.TestingServices.Scheduling
@@ -89,40 +90,34 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         }
 
         /// <summary>
-        /// Returns the next machine to schedule.
+        /// Returns the next choice to schedule.
         /// </summary>
         /// <param name="next">Next</param>
         /// <param name="choices">Choices</param>
         /// <param name="current">Curent</param>
         /// <returns>Boolean</returns>
-        public bool TryGetNext(out MachineInfo next, IEnumerable<MachineInfo> choices, MachineInfo current)
+        public bool TryGetNext(out ISchedulable next, List<ISchedulable> choices, ISchedulable current)
         {
-            var availableMachines = choices.Where(
-                m => m.IsEnabled && !m.IsWaitingToReceive).ToList();
-            if (availableMachines.Count == 0)
+            var enabledChoices = choices.Where(choice => choice.IsEnabled).ToList();
+            if (enabledChoices.Count == 0)
             {
-                availableMachines = choices.Where(m => m.IsWaitingToReceive).ToList();
-                if (availableMachines.Count == 0)
-                {
-                    next = null;
-                    return false;
-                }
+                next = null;
+                return false;
             }
 
             this.ExploredSteps++;
 
-            if (availableMachines.Count > 1)
+            if (enabledChoices.Count > 1)
             {
-                if (!this.ShouldCurrentMachineChange() &&
-                    current.IsEnabled && !current.IsWaitingToReceive)
+                if (!this.ShouldCurrentMachineChange() && current.IsEnabled)
                 {
                     next = current;
                     return true;
                 }
             }
 
-            int idx = this.Random.Next(availableMachines.Count);
-            next = availableMachines[idx];
+            int idx = this.Random.Next(enabledChoices.Count);
+            next = enabledChoices[idx];
             
             return true;
         }

--- a/Libraries/TestingServices/SchedulingStrategies/Fuzzing/RandomStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/Fuzzing/RandomStrategy.cs
@@ -24,7 +24,7 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
     /// <summary>
     /// Class representing a random-walk scheduling strategy.
     /// </summary>
-    public class RandomStrategy : ISchedulingStrategy
+    public sealed class RandomStrategy : ISchedulingStrategy
     {
         #region fields
 
@@ -148,28 +148,21 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         }
 
         /// <summary>
-        /// Returns true if the scheduling has finished.
-        /// </summary>
-        /// <returns>Boolean</returns>
-        public bool HasFinished()
-        {
-            return false;
-        }
-        
-        /// <summary>
-        /// Configures the next scheduling iteration.
-        /// </summary>
-        public void ConfigureNextIteration()
-        {
-            this.ExploredSteps = 0;
-        }
-
-        /// <summary>
         /// Checks if this a fair scheduling strategy.
         /// </summary>
         /// <returns>Boolean</returns>
         public bool IsFair()
         {
+            return true;
+        }
+
+        /// <summary>
+        /// Prepares the next scheduling iteration.
+        /// </summary>
+        /// <returns>False if all schedules have been explored</returns>
+        public bool PrepareForNextIteration()
+        {
+            this.ExploredSteps = 0;
             return true;
         }
 

--- a/Libraries/TestingServices/SchedulingStrategies/Fuzzing/RandomStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/Fuzzing/RandomStrategy.cs
@@ -16,6 +16,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+using Microsoft.PSharp.Scheduling;
 using Microsoft.PSharp.Utilities;
 
 namespace Microsoft.PSharp.TestingServices.Scheduling
@@ -64,28 +65,23 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         }
 
         /// <summary>
-        /// Returns the next machine to schedule.
+        /// Returns the next choice to schedule.
         /// </summary>
         /// <param name="next">Next</param>
         /// <param name="choices">Choices</param>
         /// <param name="current">Curent</param>
         /// <returns>Boolean</returns>
-        public bool TryGetNext(out MachineInfo next, IEnumerable<MachineInfo> choices, MachineInfo current)
+        public bool TryGetNext(out ISchedulable next, List<ISchedulable> choices, ISchedulable current)
         {
-            var availableMachines = choices.Where(
-                m => m.IsEnabled && !m.IsWaitingToReceive).ToList();
-            if (availableMachines.Count == 0)
+            var enabledChoices = choices.Where(choice => choice.IsEnabled).ToList();
+            if (enabledChoices.Count == 0)
             {
-                availableMachines = choices.Where(m => m.IsWaitingToReceive).ToList();
-                if (availableMachines.Count == 0)
-                {
-                    next = null;
-                    return false;
-                }
+                next = null;
+                return false;
             }
 
-            int idx = this.Random.Next(availableMachines.Count);
-            next = availableMachines[idx];
+            int idx = this.Random.Next(enabledChoices.Count);
+            next = enabledChoices[idx];
 
             this.ExploredSteps++;
 

--- a/Libraries/TestingServices/SchedulingStrategies/ISchedulingStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/ISchedulingStrategy.cs
@@ -61,12 +61,6 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         bool HasReachedMaxSchedulingSteps();
 
         /// <summary>
-        /// True if the scheduling has finished.
-        /// </summary>
-        /// <returns>Boolean</returns>
-        bool HasFinished();
-
-        /// <summary>
         /// Checks if this a fair scheduling strategy.
         /// </summary>
         /// <returns>Boolean</returns>
@@ -75,7 +69,8 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         /// <summary>
         /// Prepares the next scheduling iteration.
         /// </summary>
-        void ConfigureNextIteration();
+        /// <returns>False if all schedules have been explored</returns>
+        bool PrepareForNextIteration();
 
         /// <summary>
         /// Resets the scheduling strategy.

--- a/Libraries/TestingServices/SchedulingStrategies/ISchedulingStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/ISchedulingStrategy.cs
@@ -12,23 +12,24 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using Microsoft.PSharp.Scheduling;
 using System.Collections.Generic;
 
 namespace Microsoft.PSharp.TestingServices.Scheduling
 {
     /// <summary>
-    /// Interface of a generic machine scheduling strategy.
+    /// Interface of a generic scheduling strategy.
     /// </summary>
     public interface ISchedulingStrategy
     {
         /// <summary>
-        /// Returns the next machine to schedule.
+        /// Returns the next choice to schedule.
         /// </summary>
         /// <param name="next">Next</param>
         /// <param name="choices">Choices</param>
         /// <param name="current">Curent</param>
         /// <returns>Boolean</returns>
-        bool TryGetNext(out MachineInfo next, IEnumerable<MachineInfo> choices, MachineInfo current);
+        bool TryGetNext(out ISchedulable next, List<ISchedulable> choices, ISchedulable current);
 
         /// <summary>
         /// Returns the next boolean choice.

--- a/Libraries/TestingServices/SchedulingStrategies/Prioritized/PCTStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/Prioritized/PCTStrategy.cs
@@ -26,7 +26,7 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
     /// Class representing a probabilistic concurrency testing (PCT)
     /// scheduling strategy.
     /// </summary>
-    public class PCTStrategy : ISchedulingStrategy
+    public sealed class PCTStrategy : ISchedulingStrategy
     {
         #region fields
 
@@ -173,15 +173,6 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         }
 
         /// <summary>
-        /// Returns true if the scheduling has finished.
-        /// </summary>
-        /// <returns>Boolean</returns>
-        public bool HasFinished()
-        {
-            return false;
-        }
-
-        /// <summary>
         /// Checks if this a fair scheduling strategy.
         /// </summary>
         /// <returns>Boolean</returns>
@@ -191,9 +182,10 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         }
 
         /// <summary>
-        /// Configures the next scheduling iteration.
+        /// Prepares the next scheduling iteration.
         /// </summary>
-        public void ConfigureNextIteration()
+        /// <returns>False if all schedules have been explored</returns>
+        public bool PrepareForNextIteration()
         {
             this.MaxExploredSteps = Math.Max(this.MaxExploredSteps, this.ExploredSteps);
             this.ExploredSteps = 0;
@@ -211,6 +203,8 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
             {
                 this.PriorityChangePoints.Add(point);
             }
+
+            return true;
         }
 
         /// <summary>

--- a/Libraries/TestingServices/SchedulingStrategies/Special/ComboStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/Special/ComboStrategy.cs
@@ -12,6 +12,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using Microsoft.PSharp.Scheduling;
 using System.Collections.Generic;
 
 namespace Microsoft.PSharp.TestingServices.Scheduling
@@ -64,13 +65,13 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         }
 
         /// <summary>
-        /// Returns the next machine to schedule.
+        /// Returns the next choice to schedule.
         /// </summary>
         /// <param name="next">Next</param>
         /// <param name="choices">Choices</param>
         /// <param name="current">Curent</param>
         /// <returns>Boolean</returns>
-        public bool TryGetNext(out MachineInfo next, IEnumerable<MachineInfo> choices, MachineInfo current)
+        public bool TryGetNext(out ISchedulable next, List<ISchedulable> choices, ISchedulable current)
         {
             if (this.PrefixStrategy.GetExploredSteps() > this.SafetyPrefixDepth)
             {

--- a/Libraries/TestingServices/SchedulingStrategies/Special/ComboStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/Special/ComboStrategy.cs
@@ -146,15 +146,6 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         }
 
         /// <summary>
-        /// Returns true if the scheduling has finished.
-        /// </summary>
-        /// <returns>Boolean</returns>
-        public bool HasFinished()
-        {
-            return this.SuffixStrategy.HasFinished() && this.PrefixStrategy.HasFinished();
-        }
-
-        /// <summary>
         /// Checks if this a fair scheduling strategy.
         /// </summary>
         /// <returns>Boolean</returns>
@@ -164,12 +155,14 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         }
 
         /// <summary>
-        /// Configures the next scheduling iteration.
+        /// Prepares the next scheduling iteration.
         /// </summary>
-        public void ConfigureNextIteration()
+        /// <returns>False if all schedules have been explored</returns>
+        public bool PrepareForNextIteration()
         {
-            this.PrefixStrategy.ConfigureNextIteration();
-            this.SuffixStrategy.ConfigureNextIteration();
+            bool doNext = this.PrefixStrategy.PrepareForNextIteration();
+            doNext = doNext || this.SuffixStrategy.PrepareForNextIteration();
+            return doNext;
         }
 
         /// <summary>

--- a/Libraries/TestingServices/SchedulingStrategies/Special/InteractiveStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/Special/InteractiveStrategy.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.PSharp.IO;
+using Microsoft.PSharp.Scheduling;
 
 namespace Microsoft.PSharp.TestingServices.Scheduling
 {
@@ -71,21 +72,19 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         }
 
         /// <summary>
-        /// Returns the next machine to schedule.
+        /// Returns the next choice to schedule.
         /// </summary>
         /// <param name="next">Next</param>
         /// <param name="choices">Choices</param>
         /// <param name="current">Curent</param>
         /// <returns>Boolean</returns>
-        public bool TryGetNext(out MachineInfo next, IEnumerable<MachineInfo> choices, MachineInfo current)
+        public bool TryGetNext(out ISchedulable next, List<ISchedulable> choices, ISchedulable current)
         {
             next = null;
 
-            choices = choices.OrderBy(machine => machine.MachineId.Value).ToList();
-            List<MachineInfo> availableMachines = choices.Where(
-                m => m.IsEnabled && !m.IsWaitingToReceive).ToList();
+            List<ISchedulable> enabledChoices = choices.Where(choice => choice.IsEnabled).ToList();
 
-            if (availableMachines.Count == 0)
+            if (enabledChoices.Count == 0)
             {
                 this.Logger.WriteLine(">> No available machines to schedule ...");
                 return false;
@@ -109,16 +108,16 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
                         this.InputCache[this.ExploredSteps - 1] = "0";
                     }
 
-                    next = availableMachines[idx];
+                    next = enabledChoices[idx];
                     parsed = true;
                     break;
                 }
 
                 this.Logger.WriteLine(">> Available machines to schedule ...");
-                for (int idx = 0; idx < availableMachines.Count; idx++)
+                for (int idx = 0; idx < enabledChoices.Count; idx++)
                 {
-                    var m = availableMachines[idx];
-                    this.Logger.WriteLine($">> [{idx}] '{m.MachineId}'");
+                    var choice = enabledChoices[idx];
+                    this.Logger.WriteLine($">> [{idx}] '{choice.Name}'");
                 }
 
                 this.Logger.WriteLine($">> Choose machine to schedule [step '{this.ExploredSteps}']");
@@ -157,7 +156,7 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
                             continue;
                         }
 
-                        next = availableMachines[idx];
+                        next = enabledChoices[idx];
                         if (next == null)
                         {
                             this.Logger.WriteLine(">> Unexpected id, please retry ...");
@@ -172,7 +171,7 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
                 }
                 else
                 {
-                    next = availableMachines[0];
+                    next = enabledChoices[0];
                 }
 
                 this.InputCache.Add(input);

--- a/Libraries/TestingServices/SchedulingStrategies/Special/InteractiveStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/Special/InteractiveStrategy.cs
@@ -24,7 +24,7 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
     /// <summary>
     /// Class representing an interactive scheduling strategy.
     /// </summary>
-    public class InteractiveStrategy : ISchedulingStrategy
+    internal sealed class InteractiveStrategy : ISchedulingStrategy
     {
         #region fields
 
@@ -131,7 +131,7 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
                     }
 
                     this.Configuration.SchedulingIterations++;
-                    this.ConfigureNextIteration();
+                    this.PrepareForNextIteration();
                     return false;
                 }
                 else if (input.Equals("jump"))
@@ -222,7 +222,7 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
                     }
 
                     this.Configuration.SchedulingIterations++;
-                    this.ConfigureNextIteration();
+                    this.PrepareForNextIteration();
                     return false;
                 }
                 else if (input.Equals("jump"))
@@ -297,7 +297,7 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
                     }
 
                     this.Configuration.SchedulingIterations++;
-                    this.ConfigureNextIteration();
+                    this.PrepareForNextIteration();
                     return false;
                 }
                 else if (input.Equals("jump"))
@@ -364,15 +364,6 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         }
 
         /// <summary>
-        /// Returns true if the scheduling has finished.
-        /// </summary>
-        /// <returns>Boolean</returns>
-        public bool HasFinished()
-        {
-            return false;
-        }
-
-        /// <summary>
         /// Checks if this a fair scheduling strategy.
         /// </summary>
         /// <returns>Boolean</returns>
@@ -382,11 +373,13 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         }
 
         /// <summary>
-        /// Configures the next scheduling iteration.
+        /// Prepares the next scheduling iteration.
         /// </summary>
-        public void ConfigureNextIteration()
+        /// <returns>False if all schedules have been explored</returns>
+        public bool PrepareForNextIteration()
         {
             this.ExploredSteps = 0;
+            return true;
         }
 
         /// <summary>

--- a/Libraries/TestingServices/SchedulingStrategies/Special/MaceMCStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/Special/MaceMCStrategy.cs
@@ -12,6 +12,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using Microsoft.PSharp.Scheduling;
 using System.Collections.Generic;
 
 namespace Microsoft.PSharp.TestingServices.Scheduling
@@ -61,13 +62,13 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         }
 
         /// <summary>
-        /// Returns the next machine to schedule.
+        /// Returns the next choice to schedule.
         /// </summary>
         /// <param name="next">Next</param>
         /// <param name="choices">Choices</param>
         /// <param name="current">Curent</param>
         /// <returns>Boolean</returns>
-        public bool TryGetNext(out MachineInfo next, IEnumerable<MachineInfo> choices, MachineInfo current)
+        public bool TryGetNext(out ISchedulable next, List<ISchedulable> choices, ISchedulable current)
         {
             if (this.BoundedDFS.HasReachedMaxSchedulingSteps())
             {

--- a/Libraries/TestingServices/SchedulingStrategies/Special/MaceMCStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/Special/MaceMCStrategy.cs
@@ -21,7 +21,7 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
     /// Class representing a depth-first search scheduling strategy
     /// that incorporates iterative deepening.
     /// </summary>
-    public class MaceMCStrategy : ISchedulingStrategy
+    public sealed class MaceMCStrategy : ISchedulingStrategy
     {
         #region fields
 
@@ -142,15 +142,6 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         }
 
         /// <summary>
-        /// Returns true if the scheduling has finished.
-        /// </summary>
-        /// <returns>Boolean</returns>
-        public bool HasFinished()
-        {
-            return this.BoundedDFS.HasFinished();
-        }
-
-        /// <summary>
         /// Checks if this a fair scheduling strategy.
         /// </summary>
         /// <returns>Boolean</returns>
@@ -160,12 +151,14 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         }
 
         /// <summary>
-        /// Configures the next scheduling iteration.
+        /// Prepares the next scheduling iteration.
         /// </summary>
-        public void ConfigureNextIteration()
+        /// <returns>False if all schedules have been explored</returns>
+        public bool PrepareForNextIteration()
         {
-            this.BoundedDFS.ConfigureNextIteration();
-            this.Random.ConfigureNextIteration();
+            bool doNext = this.BoundedDFS.PrepareForNextIteration();
+            this.Random.PrepareForNextIteration();
+            return doNext;
         }
 
         /// <summary>

--- a/Libraries/TestingServices/SchedulingStrategies/Special/ReplayStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/Special/ReplayStrategy.cs
@@ -25,7 +25,7 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
     /// <summary>
     /// Class representing a replaying scheduling strategy.
     /// </summary>
-    internal class ReplayStrategy : ISchedulingStrategy
+    internal sealed class ReplayStrategy : ISchedulingStrategy
     {
         #region fields
 
@@ -188,7 +188,7 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         /// <param name="maxValue">Max value</param>
         /// <param name="next">Next</param>
         /// <returns>Boolean</returns>
-        public virtual bool GetNextIntegerChoice(int maxValue, out int next)
+        public bool GetNextIntegerChoice(int maxValue, out int next)
         {
             ScheduleStep nextStep = null;
 
@@ -258,15 +258,6 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         }
 
         /// <summary>
-        /// Returns true if the scheduling has finished.
-        /// </summary>
-        /// <returns>Boolean</returns>
-        public bool HasFinished()
-        {
-            return true;
-        }
-
-        /// <summary>
         /// Checks if this a fair scheduling strategy.
         /// </summary>
         /// <returns>Boolean</returns>
@@ -276,12 +267,14 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         }
 
         /// <summary>
-        /// Configures the next scheduling iteration.
+        /// Prepares the next scheduling iteration.
         /// </summary>
-        public void ConfigureNextIteration()
+        /// <returns>False if all schedules have been explored</returns>
+        public bool PrepareForNextIteration()
         {
             this.MaxExploredSteps = Math.Max(this.MaxExploredSteps, this.ExploredSteps);
             this.ExploredSteps = 0;
+            return false;
         }
 
         /// <summary>

--- a/Libraries/TestingServices/StateCaching/State.cs
+++ b/Libraries/TestingServices/StateCaching/State.cs
@@ -36,10 +36,10 @@ namespace Microsoft.PSharp.TestingServices.StateCaching
         internal Dictionary<Monitor, MonitorStatus> MonitorStatus;
 
         /// <summary>
-        /// The enabled machines. Only relevant if this is a scheduling
-        /// trace step.
+        /// Ids of the enabled machines. Only relevant
+        /// if this is a scheduling trace step.
         /// </summary>
-        internal HashSet<MachineId> EnabledMachines;
+        internal HashSet<ulong> EnabledMachineIds;
 
         #endregion
 
@@ -49,13 +49,12 @@ namespace Microsoft.PSharp.TestingServices.StateCaching
         /// Constructor.
         /// </summary>
         /// <param name="fingerprint">Fingerprint</param>
-        /// <param name="enabledMachines">Enabled machines</param>
+        /// <param name="enabledMachineIds">Ids of enabled machines</param>
         /// <param name="monitorStatus">Monitor status</param>
-        internal State(Fingerprint fingerprint, HashSet<MachineId> enabledMachines,
-            Dictionary<Monitor, MonitorStatus> monitorStatus)
+        internal State(Fingerprint fingerprint, HashSet<ulong> enabledMachineIds, Dictionary<Monitor, MonitorStatus> monitorStatus)
         {
             this.Fingerprint = fingerprint;
-            this.EnabledMachines = enabledMachines;
+            this.EnabledMachineIds = enabledMachineIds;
             this.MonitorStatus = monitorStatus;
         }
 
@@ -65,9 +64,9 @@ namespace Microsoft.PSharp.TestingServices.StateCaching
         internal void PrettyPrint()
         {
             Debug.WriteLine($"Fingerprint: {this.Fingerprint}");
-            foreach (var m in this.EnabledMachines)
+            foreach (var id in this.EnabledMachineIds)
             {
-                Debug.WriteLine($"  Enabled machine: {m}");
+                Debug.WriteLine($"  Enabled machine id: {id}");
             }
 
             foreach (var m in this.MonitorStatus)

--- a/Libraries/TestingServices/StateCaching/StateCache.cs
+++ b/Libraries/TestingServices/StateCaching/StateCache.cs
@@ -78,8 +78,8 @@ namespace Microsoft.PSharp.TestingServices.StateCaching
         internal void CaptureState(ScheduleStep scheduleStep)
         {
             var fingerprint = this.Runtime.GetProgramState();
-            var enabledMachines = this.Runtime.Scheduler.GetEnabledMachines();
-            var state = new State(fingerprint, enabledMachines, this.Runtime.LivenessChecker.GetMonitorStatus());
+            var enabledMachineIds = this.Runtime.Scheduler.GetEnabledSchedulableIds();
+            var state = new State(fingerprint, enabledMachineIds, this.Runtime.LivenessChecker.GetMonitorStatus());
 
             if (scheduleStep.Type == ScheduleStepType.SchedulingChoice)
             {

--- a/Libraries/TestingServices/Tracing/Machines/MachineActionInfo.cs
+++ b/Libraries/TestingServices/Tracing/Machines/MachineActionInfo.cs
@@ -212,17 +212,17 @@ namespace Microsoft.PSharp.TestingServices.Tracing.Machines
         /// Creates a machine creation info.
         /// </summary>
         /// <param name="index">Index</param>
-        /// <param name="creator">MachineId</param>
+        /// <param name="creatorId">Creator id</param>
         /// <param name="mid">MachineId</param>
         /// <returns>MachineId</returns>
-        internal static MachineActionInfo CreateMachineCreationInfo(int index, MachineId creator, MachineId mid)
+        internal static MachineActionInfo CreateMachineCreationInfo(int index, ulong creatorId, MachineId mid)
         {
             var actionInfo = new MachineActionInfo();
 
             actionInfo.Index = index;
             actionInfo.Type = MachineActionType.MachineCreationInfo;
 
-            actionInfo.MachineId = creator.Value;
+            actionInfo.MachineId = creatorId;
             actionInfo.createdMachineId = mid;
 
             actionInfo.TaskId = -5;

--- a/Libraries/TestingServices/Tracing/Machines/MachineActionTrace.cs
+++ b/Libraries/TestingServices/Tracing/Machines/MachineActionTrace.cs
@@ -130,7 +130,7 @@ namespace Microsoft.PSharp.TestingServices.Tracing.Machines
         /// <param name="mid">MachineId</param>
         internal void AddCreateMachineInfo(MachineId mid)
         {
-            var info = MachineActionInfo.CreateMachineCreationInfo(this.Count, this.MachineId, mid);
+            var info = MachineActionInfo.CreateMachineCreationInfo(this.Count, this.MachineId.Value, mid);
             this.Push(info);
         }
 

--- a/Libraries/TestingServices/Tracing/Schedules/ScheduleStep.cs
+++ b/Libraries/TestingServices/Tracing/Schedules/ScheduleStep.cs
@@ -32,10 +32,10 @@ namespace Microsoft.PSharp.TestingServices.Tracing.Schedule
         internal ScheduleStepType Type { get; private set; }
 
         /// <summary>
-        /// The scheduled machine id. Only relevant if this is
+        /// The id of the scheduled machine. Only relevant if this is
         /// a regular schedule step.
         /// </summary>
-        internal MachineId ScheduledMachineId;
+        internal ulong ScheduledMachineId;
 
         /// <summary>
         /// The non-deterministic choice id. Only relevant if
@@ -75,7 +75,7 @@ namespace Microsoft.PSharp.TestingServices.Tracing.Schedule
         /// <param name="index">Index</param>
         /// <param name="scheduledMachineId">Scheduled machine id</param>
         /// <returns>ScheduleStep</returns>
-        internal static ScheduleStep CreateSchedulingChoice(int index, MachineId scheduledMachineId)
+        internal static ScheduleStep CreateSchedulingChoice(int index, ulong scheduledMachineId)
         {
             var scheduleStep = new ScheduleStep();
 

--- a/Libraries/TestingServices/Tracing/Schedules/ScheduleTrace.cs
+++ b/Libraries/TestingServices/Tracing/Schedules/ScheduleTrace.cs
@@ -91,8 +91,8 @@ namespace Microsoft.PSharp.TestingServices.Tracing.Schedule
                 }
                 else
                 {
-                    string[] machineId = step.TrimEnd(')').Split('(');
-                    this.AddSchedulingChoice(new MachineId(machineId[0], ulong.Parse(machineId[1])));
+                    string id = step.TrimStart('(').TrimEnd(')');
+                    this.AddSchedulingChoice(ulong.Parse(id));
                 }
             }
         }
@@ -101,7 +101,7 @@ namespace Microsoft.PSharp.TestingServices.Tracing.Schedule
         /// Adds a scheduling choice.
         /// </summary>
         /// <param name="scheduledMachineId">Scheduled machine id</param>
-        internal void AddSchedulingChoice(MachineId scheduledMachineId)
+        internal void AddSchedulingChoice(ulong scheduledMachineId)
         {
             var scheduleStep = ScheduleStep.CreateSchedulingChoice(this.Count, scheduledMachineId);
             this.Push(scheduleStep);

--- a/Tests/TestingServices.Tests.Unit/EventHandling/ReceiveEvent/ReceiveEventFailTest.cs
+++ b/Tests/TestingServices.Tests.Unit/EventHandling/ReceiveEvent/ReceiveEventFailTest.cs
@@ -102,18 +102,46 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
             }
         }
 
-        /// <summary>
-        /// P# semantics test: two machines, monitor instantiation parameter.
-        /// </summary>
         [Fact]
-        public void TestReceiveEventFailure()
+        public void TestOneMachineReceiveEventFailure()
         {
             var configuration = base.GetConfiguration();
             configuration.SchedulingStrategy = SchedulingStrategy.DFS;
             var test = new Action<PSharpRuntime>((r) => { r.CreateMachine(typeof(Server)); });
-            var bugReport = "Livelock detected. Machine 'Microsoft.PSharp.TestingServices." +
-                "Tests.Unit.ReceiveEventFailTest+Client()' is waiting for an event, but " +
-                "no other machine is enabled.";
+            var bugReport = "Livelock detected. 'Microsoft.PSharp.TestingServices.Tests.Unit.ReceiveEventFailTest+" +
+                "Client()' is waiting for an event, but no other schedulable choices are enabled.";
+            base.AssertFailed(configuration, test, bugReport);
+        }
+
+        [Fact]
+        public void TestTwoMachinesReceiveEventFailure()
+        {
+            var configuration = base.GetConfiguration();
+            configuration.SchedulingStrategy = SchedulingStrategy.DFS;
+            var test = new Action<PSharpRuntime>((r) => {
+                r.CreateMachine(typeof(Server));
+                r.CreateMachine(typeof(Server));
+            });
+            var bugReport = "Livelock detected. 'Microsoft.PSharp.TestingServices.Tests.Unit.ReceiveEventFailTest+" +
+                "Client()' and 'Microsoft.PSharp.TestingServices.Tests.Unit.ReceiveEventFailTest+Client()' " +
+                "are waiting for an event, but no other schedulable choices are enabled.";
+            base.AssertFailed(configuration, test, bugReport);
+        }
+
+        [Fact]
+        public void TestThreeMachinesReceiveEventFailure()
+        {
+            var configuration = base.GetConfiguration();
+            configuration.SchedulingStrategy = SchedulingStrategy.DFS;
+            var test = new Action<PSharpRuntime>((r) => {
+                r.CreateMachine(typeof(Server));
+                r.CreateMachine(typeof(Server));
+                r.CreateMachine(typeof(Server));
+            });
+            var bugReport = "Livelock detected. 'Microsoft.PSharp.TestingServices.Tests.Unit.ReceiveEventFailTest+" +
+                "Client()', 'Microsoft.PSharp.TestingServices.Tests.Unit.ReceiveEventFailTest+Client()' " +
+                "and 'Microsoft.PSharp.TestingServices.Tests.Unit.ReceiveEventFailTest+Client()' " +
+                "are waiting for an event, but no other schedulable choices are enabled.";
             base.AssertFailed(configuration, test, bugReport);
         }
     }


### PR DESCRIPTION
All scheduling strategies now use the new `ISchedulable` interface rather than `MachineInfo` (which implements `ISchedulable`). This change is towards making the scheduling strategies agnostic of P# and thus reusable by arbitrary systematic testing tools that take a dependency.

This also addresses #195.