### PR TITLE
Instrumenting scheduling points now happens before create and send

### DIFF
--- a/Libraries/Core/Configuration/Configuration.cs
+++ b/Libraries/Core/Configuration/Configuration.cs
@@ -138,6 +138,13 @@ namespace Microsoft.PSharp
         public int? RandomSchedulingSeed;
 
         /// <summary>
+        /// If true, the seed will increment in each
+        /// testing iteration.
+        /// </summary>
+        [DataMember]
+        public bool IncrementalSchedulingSeed;
+
+        /// <summary>
         /// If true, the P# tester performs a full exploration,
         /// and does not stop when it finds a bug.
         /// </summary>
@@ -443,6 +450,7 @@ namespace Microsoft.PSharp
             this.SchedulingStrategy = SchedulingStrategy.Random;
             this.SchedulingIterations = 1;
             this.RandomSchedulingSeed = null;
+            this.IncrementalSchedulingSeed = false;
 
             this.PerformFullExploration = false;
             this.MaxFairSchedulingSteps = 0;

--- a/Libraries/Core/Utilities/RandomNumberGenerators/DefaultRandomNumberGenerator.cs
+++ b/Libraries/Core/Utilities/RandomNumberGenerators/DefaultRandomNumberGenerator.cs
@@ -21,14 +21,23 @@ namespace Microsoft.PSharp.Utilities
     /// </summary>
     public class DefaultRandomNumberGenerator : IRandomNumberGenerator
     {
-        Random random;
+        /// <summary>
+        /// Device for generating random numbers.
+        /// </summary>
+        private Random Random;
+
+        /// <summary>
+        /// The seed currently used by the generator.
+        /// </summary>
+        public int Seed { get; private set; }
 
         /// <summary>
         /// Initializes with a time-dependent seed.
         /// </summary>
         public DefaultRandomNumberGenerator()
         {
-            random = new Random();
+            Seed = DateTime.Now.Millisecond;
+            Random = new Random(Seed);
         }
 
         /// <summary>
@@ -37,7 +46,8 @@ namespace Microsoft.PSharp.Utilities
         /// <param name="seed">Seed value</param>
         public DefaultRandomNumberGenerator(int seed)
         {
-            random = new Random(seed);
+            Seed = seed;
+            Random = new Random(seed);
         }
 
         /// <summary>
@@ -45,7 +55,7 @@ namespace Microsoft.PSharp.Utilities
         /// </summary>
         public int Next()
         {
-            return random.Next();
+            return Random.Next();
         }
 
         /// <summary>
@@ -54,7 +64,16 @@ namespace Microsoft.PSharp.Utilities
         /// <param name="maxValue">Exclusive upper bound</param>
         public int Next(int maxValue)
         {
-            return random.Next(maxValue);
+            return Random.Next(maxValue);
+        }
+
+        /// <summary>
+        /// Increments the seed used by the generator.
+        /// </summary>
+        public void IncrementSeed()
+        {
+            Seed++;
+            Random = new Random(Seed);
         }
     }
 }

--- a/Libraries/Core/Utilities/RandomNumberGenerators/IRandomNumberGenerator.cs
+++ b/Libraries/Core/Utilities/RandomNumberGenerators/IRandomNumberGenerator.cs
@@ -20,6 +20,11 @@ namespace Microsoft.PSharp.Utilities
     public interface IRandomNumberGenerator
     {
         /// <summary>
+        /// The seed currently used by the generator.
+        /// </summary>
+        int Seed { get; }
+
+        /// <summary>
         /// Returns a non-negative random number.
         /// </summary>
         int Next();
@@ -29,5 +34,10 @@ namespace Microsoft.PSharp.Utilities
         /// </summary>
         /// <param name="maxValue">Exclusive upper bound</param>
         int Next(int maxValue);
+
+        /// <summary>
+        /// Increments the seed used by the generator.
+        /// </summary>
+        void IncrementSeed();
     }
 }

--- a/Libraries/TestingServices/Runtime/BugFindingRuntime.cs
+++ b/Libraries/TestingServices/Runtime/BugFindingRuntime.cs
@@ -396,6 +396,8 @@ namespace Microsoft.PSharp.TestingServices
 
             Machine machine = this.CreateMachine(type, friendlyName);
 
+            this.Scheduler.Schedule();
+
             this.BugTrace.AddCreateMachineStep(creator, machine.Id, e == null ? null : new EventInfo(e));
             if (base.Configuration.EnableDataRaceDetection)
             {
@@ -408,7 +410,6 @@ namespace Microsoft.PSharp.TestingServices
             }
 
             this.RunMachineEventHandler(machine, e, true, false);
-            this.Scheduler.Schedule();
 
             return machine.Id;
         }
@@ -432,6 +433,8 @@ namespace Microsoft.PSharp.TestingServices
 
             Machine machine = this.CreateMachine(type, friendlyName);
 
+            this.Scheduler.Schedule();
+
             this.BugTrace.AddCreateMachineStep(creator, machine.Id, e == null ? null : new EventInfo(e));
             if (base.Configuration.EnableDataRaceDetection)
             {
@@ -444,7 +447,6 @@ namespace Microsoft.PSharp.TestingServices
             }
 
             this.RunMachineEventHandler(machine, e, true, true);
-            this.Scheduler.Schedule();
 
             return await Task.FromResult(machine.Id);
         }
@@ -519,14 +521,14 @@ namespace Microsoft.PSharp.TestingServices
                 return;
             }
 
+            this.Scheduler.Schedule();
+
             bool runNewHandler = false;
             this.EnqueueEvent(machine, e, sender, ref runNewHandler);
             if (runNewHandler)
             {
                 this.RunMachineEventHandler(machine, null, false, false);
             }
-
-            this.Scheduler.Schedule();
         }
 
         /// <summary>
@@ -553,14 +555,14 @@ namespace Microsoft.PSharp.TestingServices
                 return;
             }
 
+            this.Scheduler.Schedule();
+
             bool runNewHandler = false;
             this.EnqueueEvent(machine, e, sender, ref runNewHandler);
             if (runNewHandler)
             {
                 this.RunMachineEventHandler(machine, null, false, true);
             }
-
-            this.Scheduler.Schedule();
 
             await Task.CompletedTask;
         }

--- a/Libraries/TestingServices/SchedulingStrategies/Fuzzing/ProbabilisticRandomStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/Fuzzing/ProbabilisticRandomStrategy.cs
@@ -31,7 +31,7 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         /// <summary>
         /// The configuration.
         /// </summary>
-        protected Configuration Configuration;
+        private Configuration Configuration;
 
         /// <summary>
         /// Nondeterminitic seed.

--- a/Libraries/TestingServices/SchedulingStrategies/Fuzzing/RandomStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/Fuzzing/RandomStrategy.cs
@@ -30,7 +30,7 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         /// <summary>
         /// The configuration.
         /// </summary>
-        protected Configuration Configuration;
+        private Configuration Configuration;
 
         /// <summary>
         /// Nondeterminitic seed.

--- a/Libraries/TestingServices/SchedulingStrategies/Fuzzing/RandomStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/Fuzzing/RandomStrategy.cs
@@ -162,6 +162,11 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         public bool PrepareForNextIteration()
         {
             this.ExploredSteps = 0;
+            if (this.Configuration.IncrementalSchedulingSeed)
+            {
+                this.Random.IncrementSeed();
+            }
+
             return true;
         }
 

--- a/Libraries/TestingServices/SchedulingStrategies/Prioritized/PCTStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/Prioritized/PCTStrategy.cs
@@ -203,6 +203,11 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
                 this.PriorityChangePoints.Add(point);
             }
 
+            if (this.Configuration.IncrementalSchedulingSeed)
+            {
+                this.Random.IncrementSeed();
+            }
+
             return true;
         }
 

--- a/Libraries/TestingServices/SchedulingStrategies/Special/ComboStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/Special/ComboStrategy.cs
@@ -20,14 +20,14 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
     /// Class representing a combination of two strategies, used
     /// one after the other.
     /// </summary>
-    public class ComboStrategy : ISchedulingStrategy
+    public sealed class ComboStrategy : ISchedulingStrategy
     {
         #region fields
 
         /// <summary>
         /// The configuration.
         /// </summary>
-        protected Configuration Configuration;
+        private Configuration Configuration;
 
         /// <summary>
         /// The safety prefix depth.

--- a/Libraries/TestingServices/SchedulingStrategies/Special/MaceMCStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/Special/MaceMCStrategy.cs
@@ -27,7 +27,7 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         /// <summary>
         /// The configuration.
         /// </summary>
-        protected Configuration Configuration;
+        private Configuration Configuration;
 
         /// <summary>
         /// The safety prefix depth.

--- a/Libraries/TestingServices/SchedulingStrategies/Special/ReplayStrategy.cs
+++ b/Libraries/TestingServices/SchedulingStrategies/Special/ReplayStrategy.cs
@@ -31,7 +31,7 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         /// <summary>
         /// The configuration.
         /// </summary>
-        protected Configuration Configuration;
+        private Configuration Configuration;
 
         /// <summary>
         /// The P# program schedule trace.

--- a/Tests/TestingServices.Tests.Integration/Advanced/ChainReplicationTest.cs
+++ b/Tests/TestingServices.Tests.Integration/Advanced/ChainReplicationTest.cs
@@ -1447,8 +1447,8 @@ namespace Microsoft.PSharp.TestingServices.Tests.Integration
             configuration.SchedulingStrategy = Utilities.SchedulingStrategy.FairPCT;
             configuration.PrioritySwitchBound = 1;
             configuration.MaxUnfairSchedulingSteps = 100;
-            configuration.RandomSchedulingSeed = 504;
-            configuration.SchedulingIterations = 10;
+            configuration.RandomSchedulingSeed = 389;
+            configuration.SchedulingIterations = 1;
 
             var test = new Action<PSharpRuntime>((r) => {
                 r.RegisterMonitor(typeof(InvariantMonitor));

--- a/Tests/TestingServices.Tests.Integration/Advanced/FailureDetectorTest.cs
+++ b/Tests/TestingServices.Tests.Integration/Advanced/FailureDetectorTest.cs
@@ -483,7 +483,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Integration
             configuration.MaxUnfairSchedulingSteps = 200;
             configuration.MaxFairSchedulingSteps = 2000;
             configuration.LivenessTemperatureThreshold = 1000;
-            configuration.RandomSchedulingSeed = 34795;
+            configuration.RandomSchedulingSeed = 117421;
             configuration.SchedulingIterations = 1;
 
             var test = new Action<PSharpRuntime>((r) => {
@@ -503,7 +503,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Integration
             configuration.MaxUnfairSchedulingSteps = 200;
             configuration.MaxFairSchedulingSteps = 2000;
             configuration.LivenessTemperatureThreshold = 1000;
-            configuration.RandomSchedulingSeed = 7724;
+            configuration.RandomSchedulingSeed = 32258;
             configuration.SchedulingIterations = 1;
 
             var test = new Action<PSharpRuntime>((r) => {

--- a/Tests/TestingServices.Tests.Integration/Advanced/RaftTest.cs
+++ b/Tests/TestingServices.Tests.Integration/Advanced/RaftTest.cs
@@ -1155,7 +1155,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Integration
             configuration.MaxUnfairSchedulingSteps = 100;
             configuration.MaxFairSchedulingSteps = 1000;
             configuration.LivenessTemperatureThreshold = 500;
-            configuration.RandomSchedulingSeed = 495;
+            configuration.RandomSchedulingSeed = 16;
             configuration.SchedulingIterations = 1;
 
             var test = new Action<PSharpRuntime>((r) => {

--- a/Tests/TestingServices.Tests.Integration/BaseTest.cs
+++ b/Tests/TestingServices.Tests.Integration/BaseTest.cs
@@ -14,11 +14,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text.RegularExpressions;
 
 using Microsoft.PSharp.IO;
-using Microsoft.PSharp.Utilities;
 
 using Xunit;
 

--- a/Tests/TestingServices.Tests.Unit/EventHandling/MaxInstances1FailTest.cs
+++ b/Tests/TestingServices.Tests.Unit/EventHandling/MaxInstances1FailTest.cs
@@ -142,7 +142,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
         {
             var configuration = base.GetConfiguration();
             configuration.SchedulingStrategy = SchedulingStrategy.DFS;
-            configuration.MaxSchedulingSteps = 5;
+            configuration.MaxSchedulingSteps = 6;
             var test = new Action<PSharpRuntime>((r) => { r.CreateMachine(typeof(RealMachine)); });
             base.AssertFailed(configuration, test, 1);
         }


### PR DESCRIPTION
Also updated 3 unit tests that were using a fixed seed, since that changed.