### PR TITLE
Adding the DPOR scheduling strategy

### DIFF
--- a/Source/Core/Configuration/Configuration.cs
+++ b/Source/Core/Configuration/Configuration.cs
@@ -126,6 +126,12 @@ namespace Microsoft.PSharp
         public SchedulingStrategy SchedulingStrategy;
 
         /// <summary>
+        /// Reduction strategy to use with the P# tester.
+        /// </summary>
+        [DataMember]
+        public ReductionStrategy ReductionStrategy;
+
+        /// <summary>
         /// Number of scheduling iterations.
         /// </summary>
         [DataMember]
@@ -449,6 +455,7 @@ namespace Microsoft.PSharp
             this.TestMethodName = "";
 
             this.SchedulingStrategy = SchedulingStrategy.Random;
+            this.ReductionStrategy = ReductionStrategy.ForceSchedule;
             this.SchedulingIterations = 1;
             this.RandomSchedulingSeed = null;
             this.IncrementalSchedulingSeed = false;

--- a/Source/Core/Library/Events/EventInfo.cs
+++ b/Source/Core/Library/Events/EventInfo.cs
@@ -41,6 +41,11 @@ namespace Microsoft.PSharp
         internal string EventName { get; private set; }
 
         /// <summary>
+        /// The step from which this event was sent.
+        /// </summary>
+        internal int SendStep { get; }
+
+        /// <summary>
         /// Information regarding the event origin.
         /// </summary>
         [DataMember]
@@ -52,14 +57,14 @@ namespace Microsoft.PSharp
         internal Guid OperationGroupId { get; private set; }
 
         /// <summary>
-        /// Constructor.
+        /// Creates a new <see cref="EventInfo"/>.
         /// </summary>
         /// <param name="e">Event</param>
         internal EventInfo(Event e)
         {
-            this.Event = e;
-            this.EventType = e.GetType();
-            this.EventName = this.EventType.FullName;
+            Event = e;
+            EventType = e.GetType();
+            EventName = EventType.FullName;
         }
 
         /// <summary>
@@ -67,12 +72,9 @@ namespace Microsoft.PSharp
         /// </summary>
         /// <param name="e">Event</param>
         /// <param name="originInfo">EventOriginInfo</param>
-        internal EventInfo(Event e, EventOriginInfo originInfo)
+        internal EventInfo(Event e, EventOriginInfo originInfo) : this(e)
         {
-            this.Event = e;
-            this.EventType = e.GetType();
-            this.EventName = this.EventType.FullName;
-            this.OriginInfo = originInfo;
+            OriginInfo = originInfo;
         }
 
         /// <summary>
@@ -82,6 +84,18 @@ namespace Microsoft.PSharp
         internal void SetOperationGroupId(Guid operationGroupId)
         {
             this.OperationGroupId = operationGroupId;
+        }
+
+        /// <summary>
+        /// Construtor.
+        /// </summary>
+        /// <param name="e">Event</param>
+        /// <param name="originInfo">EventOriginInfo</param>
+        /// <param name="sendStep">int</param>
+        internal EventInfo(Event e, EventOriginInfo originInfo, int sendStep)
+            : this(e, originInfo)
+        {
+            SendStep = sendStep;
         }
     }
 }

--- a/Source/Core/Library/MachineId.cs
+++ b/Source/Core/Library/MachineId.cs
@@ -80,7 +80,7 @@ namespace Microsoft.PSharp
             this.Endpoint = this.Runtime.NetworkProvider.GetLocalEndpoint();
             
             // Atomically increments and safely wraps into an unsigned long.
-            this.Value = (ulong)Interlocked.Increment(ref runtime.MachineIdCounter);
+            this.Value = (ulong)Interlocked.Increment(ref runtime.MachineIdCounter) - 1;
 
             // Checks for overflow.
             Runtime.Assert(this.Value != ulong.MaxValue, "Detected MachineId overflow.");

--- a/Source/Core/Runtime/PSharpRuntime.cs
+++ b/Source/Core/Runtime/PSharpRuntime.cs
@@ -347,6 +347,18 @@ namespace Microsoft.PSharp
         /// <param name="operationGroupId">Operation group id</param>
         internal abstract void SendEventRemotely(MachineId mid, Event e, AbstractMachine sender, Guid? operationGroupId);
 
+        /// <summary>
+        /// Checks that a machine can start its event handler. Returns false if the event
+        /// handler should not be started.
+        /// </summary>
+        /// <param name="machine">Machine</param>
+        /// <returns>Boolean</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal virtual bool CheckStartEventHandler(Machine machine)
+        {
+            return true;
+        }
+
         #endregion
 
         #region specifications and error checking
@@ -565,7 +577,8 @@ namespace Microsoft.PSharp
         /// Notifies that a machine is waiting to receive one or more events.
         /// </summary>
         /// <param name="machine">Machine</param>
-        internal virtual void NotifyWaitEvents(Machine machine)
+        /// <param name="eventInfoInInbox">The event info if it is in the inbox, else null</param>
+        internal virtual void NotifyWaitEvents(Machine machine, EventInfo eventInfoInInbox)
         {
             // Override to implement the notification.
         }
@@ -592,10 +605,21 @@ namespace Microsoft.PSharp
         }
 
         /// <summary>
-        /// Notifies that a default handler has been used.
+        /// Notifies that the inbox of the specified machine is about to be
+        /// checked to see if the default event handler should fire.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal virtual void NotifyDefaultHandlerFired()
+        internal virtual void NotifyDefaultEventHandlerCheck(Machine machine)
+        {
+            // Override to implement the notification.
+        }
+
+        /// <summary>
+        /// Notifies that the default handler of the specified machine has been fired.
+        /// </summary>
+        /// <param name="machine">Machine</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal virtual void NotifyDefaultHandlerFired(Machine machine)
         {
             // Override to implement the notification.
         }
@@ -716,5 +740,6 @@ namespace Microsoft.PSharp
         }
 
         #endregion
+
     }
 }

--- a/Source/Core/Runtime/StateMachineRuntime.cs
+++ b/Source/Core/Runtime/StateMachineRuntime.cs
@@ -417,10 +417,10 @@ namespace Microsoft.PSharp
         /// Runs a new asynchronous machine event handler.
         /// This is a fire and forget invocation.
         /// </summary>
-        /// <param name="machine">Machine</param>
-        /// <param name="e">Event</param>
-        /// <param name="isFresh">Is a new machine</param>
-        private void RunMachineEventHandler(Machine machine, Event e, bool isFresh)
+        /// <param name="machine">Machine that executes this event handler.</param>
+        /// <param name="initialEvent">Event for initializing the machine.</param>
+        /// <param name="isFresh">If true, then this is a new machine.</param>
+        private void RunMachineEventHandler(Machine machine, Event initialEvent, bool isFresh)
         {
             Task.Run(async () =>
             {
@@ -428,7 +428,7 @@ namespace Microsoft.PSharp
                 {
                     if (isFresh)
                     {
-                        await machine.GotoStartState(e);
+                        await machine.GotoStartState(initialEvent);
                     }
 
                     await machine.RunEventHandler();
@@ -448,16 +448,16 @@ namespace Microsoft.PSharp
         /// <summary>
         /// Runs a new asynchronous machine event handler.
         /// </summary>
-        /// <param name="machine">Machine</param>
-        /// <param name="e">Event</param>
-        /// <param name="isFresh">Is a new machine</param>
-        private async Task RunMachineEventHandlerAsync(Machine machine, Event e, bool isFresh)
+        /// <param name="machine">Machine that executes this event handler.</param>
+        /// <param name="initialEvent">Event for initializing the machine.</param>
+        /// <param name="isFresh">If true, then this is a new machine.</param>
+        private async Task RunMachineEventHandlerAsync(Machine machine, Event initialEvent, bool isFresh)
         {
             try
             {
                 if (isFresh)
                 {
-                    await machine.GotoStartState(e);
+                    await machine.GotoStartState(initialEvent);
                 }
 
                 await machine.RunEventHandler(true);
@@ -789,10 +789,14 @@ namespace Microsoft.PSharp
         /// Notifies that a machine is waiting to receive one or more events.
         /// </summary>
         /// <param name="machine">Machine</param>
-        internal override void NotifyWaitEvents(Machine machine)
+        /// <param name="eventInfoInInbox">The event info if it is in the inbox, else null</param>
+        internal override void NotifyWaitEvents(Machine machine, EventInfo eventInfoInInbox)
         {
-            base.Log($"<ReceiveLog> Machine '{machine.Id}' is waiting to receive an event.");
-            machine.Info.IsWaitingToReceive = true;
+            if (eventInfoInInbox == null)
+            {
+                base.Log($"<ReceiveLog> Machine '{machine.Id}' is waiting to receive an event.");
+                machine.Info.IsWaitingToReceive = true;
+            }
         }
 
         /// <summary>

--- a/Source/Core/Utilities/Tooling/ReductionStrategy.cs
+++ b/Source/Core/Utilities/Tooling/ReductionStrategy.cs
@@ -1,0 +1,35 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ReductionStrategy.cs">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// 
+//      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace Microsoft.PSharp.Utilities
+{
+    /// <summary>
+    /// Type of reduction strategy.
+    /// </summary>
+    public enum ReductionStrategy
+    {
+        /// <summary>
+        /// No reduction.
+        /// </summary>
+        None = 0,
+        /// <summary>
+        /// Reduction strategy that omits scheduling points.
+        /// </summary>
+        OmitSchedulingPoints,
+        /// <summary>
+        /// Reduction strategy that forces scheduling points.
+        /// </summary>
+        ForceSchedule
+    }
+}

--- a/Source/Core/Utilities/Tooling/SchedulingStrategy.cs
+++ b/Source/Core/Utilities/Tooling/SchedulingStrategy.cs
@@ -69,6 +69,16 @@ namespace Microsoft.PSharp.Utilities
         [EnumMember(Value = "IDDFS")]
         IDDFS,
         /// <summary>
+        /// Dynamic partial-order reduction (DPOR) scheduling.
+        /// </summary>
+        [EnumMember(Value = "DPOR")]
+        DPOR,
+        /// <summary>
+        /// Randomized dynamic partial-order reduction (rDPOR) scheduling.
+        /// </summary>
+        [EnumMember(Value = "rDPOR")]
+        RDPOR,
+        /// <summary>
         /// Delay-bounding scheduling.
         /// </summary>
         [EnumMember(Value = "DelayBounding")]

--- a/Source/SchedulingStrategies/ISchedulable.cs
+++ b/Source/SchedulingStrategies/ISchedulable.cs
@@ -37,11 +37,6 @@ namespace Microsoft.PSharp.TestingServices.SchedulingStrategies
         bool IsEnabled { get; }
 
         /// <summary>
-        /// Is the entity completed.
-        /// </summary>
-        bool IsCompleted { get; }
-
-        /// <summary>
         /// Type of the next operation of the entity.
         /// </summary>
         OperationType NextOperationType { get; }

--- a/Source/SchedulingStrategies/ISchedulable.cs
+++ b/Source/SchedulingStrategies/ISchedulable.cs
@@ -34,7 +34,7 @@ namespace Microsoft.PSharp.TestingServices.SchedulingStrategies
         /// <summary>
         /// Is the entity enabled.
         /// </summary>
-        bool IsEnabled { get; }
+        bool IsEnabled { get; set; }
 
         /// <summary>
         /// Type of the next operation of the entity.

--- a/Source/SchedulingStrategies/ISchedulingStrategy.cs
+++ b/Source/SchedulingStrategies/ISchedulingStrategy.cs
@@ -47,6 +47,31 @@ namespace Microsoft.PSharp.TestingServices.SchedulingStrategies
         bool GetNextIntegerChoice(int maxValue, out int next);
 
         /// <summary>
+        /// Forces the next choice to schedule.
+        /// </summary>
+        /// <param name="next">Next</param>
+        /// <param name="choices">Choices</param>
+        /// <param name="current">Curent</param>
+        /// <returns>Boolean</returns>
+        void ForceNext(ISchedulable next, List<ISchedulable> choices, ISchedulable current);
+
+        /// <summary>
+        /// Forces the next boolean choice.
+        /// </summary>
+        /// <param name="maxValue">Max value</param>
+        /// <param name="next">Next</param>
+        /// <returns>Boolean</returns>
+        void ForceNextBooleanChoice(int maxValue, bool next);
+
+        /// <summary>
+        /// Forces the next integer choice.
+        /// </summary>
+        /// <param name="maxValue">Max value</param>
+        /// <param name="next">Next</param>
+        /// <returns>Boolean</returns>
+        void ForceNextIntegerChoice(int maxValue, int next);
+
+        /// <summary>
         /// Prepares for the next scheduling iteration. This is invoked
         /// at the end of a scheduling iteration. It must return false
         /// if the scheduling strategy should stop exploring.

--- a/Source/SchedulingStrategies/Operations/OperationType.cs
+++ b/Source/SchedulingStrategies/Operations/OperationType.cs
@@ -41,13 +41,32 @@ namespace Microsoft.PSharp.TestingServices.SchedulingStrategies
         Receive,
         /// <summary>
         /// Operation used when an <see cref="ISchedulable"/>
-        /// waits for an event.
-        /// </summary>
-        Wait,
-        /// <summary>
-        /// Operation used when an <see cref="ISchedulable"/>
         /// stops executing.
         /// </summary>
-        Stop
+        Stop,
+        /// <summary>
+        /// Operation used when an <see cref="ISchedulable"/> yields. This denotes
+        /// that the current <see cref="ISchedulable"/> is not making progress. An
+        /// unfair scheduler could disable these <see cref="ISchedulable"/> until
+        /// quiescence, and then re-enable them.
+        /// 
+        /// This operation is not currently supported in P#.
+        /// </summary>
+        Yield,
+        /// <summary>
+        /// Operation used when an <see cref="ISchedulable"/> wants to wait for
+        /// quiescence. A scheduler could disable the <see cref="ISchedulable"/>
+        /// until quiescence, and then re-enable it.
+        /// 
+        /// This operation is not currently supported in P#.
+        /// </summary>
+        WaitForQuiescence,
+        /// <summary>
+        /// Operation used when an <see cref="ISchedulable"/> wants to wait for
+        /// another <see cref="ISchedulable"/> to <see cref="Stop"/>.
+        /// 
+        /// This operation is not currently supported in P#.
+        /// </summary>
+        Join
     }
 }

--- a/Source/SchedulingStrategies/Strategies/DFS/DFSStrategy.cs
+++ b/Source/SchedulingStrategies/Strategies/DFS/DFSStrategy.cs
@@ -235,6 +235,40 @@ namespace Microsoft.PSharp.TestingServices.SchedulingStrategies
         }
 
         /// <summary>
+        /// Forces the next choice to schedule.
+        /// </summary>
+        /// <param name="next">Next</param>
+        /// <param name="choices">Choices</param>
+        /// <param name="current">Curent</param>
+        /// <returns>Boolean</returns>
+        public void ForceNext(ISchedulable next, List<ISchedulable> choices, ISchedulable current)
+        {
+            ScheduledSteps++;
+        }
+
+        /// <summary>
+        /// Forces the next boolean choice.
+        /// </summary>
+        /// <param name="maxValue">Max value</param>
+        /// <param name="next">Next</param>
+        /// <returns>Boolean</returns>
+        public void ForceNextBooleanChoice(int maxValue, bool next)
+        {
+            ScheduledSteps++;
+        }
+
+        /// <summary>
+        /// Forces the next integer choice.
+        /// </summary>
+        /// <param name="maxValue">Max value</param>
+        /// <param name="next">Next</param>
+        /// <returns>Boolean</returns>
+        public void ForceNextIntegerChoice(int maxValue, int next)
+        {
+            ScheduledSteps++;
+        }
+
+        /// <summary>
         /// Prepares for the next scheduling iteration. This is invoked
         /// at the end of a scheduling iteration. It must return false
         /// if the scheduling strategy should stop exploring.

--- a/Source/SchedulingStrategies/Strategies/DPOR/DPORAlgorithm.cs
+++ b/Source/SchedulingStrategies/Strategies/DPOR/DPORAlgorithm.cs
@@ -1,0 +1,699 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="DPORAlgorithm.cs">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// 
+//      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.PSharp.TestingServices.SchedulingStrategies.DPOR
+{
+    /// <summary>
+    /// The actual DPOR algorithm used by <see cref="DPORStrategy"/>.
+    /// 
+    /// This is actually the "Source DPOR" algorithm.
+    /// 
+    /// Implementation notes:
+    /// 
+    /// 
+    /// Note that when we store indexes, they start at 1.
+    /// This allows 0 to mean: null / not yet seen.
+    /// Thus, when accessing e.g. Vcs, we must subtract 1.
+    /// But most accesses should be done via a method to hide this.
+    /// 
+    /// The happens-before relation (HBR) is assigned as follows:
+    /// - create, start, stop with the same target id are totally-ordered
+    /// - operations from the same thread are totally ordered.
+    /// - corresponding send-receive operation pairs are ordered.
+    /// - sends to the same target id are totally-ordered.
+    /// 
+    /// That last one is expected, but a bit annoying when doing random DPOR
+    /// because it limits the races (see below) between send operations to the same target id.
+    /// 
+    /// The HBR is tracked using vector clocks (VCs).
+    /// 
+    /// A pair of operations A and B is a race iff:
+    /// - A happens-before B 
+    /// - and A and B are from different threads
+    /// - and there does not exist an operation C such that A happens-before C happens-before B.
+    /// 
+    /// In other words, A and B must be directly related in the HBR with no intervening operation
+    /// connecting them. They do not need to be adjacent though 
+    /// (i.e. in a schedule, ACB, A and B might still be a race, unless A hb C hb B).
+    /// We check this in the code by checking if A hb B *before* we update the 
+    /// VC of B to include the A-B edge; if A already happens-before B then this is not a race.
+    /// 
+    /// </summary>
+    internal class DPORAlgorithm
+    {
+        /// <summary>
+        /// An upper bound of the number of threads (schedulables).
+        /// Will be increased as needed.
+        /// </summary>
+        private int NumThreads;
+
+        /// <summary>
+        /// The total number of steps (visible operations).
+        /// Will be increased as needed.
+        /// </summary>
+        private int NumSteps;
+        
+        /// <summary>
+        /// A map from thread id to the index of the last op
+        /// performed by the thread.
+        /// </summary>
+        private int[] ThreadIdToLastOpIndex;
+
+        /// <summary>
+        /// A map from target id to the last create, start or stop operation.
+        /// Used to update the HBR/VCs.
+        /// </summary>
+        private int[] TargetIdToLastCreateStartEnd;
+
+        /// <summary>
+        /// A map from target id to the last send (*to* this target).
+        /// Used to update the HBR/VCs.
+        /// </summary>
+        private int[] TargetIdToLastSend;
+
+        /// <summary>
+        /// A map from target id to the first send (*to* this target).
+        /// TODO: Used in random DPOR to slightly limit the search
+        /// of prior sends that could race with the current send.
+        /// </summary>
+        private int[] TargetIdToFirstSend;
+
+        /// <summary>
+        /// The list of vector clocks (VCs).
+        /// We store a VC for each visible operation.
+        /// Thus, this is a map from a step index to the operation's VC.
+        /// Given a step index i and thread id c:
+        ///   Vcs[(i-1)*NumThreads + c] == the vector clock of thread c.
+        /// </summary>
+        private int[] Vcs;
+
+        /// <summary>
+        /// A way for the ISchedulable to assert conditions.
+        /// </summary>
+        private readonly IContract Contract;
+
+        /// <summary>
+        /// A list of all races.
+        /// Only used when performing random DPOR.
+        /// </summary>
+        private readonly List<Race> Races;
+
+        /// <summary>
+        /// The missing thread ids when replaying a reversed race.
+        /// When performing random DPOR,
+        /// we pick a race, reverse it, and "replay" it.
+        /// In the replay, some threads may not get created
+        /// (because the replay is different)
+        /// and we must be careful when writing the RaceReplaySuffix,
+        /// subtracting 1 for every missing thread that is less than
+        /// the thread id we want to record.
+        /// This field tracks those threads.
+        /// It is a list of thread ids (not a map).
+        /// </summary>
+        private readonly List<int> MissingThreadIds;
+
+        /// <summary>
+        /// When performing random DPOR,
+        /// this field gives the schedule (as a list of thread ids)
+        /// that should be followed in order to reverse a randomly chosen race.
+        /// </summary>
+        public readonly List<TidForRaceReplay> RaceReplaySuffix;
+
+        /// <summary>
+        /// An index for the <see cref="RaceReplaySuffix"/> (for convenience) to be used 
+        /// when replaying a reversed race.
+        /// </summary>
+        public int ReplayRaceIndex;
+
+        /// <summary>
+        /// Construct the DPOR algorithm.
+        /// </summary>
+        public DPORAlgorithm(IContract contract)
+        {
+            Contract = contract;
+            // initial estimates
+            NumThreads = 4;
+            NumSteps = 1 << 8;
+
+            ThreadIdToLastOpIndex = new int[NumThreads];
+            TargetIdToLastCreateStartEnd = new int[NumThreads];
+            TargetIdToLastSend = new int[NumThreads];
+            TargetIdToFirstSend = new int[NumThreads];
+            Vcs = new int[NumSteps * NumThreads];
+            Races = new List<Race>(NumSteps);
+            RaceReplaySuffix = new List<TidForRaceReplay>();
+            MissingThreadIds = new List<int>();
+            ReplayRaceIndex = 0;
+        }
+
+        private void FromVCSetVC(int from, int to)
+        {
+            int fromI = (from-1) * NumThreads;
+            int toI = (to-1) * NumThreads;
+            for (int i = 0; i < NumThreads; ++i)
+            {
+                Vcs[toI] = Vcs[fromI];
+                ++fromI;
+                ++toI;
+            }
+        }
+
+        private void ForVCSetClockToValue(int vc, int clock, int value)
+        {
+            Vcs[(vc - 1) * NumThreads + clock] = value;
+        }
+
+        private int ForVCGetClock(int vc, int clock)
+        {
+            return Vcs[(vc - 1) * NumThreads + clock];
+        }
+
+        private void ForVCJoinFromVC(int to, int from)
+        {
+            int fromI = (from - 1) * NumThreads;
+            int toI = (to - 1) * NumThreads;
+            for (int i = 0; i < NumThreads; ++i)
+            {
+                if (Vcs[fromI] > Vcs[toI])
+                {
+                    Vcs[toI] = Vcs[fromI];
+                }
+                ++fromI;
+                ++toI;
+            }
+        }
+
+        private void ClearVC(int vc)
+        {
+            int vcI = (vc - 1) * NumThreads;
+            for (int i = 0; i < NumThreads; ++i)
+            {
+                Vcs[vcI] = 0;
+                ++vcI;
+            }
+        }
+
+        private int[] GetVC(int vc)
+        {
+            int[] res = new int[NumThreads];
+            int fromI = (vc - 1) * NumThreads;
+            for (int i = 0; i < NumThreads; ++i)
+            {
+                res[i] = Vcs[fromI];
+                ++fromI;
+            }
+            return res;
+        }
+
+        private bool HB(int threadIdOfA, int vca, int vcb)
+        {
+            // A hb B
+            // iff:
+            // A's index <= B.VC[A's tid]
+
+            // TidEntry aStep = GetSelectedTidEntry(stack, vca);
+
+            return vca <= ForVCGetClock(vcb, /*aStep.Id*/ threadIdOfA);
+        }
+
+
+        private TidEntry GetSelectedTidEntry(Stack stack, int index)
+        {
+            var list = GetThreadsAt(stack, index);
+            return list.List[list.GetSelected(Contract)];
+        }
+
+        /// <summary>
+        /// Checks if two operations are reversible.
+        /// Assumes both operations passed in are dependent.
+        /// </summary>
+        /// <param name="stack">Stack</param>
+        /// <param name="index1"></param>
+        /// <param name="index2"></param>
+        /// <returns>Are the operations reversible?</returns>
+        private bool Reversible(Stack stack, int index1, int index2)
+        {
+            var step1 = GetSelectedTidEntry(stack, index1);
+            var step2 = GetSelectedTidEntry(stack, index2);
+            return step1.OpType == OperationType.Send &&
+                   step2.OpType == OperationType.Send;
+        }
+
+        private static TidEntryList GetThreadsAt(Stack stack, int index)
+        {
+            return stack.StackInternal[index - 1];
+        }
+
+        /// <summary>
+        /// The main entry point to the DPOR algorithm.
+        /// </summary>
+        /// <param name="stack">Should contain a terminal schedule.</param>
+        /// <param name="rand">If non-null, then a randomized DPOR algorithm will be used.</param>
+        public void DoDPOR(Stack stack, IRandomNumberGenerator rand)
+        {
+            UpdateFieldsAndRealocateDatastructuresIfNeeded(stack);
+            
+            // Indexes start at 1.
+
+            for (int i = 1; i < NumSteps; ++i)
+            {
+                TidEntry step = GetSelectedTidEntry(stack, i);
+                if (ThreadIdToLastOpIndex[step.Id] > 0)
+                {
+                    FromVCSetVC(ThreadIdToLastOpIndex[step.Id], i);
+                }
+                else
+                {
+                    ClearVC(i);
+                }
+                ForVCSetClockToValue(i, step.Id, i);
+                ThreadIdToLastOpIndex[step.Id] = i;
+
+                int targetId = step.TargetId;
+                if (step.OpType == OperationType.Create && i + 1 < NumSteps)
+                {
+                    targetId = GetThreadsAt(stack, i).List.Count;
+                }
+
+                if (targetId < 0)
+                {
+                    continue;
+                }
+
+                int lastAccessIndex = 0;
+
+                switch (step.OpType)
+                {
+                    case OperationType.Start:
+                    case OperationType.Stop:
+                    case OperationType.Create:
+                    case OperationType.Join:
+                    {
+                        lastAccessIndex =
+                            TargetIdToLastCreateStartEnd[targetId];
+                        TargetIdToLastCreateStartEnd[targetId] = i;
+                        break;
+                    }
+                    case OperationType.Send:
+                    {
+                        lastAccessIndex = TargetIdToLastSend[targetId];
+                        TargetIdToLastSend[targetId] = i;
+                        if (TargetIdToFirstSend[targetId] == 0)
+                        {
+                            TargetIdToFirstSend[targetId] = i;
+                        }
+                        break;
+                    }
+                    case OperationType.Receive:
+                    {
+                        lastAccessIndex = step.SendStepIndex;
+                        break;
+                    }
+                    case OperationType.WaitForQuiescence:
+                        for (int j = 0; j < ThreadIdToLastOpIndex.Length; j++)
+                        {
+                            if (j == step.Id || ThreadIdToLastOpIndex[j] == 0)
+                            {
+                                continue;
+                            }
+                            ForVCJoinFromVC(i, ThreadIdToLastOpIndex[j]);
+                        }
+                        // Continue. No backtrack.
+                        continue;
+
+                    case OperationType.Yield:
+                        // Nothing.
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+                
+                    
+                if (lastAccessIndex > 0)
+                {
+                    AddBacktrack(stack, rand != null, lastAccessIndex, i, step);
+
+                    // Random DPOR skips joining for sends.
+                    if (!(rand != null && step.OpType == OperationType.Send))
+                    {
+                        ForVCJoinFromVC(i, lastAccessIndex);
+                    }
+                }
+            }
+
+            if (rand != null)
+            {
+                DoRandomRaceReverse(stack, rand);
+            }
+        }
+
+        private void DoRandomRaceReverse(Stack stack, IRandomNumberGenerator rand)
+        {
+            int raceIndex = rand.Next(Races.Count);
+            if (raceIndex == 0)
+            {
+                return;
+            }
+            Race race = Races[raceIndex];
+
+            Contract.Assert(RaceReplaySuffix.Count == 0, "Tried to reverse race but replay suffix was not empty!");
+
+            int threadIdOfA = GetSelectedTidEntry(stack, race.A).Id;
+
+            // Add to RaceReplaySuffix: all steps between a and b that do not h.a. a.
+            for (int i = race.A; i < race.B; ++i)
+            {
+                if (HB(threadIdOfA, race.A, i))
+                {
+                    // Skip it.
+                    // But track the missing thread id if this is a create operation.
+                    if (GetSelectedTidEntry(stack, i).OpType == OperationType.Create)
+                    {
+                        var missingThreadId = GetThreadsAt(stack, i).List.Count;
+                        var index = MissingThreadIds.BinarySearch(missingThreadId);
+                        // We should not find it.
+                        Contract.Assert(index < 0);
+                        // Get the next largest index (see BinarySearch).
+                        index = ~index;
+                        // Insert before the next largest item.
+                        MissingThreadIds.Insert(index, missingThreadId);
+                    }
+                }
+                else
+                {
+                    // Add thread id to the RaceReplaySuffix, but adjust
+                    // it for missing thread ids.
+                    AddThreadIdToRaceReplaySuffix(GetThreadsAt(stack, i));
+                }
+            }
+
+            AddThreadIdToRaceReplaySuffix(GetThreadsAt(stack, race.B));
+            AddThreadIdToRaceReplaySuffix(GetThreadsAt(stack, race.A));
+
+            // Remove steps from a onwards. Indexes start at one so we must subtract 1.
+            stack.StackInternal.RemoveRange(race.A - 1, stack.StackInternal.Count - (race.A - 1));
+        }
+
+        private void AddThreadIdToRaceReplaySuffix(TidEntryList tidEntryList)
+        {
+            // Add thread id to the RaceReplaySuffix, but adjust
+            // it for missing thread ids.
+
+            int tid = tidEntryList.GetSelected(Contract);
+
+            var index = MissingThreadIds.BinarySearch(tid);
+            // Make it so index is the number of missing thread ids before and including threadId.
+            // e.g. if missingThreadIds = [3,6,9]
+            // 3 => index + 1  = 1
+            // 4 => ~index     = 1
+            if (index >= 0)
+            {
+                index += 1;
+            }
+            else
+            {
+                index = ~index;
+            }
+
+            RaceReplaySuffix.Add(new TidForRaceReplay(tid - index, tidEntryList.NondetChoices));
+        }
+
+        private void DoRandomDPORAddRaces(Stack stack,
+            int lastAccessIndex,
+            int i,
+            TidEntry step)
+        {
+            // Note: Only sends are reversible
+            // so we will only get here if step.OpType is a send
+            // so the if below is redundant.
+            // But I am leaving this here in case we end up with more reversible types.
+            // The following assert will then fail and more thought will be needed.
+            // The if below is probably sufficient though, so the assert can probably just be removed.
+
+            Contract.Assert(step.OpType == OperationType.Send);
+
+            // Easy case (non-sends).
+            if (step.OpType != OperationType.Send)
+            {
+                Races.Add(new Race(lastAccessIndex, i));
+                return;
+            }
+
+            // Harder case (sends).
+
+            // In random DPOR, we don't just want the last race;
+            // we want all races.
+            // In random DPOR, we don't join the VCs of sends,
+            // so a send will potentially race with many prior sends to the 
+            // same mailbox. 
+            // We scan the stack looking for concurrent sends.
+            // We only need to start scanning from the first send to this mailbox.
+            int firstSend = TargetIdToFirstSend[step.TargetId];
+            Contract.Assert(
+                firstSend > 0, 
+                "We should only get here if a send races with a prior send, but it does not.");
+
+            for (int j = firstSend; j < i; j++)
+            {
+                var entry = GetSelectedTidEntry(stack, j);
+                if (entry.OpType != OperationType.Send
+                    || entry.Id == step.Id
+                    || HB(entry.Id, j, i))
+                {
+                    continue;
+                }
+                
+                Races.Add(new Race(j, i));
+            }
+        }
+
+        private void AddBacktrack(Stack stack,
+            bool doRandomDPOR,
+            int lastAccessIndex,
+            int i,
+            TidEntry step)
+        {
+            var aTidEntries = GetThreadsAt(stack, lastAccessIndex);
+            var a = GetSelectedTidEntry(stack, lastAccessIndex);
+            if (HB(a.Id, lastAccessIndex, i) ||
+                !Reversible(stack, lastAccessIndex, i)) return;
+
+            if (doRandomDPOR)
+            {
+                DoRandomDPORAddRaces(stack, lastAccessIndex, i, step);
+                return;
+            }
+
+            // PSEUDOCODE: Find candidates.
+            //  There is a race between `a` and `b`.
+            //  Must find first steps after `a` that do not HA `a`
+            //  (except maybe b.tid) and do not HA each other.
+            // candidates = {}
+            // if b.tid is enabled before a:
+            //   add b.tid to candidates
+            // lookingFor = set of enabled threads before a - a.tid - b.tid.
+            // let vc = [0,0,...]
+            // vc[a.tid] = a;
+            // for k = aIndex+1 to bIndex:
+            //   if lookingFor does not contain k.tid:
+            //     continue
+            //   remove k.tid from lookingFor
+            //   doesHaAnother = false
+            //   foreach t in tids:
+            //     if vc[t] hb k:
+            //       doesHaAnother = true
+            //       break
+            //   vc[k.tid] = k
+            //   if !doesHaAnother:
+            //     add k.tid to candidates
+            //   if lookingFor is empty:
+            //     break
+
+            var candidateThreadIds = new HashSet<int>();
+            
+            if (aTidEntries.List.Count > step.Id && 
+                (aTidEntries.List[step.Id].Enabled || aTidEntries.List[step.Id].OpType == OperationType.Yield))
+            {
+                candidateThreadIds.Add(step.Id);
+            }
+            var lookingFor = new HashSet<int>();
+            for (int j = 0; j < aTidEntries.List.Count; ++j)
+            {
+                if (j != a.Id &&
+                    j != step.Id &&
+                    (aTidEntries.List[j].Enabled || aTidEntries.List[j].OpType == OperationType.Yield))
+                {
+                    lookingFor.Add(j);
+                }
+            }
+
+            int[] vc = new int[NumThreads];
+            vc[a.Id] = lastAccessIndex;
+            if (lookingFor.Count > 0)
+            {
+                for (int k = lastAccessIndex + 1; k < i; ++k)
+                {
+                    var kEntry = GetSelectedTidEntry(stack, k);
+                    if (!lookingFor.Contains(kEntry.Id)) continue;
+
+                    lookingFor.Remove(kEntry.Id);
+                    bool doesHaAnother = false;
+                    for (int t = 0; t < NumThreads; ++t)
+                    {
+                        if (vc[t] > 0 &&
+                            vc[t] <= ForVCGetClock(k, t))
+                        {
+                            doesHaAnother = true;
+                            break;
+                        }
+                    }
+                    if (!doesHaAnother)
+                    {
+                        candidateThreadIds.Add(kEntry.Id);
+                    }
+                    if (lookingFor.Count == 0)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            // Make sure at least one candidate is found
+
+            Contract.Assert(candidateThreadIds.Count > 0, "DPOR: There were no candidate backtrack points.");
+
+            // Is one already backtracked?
+            foreach (var tid in candidateThreadIds)
+            {
+                if (aTidEntries.List[tid].Backtrack)
+                {
+                    return;
+                }
+            }
+
+            // None are backtracked, so we have to pick one.
+            // Try to pick one that is slept first.
+            // Start from thread b.tid:
+            {
+                int sleptThread = step.Id;
+                for (int k = 0; k < NumThreads; ++k)
+                {
+                    if (candidateThreadIds.Contains(sleptThread) &&
+                        aTidEntries.List[sleptThread].Sleep)
+                    {
+                        aTidEntries.List[sleptThread].Backtrack = true;
+                        return;
+                    }
+                    ++sleptThread;
+                    if (sleptThread >= NumThreads)
+                    {
+                        sleptThread = 0;
+                    }
+                }
+            }
+
+            // None are slept.
+            // Avoid picking threads that are disabled (due to yield hack)
+            // Start from thread b.tid:
+            {
+                int backtrackThread = step.Id;
+                for (int k = 0; k < NumThreads; ++k)
+                {
+                    if (candidateThreadIds.Contains(backtrackThread) &&
+                        aTidEntries.List[backtrackThread].Enabled)
+                    {
+                        aTidEntries.List[backtrackThread].Backtrack = true;
+                        return;
+                    }
+                    ++backtrackThread;
+                    if (backtrackThread >= NumThreads)
+                    {
+                        backtrackThread = 0;
+                    }
+                }
+            }
+
+            // None are slept and enabled.
+            // Start from thread b.tid:
+            {
+                int backtrackThread = step.Id;
+                for (int k = 0; k < NumThreads; ++k)
+                {
+                    if (candidateThreadIds.Contains(backtrackThread))
+                    {
+                        aTidEntries.List[backtrackThread].Backtrack = true;
+                        return;
+                    }
+                    ++backtrackThread;
+                    if (backtrackThread >= NumThreads)
+                    {
+                        backtrackThread = 0;
+                    }
+                }
+            }
+
+            Contract.Assert(false, "DPOR: Did not manage to add backtrack point.");
+        }
+
+        private void UpdateFieldsAndRealocateDatastructuresIfNeeded(Stack stack)
+        {
+            // GetTop will throw if 0 steps have been performed but this should never happen.
+            NumThreads = stack.GetTopAsRealTop().List.Count;
+            NumSteps = stack.StackInternal.Count;
+
+            int temp = ThreadIdToLastOpIndex.Length;
+            while (temp < NumThreads)
+            {
+                temp <<= 1;
+            }
+
+            if (ThreadIdToLastOpIndex.Length < temp)
+            {
+                ThreadIdToLastOpIndex = new int[temp];
+                TargetIdToLastCreateStartEnd = new int[temp];
+                TargetIdToLastSend = new int[temp];
+                TargetIdToFirstSend = new int[temp];
+            }
+            else
+            {
+                Array.Clear(ThreadIdToLastOpIndex, 0, ThreadIdToLastOpIndex.Length);
+                Array.Clear(TargetIdToLastCreateStartEnd, 0, TargetIdToLastCreateStartEnd.Length);
+                Array.Clear(TargetIdToLastSend, 0, TargetIdToLastSend.Length);
+                Array.Clear(TargetIdToFirstSend, 0, TargetIdToFirstSend.Length);
+            }
+
+            int numClocks = NumThreads * NumSteps;
+
+            temp = Vcs.Length;
+
+            while (temp < numClocks)
+            {
+                temp <<= 1;
+            }
+
+            if (Vcs.Length < temp)
+            {
+                Vcs = new int[temp];
+            }
+
+            Races.Clear();
+            RaceReplaySuffix.Clear();
+            MissingThreadIds.Clear();
+            ReplayRaceIndex = 0;
+        }
+    }
+}

--- a/Source/SchedulingStrategies/Strategies/DPOR/DPORStrategy.cs
+++ b/Source/SchedulingStrategies/Strategies/DPOR/DPORStrategy.cs
@@ -1,0 +1,280 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="DPORStrategy.cs">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// 
+//      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+using Microsoft.PSharp.TestingServices.SchedulingStrategies.DPOR;
+
+namespace Microsoft.PSharp.TestingServices.SchedulingStrategies
+{
+    /// <summary>
+    /// Dynamic partial-order reduction (DPOR) scheduling strategy.
+    /// In fact, this uses the Source DPOR algorithm.
+    /// </summary>
+    public class DPORStrategy : ISchedulingStrategy
+    {
+        /// <summary>
+        /// The stack datastructure used to perform the
+        /// depth-first search.
+        /// </summary>
+        private readonly Stack Stack;
+
+        /// <summary>
+        /// The actual DPOR algorithm implementation.
+        /// </summary>
+        private readonly DPORAlgorithm Dpor;
+
+        /// <summary>
+        /// Whether to use sleep sets.
+        /// See <see cref="SleepSets"/>.
+        /// </summary>
+        private readonly bool UseSleepSets;
+
+        /// <summary>
+        /// If non-null, we perform random DPOR
+        /// using this RNG.
+        /// </summary>
+        private readonly IRandomNumberGenerator Rand;
+
+        /// <summary>
+        /// A way for the ISchedulable to assert conditions.
+        /// </summary>
+        private readonly IContract Contract;
+
+        // TODO: implement the step limit.
+        /// <summary>
+        /// The step limit.
+        /// </summary>
+        private readonly int StepLimit;
+
+        /// <summary>
+        /// Number of iterations.
+        /// </summary>
+        private int NumIterations;
+
+        /// <summary>
+        /// Creates the DPOR strategy.
+        /// </summary>
+        public DPORStrategy(IContract contract, IRandomNumberGenerator rand = null, int stepLimit = -1, bool useSleepSets = true, bool dpor = true)
+        {
+            Contract = contract;
+            Rand = rand;
+            StepLimit = stepLimit;
+            Stack = new Stack(rand, Contract);
+            Dpor = dpor ? new DPORAlgorithm(Contract) : null;
+            UseSleepSets = rand == null && useSleepSets;
+            Reset();
+        }
+
+        /// <summary>
+        /// Returns the next choice to schedule.
+        /// </summary>
+        /// <param name="next">Next</param>
+        /// <param name="choices">Choices</param>
+        /// <param name="current">Curent</param>
+        /// <returns>Boolean</returns>
+        public bool GetNext(out ISchedulable next, List<ISchedulable> choices, ISchedulable current)
+        {
+            int currentSchedulableId = (int) current.Id;
+            // "Yield" and "Waiting for quiescence" hack.
+            if (choices.TrueForAll(info => !info.IsEnabled))
+            {
+                if (choices.Exists(info => info.NextOperationType == OperationType.Yield))
+                {
+                    foreach (var actorInfo in choices)
+                    {
+                        if (actorInfo.NextOperationType == OperationType.Yield)
+                        {
+                            actorInfo.IsEnabled = true;
+                        }
+                    }
+                }
+                else if (choices.Exists(
+                    info => info.NextOperationType == OperationType.WaitForQuiescence))
+                {
+                    foreach (var actorInfo in choices)
+                    {
+                        if (actorInfo.NextOperationType == OperationType.WaitForQuiescence)
+                        {
+                            actorInfo.IsEnabled = true;
+                        }
+                    }
+                }
+            }
+
+            bool added = Stack.Push(choices, currentSchedulableId);
+            TidEntryList top = Stack.GetTop();
+
+            if (added)
+            {
+                if (UseSleepSets)
+                {
+                    SleepSets.UpdateSleepSets(Stack, Contract);
+                }
+
+                if (Dpor == null)
+                {
+                    top.SetAllEnabledToBeBacktracked(Contract);
+                }
+                else if (Dpor.RaceReplaySuffix.Count > 0 && Dpor.ReplayRaceIndex < Dpor.RaceReplaySuffix.Count)
+                {
+                    // Replaying a race:
+                    var tidReplay = Dpor.RaceReplaySuffix[Dpor.ReplayRaceIndex];
+                    // Restore the nondet choices on the top of stack.
+                    top.NondetChoices = tidReplay.NondetChoices;
+                    // Add the replay tid to the backtrack set.
+                    top.List[tidReplay.Id].Backtrack = true;
+                    Contract.Assert(
+                        top.List[tidReplay.Id].Enabled 
+                        || top.List[tidReplay.Id].OpType == OperationType.Yield);
+                    ++Dpor.ReplayRaceIndex;
+                }
+                else
+                {
+                    // TODO: Here is where we can combine with another scheduler:
+                    // For now, we just do round-robin when doing DPOR and random when doing random DPOR.
+                    if (Rand == null)
+                    {
+                        top.AddFirstEnabledNotSleptToBacktrack(currentSchedulableId, Contract);
+                    }
+                    else
+                    {
+                        top.AddRandomEnabledNotSleptToBacktrack(Rand);
+                    }
+                }
+            }
+            else if (Rand != null)
+            {
+                // When doing random DPOR: we are replaying a schedule prefix so rewind the nondet choices now.
+                top.RewindNondetChoicesForReplay();
+            }
+
+            int nextTid = Stack.GetSelectedOrFirstBacktrackNotSlept(currentSchedulableId);
+
+            if (nextTid < 0)
+            {
+                next = null;
+                // TODO: if nextTidIndex == DPORAlgorithm.SLEEP_SET_BLOCKED then let caller know that this is the case.
+                // I.e. this is not deadlock.
+                return false;
+            }
+
+            if (top.TryGetSelected(Contract) != nextTid)
+            {
+                top.SetSelected(nextTid, Contract);
+            }
+
+            Contract.Assert(nextTid < choices.Count);
+            next = choices[nextTid];
+
+            // TODO: Part of yield hack.
+            if (!next.IsEnabled &&
+                next.NextOperationType == OperationType.Yield)
+            {
+//                // Uncomment to avoid waking a yielding thread.
+//                next = null;
+//                // TODO: let caller know that this is not deadlock.
+//                return false;
+                next.IsEnabled = true;
+            }
+
+            Contract.Assert(next.IsEnabled);
+            return true;
+        }
+
+        /// <summary>
+        /// Returns the next boolean choice.
+        /// </summary>
+        /// <param name="maxValue">Max value</param>
+        /// <param name="next">Next</param>
+        /// <returns>Boolean</returns>
+        public bool GetNextBooleanChoice(int maxValue, out bool next)
+        {
+            next = Stack.GetTop().MakeOrReplayNondetChoice(true, Rand, Contract) == 1;
+            return true;
+        }
+
+        /// <summary>
+        /// Returns the next integer choice.
+        /// </summary>
+        /// <param name="maxValue">Max value</param>
+        /// <param name="next">Next</param>
+        /// <returns>Boolean</returns>
+        public bool GetNextIntegerChoice(int maxValue, out int next)
+        {
+            // TODO: 
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
+        /// Returns the explored steps.
+        /// </summary>
+        /// <returns>Explored steps</returns>
+        public int GetScheduledSteps()
+        {
+            return Stack.GetNumSteps();
+        }
+
+        /// <summary>
+        /// True if the scheduling strategy has reached the max
+        /// scheduling steps for the given scheduling iteration.
+        /// </summary>
+        /// <returns>Boolean</returns>
+        public bool HasReachedMaxSchedulingSteps()
+        {
+            return StepLimit > 0 && Stack.GetNumSteps() >= StepLimit;
+        }
+
+        /// <summary>
+        /// Checks if this a fair scheduling strategy.
+        /// </summary>
+        /// <returns>Boolean</returns>
+        public bool IsFair()
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// Prepares the next scheduling iteration.
+        /// </summary>
+        /// <returns>False if all schedules have been explored</returns>
+        public bool PrepareForNextIteration()
+        {
+            ++NumIterations;
+            Dpor?.DoDPOR(Stack, Rand);
+
+            Stack.PrepareForNextSchedule();
+            return Rand != null || Stack.GetInternalSize() != 0;
+        }
+
+        /// <summary>
+        /// Resets the scheduling strategy.
+        /// </summary>
+        public void Reset()
+        {
+            Stack.Clear();
+            NumIterations = 0;
+        }
+
+        /// <summary>
+        /// Returns a textual description of the scheduling strategy.
+        /// </summary>
+        /// <returns>String</returns>
+        public string GetDescription()
+        {
+            return "DPOR";
+        }
+    }
+}

--- a/Source/SchedulingStrategies/Strategies/DPOR/DPORStrategy.cs
+++ b/Source/SchedulingStrategies/Strategies/DPOR/DPORStrategy.cs
@@ -249,6 +249,23 @@ namespace Microsoft.PSharp.TestingServices.SchedulingStrategies
         }
 
         /// <summary>
+        /// Returns or forces the next integer choice.
+        /// </summary>
+        /// <param name="maxValue">Max value</param>
+        /// <param name="next">Next</param>
+        /// <returns>Boolean</returns>
+        private bool GetNextIntegerChoiceHelper(int maxValue, ref int? next)
+        {
+            if (next != null)
+            {
+                AbdandonReplay(true);
+                return true;
+            }
+            next = Stack.GetTop().MakeOrReplayNondetChoice(false, Rand, Contract);
+            return true;
+        }
+
+        /// <summary>
         /// Abandon the replay of a schedule prefix and/or a race suffice.
         /// </summary>
         private void AbdandonReplay(bool clearNonDet)
@@ -299,8 +316,11 @@ namespace Microsoft.PSharp.TestingServices.SchedulingStrategies
         /// <returns>Boolean</returns>
         public bool GetNextIntegerChoice(int maxValue, out int next)
         {
-            // TODO: 
-            throw new System.NotImplementedException();
+            int? nextTemp = null;
+            GetNextIntegerChoiceHelper(maxValue, ref nextTemp);
+            Contract.Assert(nextTemp != null);
+            next = nextTemp.Value;
+            return true;
         }
 
         /// <summary>
@@ -342,7 +362,12 @@ namespace Microsoft.PSharp.TestingServices.SchedulingStrategies
         /// <returns>Boolean</returns>
         public void ForceNextIntegerChoice(int maxValue, int next)
         {
-            throw new NotImplementedException();
+            int? nextTemp = next;
+            bool res = GetNextIntegerChoiceHelper(maxValue, ref nextTemp);
+            Contract.Assert(res, "DPOR scheduler refused to schedule a forced integer choice.");
+            Contract.Assert(
+                nextTemp.HasValue && nextTemp.Value == next,
+                "DPOR scheduler changed forced next integer choice.");
         }
 
         /// <summary>

--- a/Source/SchedulingStrategies/Strategies/DPOR/NonDetChoice.cs
+++ b/Source/SchedulingStrategies/Strategies/DPOR/NonDetChoice.cs
@@ -1,0 +1,35 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="NonDetChoice.cs">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// 
+//      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace Microsoft.PSharp.TestingServices.SchedulingStrategies.DPOR
+{
+    /// <summary>
+    /// Stores the outcome of a nondetereminstic (nondet) choice.
+    /// </summary>
+    internal struct NonDetChoice
+    {
+        /// <summary>
+        /// Is this nondet choice a boolean choice?
+        /// If so, <see cref="Choice"/> is 0 or 1.
+        /// Otherwise, it can be any int value.
+        /// </summary>
+        public bool IsBoolChoice;
+
+        /// <summary>
+        /// The nondet choice; 0 or 1 if this is a bool choice;
+        /// otherwise, any int.
+        /// </summary>
+        public int Choice;
+    }
+}

--- a/Source/SchedulingStrategies/Strategies/DPOR/Race.cs
+++ b/Source/SchedulingStrategies/Strategies/DPOR/Race.cs
@@ -1,0 +1,44 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="Race.cs">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// 
+//      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace Microsoft.PSharp.TestingServices.SchedulingStrategies.DPOR
+{
+    /// <summary>
+    /// Represents a race (two visible operation that are concurrent but dependent)
+    /// that can be reversed to reach a different terminal state.
+    /// </summary>
+    internal class Race
+    {
+        /// <summary>
+        /// The index of the first racing visible operation.
+        /// </summary>
+        public int A;
+
+        /// <summary>
+        /// The index of the second racing visible operation.
+        /// </summary>
+        public int B;
+
+        /// <summary>
+        /// Construct a race.
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        public Race(int a, int b)
+        {
+            A = a;
+            B = b;
+        }
+    }
+}

--- a/Source/SchedulingStrategies/Strategies/DPOR/SleepSets.cs
+++ b/Source/SchedulingStrategies/Strategies/DPOR/SleepSets.cs
@@ -1,0 +1,100 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="SleepSets.cs">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// 
+//      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace Microsoft.PSharp.TestingServices.SchedulingStrategies.DPOR
+{
+    /// <summary>
+    /// Sleep sets is a reduction technique that can be in addition to DPOR
+    /// or on its own.
+    /// </summary>
+    internal static class SleepSets
+    {
+        /// <summary>
+        /// Update the sleep sets for the top operation on the stack.
+        /// This will look at the second from top element in the stack
+        /// and copy forward the sleep set, excluding threads that are dependent
+        /// with the executed operation.
+        /// </summary>
+        /// <param name="stack">Stack</param>
+        /// <param name="contract">IContract</param>
+        public static void UpdateSleepSets(Stack stack, IContract contract)
+        {
+            if (stack.GetNumSteps() <= 1)
+            {
+                return;
+            }
+
+            TidEntryList prevTop = stack.GetSecondFromTop();
+            TidEntry prevSelected = prevTop.List[prevTop.GetSelected(contract)];
+
+            TidEntryList currTop = stack.GetTop();
+
+            // For each thread on the top of stack (except previously selected thread and new threads):
+            //   if thread was slept previously 
+            //   and thread's op was independent with selected op then:
+            //     the thread is still slept.
+            //   else: not slept.
+
+            for (int i = 0; i < prevTop.List.Count; i++)
+            {
+                if (i == prevSelected.Id)
+                {
+                    continue;
+                }
+                if (prevTop.List[i].Sleep && !IsDependent(prevTop.List[i], prevSelected))
+                {
+                    currTop.List[i].Sleep = true;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Used to test if two operations are dependent.
+        /// However, it is not perfect and it assumes we are only checking
+        /// co-enabled operations from the same scheduling point.
+        /// Thus, the following will always appear to be independent,
+        /// even though this is not always the case:
+        /// Create and Start, Send and Receive.
+        /// </summary>
+        public static bool IsDependent(TidEntry a, TidEntry b)
+        {
+            // This method will not detect the dependency between 
+            // Create and Start (because Create's target id is always -1), 
+            // but this is probably fine because we will never be checking that;
+            // we only check enabled ops against other enabled ops.
+            // Similarly, we assume that Send and Receive will always be independent
+            // because the Send would need to enable the Receive to be dependent.
+            // Receives are independent as they will always be from different threads,
+            // but they should always have different target ids anyway.
+
+            if (
+                a.TargetId != b.TargetId || 
+                a.TargetType != b.TargetType || 
+                a.TargetId == -1 || 
+                b.TargetId == -1)
+            {
+                return false;
+            }
+
+            // Same target:
+
+            if (a.TargetType == OperationTargetType.Inbox)
+            {
+                return a.OpType == OperationType.Send && b.OpType == OperationType.Send;
+            }
+
+            return true;
+        }
+    }
+}

--- a/Source/SchedulingStrategies/Strategies/DPOR/Stack.cs
+++ b/Source/SchedulingStrategies/Strategies/DPOR/Stack.cs
@@ -1,0 +1,236 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="Stack.cs">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// 
+//      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.PSharp.TestingServices.SchedulingStrategies.DPOR
+{
+    /// <summary>
+    /// The stack datastructure used by <see cref="DPORStrategy"/> to perform the
+    /// depth-first search.
+    /// </summary>
+    internal class Stack
+    {
+        /// <summary>
+        /// The actual stack.
+        /// </summary>
+        public readonly List<TidEntryList> StackInternal = new List<TidEntryList>();
+
+        private int NextStackPos;
+
+        private readonly IRandomNumberGenerator Rand;
+
+        private readonly IContract Contract;
+
+        /// <summary>
+        /// If no thread id can be chosen,
+        /// a negative thread id is returned.
+        /// This indicates that some threads
+        /// were enabled, but they were all slept (due to <see cref="SleepSets"/>).
+        /// </summary>
+        public const int SLEEP_SET_BLOCKED = -2;
+
+        /// <summary>
+        /// Construct the stack.
+        /// </summary>
+        /// <param name="rand">If non-null, then randomized DPOR is assumed.
+        /// The stack will not be backtracked in <see cref="PrepareForNextSchedule"/>.</param>
+        /// <param name="contract">IContract</param>
+        public Stack(IRandomNumberGenerator rand, IContract contract)
+        {
+            Rand = rand;
+            Contract = contract;
+        }
+
+        /// <summary>
+        /// Push a list of tid entries onto the stack.
+        /// If we are replaying, this will verify that
+        /// the list is what we expected.
+        /// </summary>
+        /// <param name="machines"></param>
+        /// <param name="prevThreadIndex"></param>
+        /// <returns>true if a new element was added to the stack, otherwise the existing entry was verified</returns>
+        public bool Push(List<ISchedulable> machines, int prevThreadIndex)
+        {
+            List<TidEntry> list = new List<TidEntry>();
+
+            foreach (var machineInfo in machines)
+            {
+                list.Add(
+                    new TidEntry(
+                        (int) machineInfo.Id,
+                        machineInfo.IsEnabled,
+                        machineInfo.NextOperationType,
+                        machineInfo.NextTargetType,
+                        (int) machineInfo.NextTargetId,
+                        (int) machineInfo.NextOperationMatchingSendIndex));
+            }
+            
+            Contract.Assert(NextStackPos <= StackInternal.Count, "DFS strategy unexpected stack state.");
+
+            bool added = NextStackPos == StackInternal.Count;
+
+            if (added)
+            {
+                StackInternal.Add(new TidEntryList(list));
+            }
+            else
+            {
+                CheckMatches(list);
+            }
+
+            ++NextStackPos;
+
+            return added;
+        }
+
+        /// <summary>
+        /// Get the number of entries on the stack 
+        /// (not including those that are yet to be replayed).
+        /// </summary>
+        /// <returns></returns>
+        public int GetNumSteps()
+        {
+            return NextStackPos;
+        }
+
+        /// <summary>
+        /// Get the real size of the stack
+        /// (including entries that are yet to be replayed).
+        /// </summary>
+        /// <returns></returns>
+        public int GetInternalSize()
+        {
+            return StackInternal.Count;
+        }
+
+        /// <summary>
+        /// Get the top entry of the stack.
+        /// </summary>
+        /// <returns></returns>
+        public TidEntryList GetTop()
+        {
+            return StackInternal[NextStackPos - 1];
+        }
+
+        /// <summary>
+        /// Get the second from top entry of the stack.
+        /// </summary>
+        /// <returns></returns>
+        public TidEntryList GetSecondFromTop()
+        {
+            return StackInternal[NextStackPos - 2];
+        }
+
+        /// <summary>
+        /// Gets the top of stack and also ensures that this is the real top of stack.
+        /// </summary>
+        /// <returns></returns>
+        public TidEntryList GetTopAsRealTop()
+        {
+            Contract.Assert(NextStackPos == StackInternal.Count, "DFS Strategy: top of stack is not aligned.");
+            return GetTop();
+        }
+
+        /// <summary>
+        /// Get the next thread to schedule: either the preselected thread entry
+        /// from the current schedule prefix that we are replaying or the first
+        /// suitable thread entry from the real top of the stack.
+        /// </summary>
+        public int GetSelectedOrFirstBacktrackNotSlept(int startingFrom)
+        {
+            var top = GetTop();
+
+            if (StackInternal.Count > NextStackPos)
+            {
+                return top.GetSelected(Contract);
+            }
+
+            int res = top.TryGetSelected(Contract);
+            return res >= 0 ? res : top.GetFirstBacktrackNotSlept(startingFrom);
+        }
+
+        /// <summary>
+        /// Prepare for the next schedule by popping entries from the stack
+        /// until we find some tid entries that are not slept.
+        /// </summary>
+        public void PrepareForNextSchedule()
+        {
+            if (Rand != null)
+            {
+                NextStackPos = 0;
+                return;
+
+            }
+
+            // Deadlock / sleep set blocked; no selected tid entry.
+            {
+                TidEntryList top = GetTopAsRealTop();
+                
+                if (top.IsNoneSelected(Contract))
+                {
+                    Pop();
+                }
+            }
+            
+
+            // Pop until there are some tid entries that are not done/slept OR stack is empty.
+            while (StackInternal.Count > 0)
+            {
+                TidEntryList top = GetTopAsRealTop();
+
+                if (top.BacktrackNondetChoices(Contract))
+                {
+                    break;
+                }
+
+                top.SetSelectedToSleep(Contract);
+                top.ClearSelected(Contract);
+
+                if (!top.AllDoneOrSlept())
+                {
+                    break;
+                }
+
+                Pop();
+            }
+
+            NextStackPos = 0;
+        }
+
+        private void Pop()
+        {
+            Contract.Assert(NextStackPos == StackInternal.Count, "DFS Strategy: top of stack is not aligned.");
+            StackInternal.RemoveAt(StackInternal.Count - 1);
+            --NextStackPos;
+        }
+
+        private void CheckMatches(List<TidEntry> list)
+        {
+            Contract.Assert(
+                StackInternal[NextStackPos].List.SequenceEqual(list, TidEntry.ComparerSingleton), 
+                "DFS strategy detected nondeterminism when replaying.");
+        }
+
+        /// <summary>
+        /// Clear the stack.
+        /// </summary>
+        public void Clear()
+        {
+            StackInternal.Clear();
+        }
+    }
+}

--- a/Source/SchedulingStrategies/Strategies/DPOR/Stack.cs
+++ b/Source/SchedulingStrategies/Strategies/DPOR/Stack.cs
@@ -232,5 +232,13 @@ namespace Microsoft.PSharp.TestingServices.SchedulingStrategies.DPOR
         {
             StackInternal.Clear();
         }
+
+        /// <summary>
+        /// Clear all entries beyond the current top of stack.
+        /// </summary>
+        public void ClearAboveTop()
+        {
+            StackInternal.RemoveRange(NextStackPos, StackInternal.Count - NextStackPos);
+        }
     }
 }

--- a/Source/SchedulingStrategies/Strategies/DPOR/TidEntry.cs
+++ b/Source/SchedulingStrategies/Strategies/DPOR/TidEntry.cs
@@ -1,0 +1,134 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="TidEntry.cs">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// 
+//      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Collections.Generic;
+
+namespace Microsoft.PSharp.TestingServices.SchedulingStrategies.DPOR
+{
+    /// <summary>
+    /// Thread entry stored on the stack of a depth-first search to track which threads existed
+    /// and whether they have been executed already, etc.
+    /// </summary>
+    internal class TidEntry
+    {
+        /// <summary>
+        /// The id/index of this thread in the original thread creation order list of threads.
+        /// </summary>
+        public int Id;
+
+        /// <summary>
+        /// Is the thread enabled?
+        /// </summary>
+        public bool Enabled;
+
+        /// <summary>
+        /// Skip exploring this thread from here.
+        /// </summary>
+        public bool Sleep;
+
+        /// <summary>
+        /// Backtrack to this transition?
+        /// </summary>
+        public bool Backtrack;
+
+        /// <summary>
+        /// Operation type.
+        /// </summary>
+        public OperationType OpType;
+
+        /// <summary>
+        /// Target type. E.g. thread, queue, mutex, variable.
+        /// </summary>
+        public OperationTargetType TargetType;
+
+        /// <summary>
+        /// Target of the operation.
+        /// </summary>
+        public int TargetId;
+
+        /// <summary>
+        /// For a receive operation: the step of the corresponding send.
+        /// </summary>
+        public int SendStepIndex;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="enabled"></param>
+        /// <param name="opType"></param>
+        /// <param name="targetType"></param>
+        /// <param name="targetId"></param>
+        /// <param name="sendStepIndex"></param>
+        public TidEntry(int id, bool enabled, OperationType opType, OperationTargetType targetType, int targetId, int sendStepIndex)
+        {
+            Id = id;
+            Enabled = enabled;
+            Sleep = false;
+            Backtrack = false;
+            OpType = opType;
+            TargetType = targetType;
+            TargetId = targetId;
+            SendStepIndex = sendStepIndex;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public static readonly Comparer ComparerSingleton = new Comparer();
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public class Comparer : IEqualityComparer<TidEntry>
+        {
+            #region Implementation of IEqualityComparer<in Comparer>
+
+            /// <summary>Determines whether the specified objects are equal.</summary>
+            /// <returns>true if the specified objects are equal; otherwise, false.</returns>
+            /// <param name="x">The first object to compare.</param>
+            /// <param name="y">The second object to compare.</param>
+            public bool Equals(TidEntry x, TidEntry y)
+            {
+                return
+                    x.OpType == y.OpType &&
+                    (x.OpType == OperationType.Yield || x.Enabled == y.Enabled) &&
+                    x.Id == y.Id &&
+                    x.TargetId == y.TargetId &&
+                    x.TargetType == y.TargetType;
+            }
+
+            /// <summary>Returns a hash code for the specified object.</summary>
+            /// <returns>A hash code for the specified object.</returns>
+            /// <param name="obj">The <see cref="T:System.Object" /> for which a hash code is to be returned.</param>
+            /// <exception cref="T:System.ArgumentNullException">The type of <paramref name="obj" /> is a reference type and <paramref name="obj" /> is null.</exception>
+            public int GetHashCode(TidEntry obj)
+            {
+                unchecked
+                {
+                    int hash = 17;
+                    hash = hash * 23 + obj.Id.GetHashCode();
+                    hash = hash * 23 + obj.OpType.GetHashCode();
+                    hash = hash * 23 + obj.TargetId.GetHashCode();
+                    hash = hash * 23 + obj.TargetType.GetHashCode();
+                    hash = hash * 23 + (obj.OpType == OperationType.Yield ? true.GetHashCode() : obj.Enabled.GetHashCode());
+                    return hash;
+                }
+            }
+
+            #endregion
+        }
+
+    }
+}

--- a/Source/SchedulingStrategies/Strategies/DPOR/TidEntryList.cs
+++ b/Source/SchedulingStrategies/Strategies/DPOR/TidEntryList.cs
@@ -1,0 +1,434 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="TidEntryList.cs">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// 
+//      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Microsoft.PSharp.TestingServices.SchedulingStrategies.DPOR
+{
+    /// <summary>
+    /// The elements of the <see cref="Stack"/> 
+    /// used by <see cref="DPORStrategy"/>.
+    /// Stores a list of <see cref="TidEntry"/>;
+    /// one for each <see cref="ISchedulable"/>.
+    /// </summary>
+    internal class TidEntryList
+    {
+        /// <summary>
+        /// The actual list.
+        /// </summary>
+        public readonly List<TidEntry> List;
+
+        private int SelectedEntry;
+
+        /// <summary>
+        /// A list of random choices made by the <see cref="SelectedEntry"/> thread as part of its
+        /// visible operation.
+        /// Can be null.
+        /// </summary>
+        public List<NonDetChoice> NondetChoices;
+
+        /// <summary>
+        /// When replaying/adding nondet choices,
+        /// this is the index of the next nondet choice.
+        /// </summary>
+        private int NextNondetChoiceIndex;
+
+        /// <summary>
+        /// Construct a TidEntryList.
+        /// </summary>
+        /// <param name="list"></param>
+        public TidEntryList(List<TidEntry> list)
+        {
+            List = list;
+            SelectedEntry = -1;
+            NondetChoices = null;
+            NextNondetChoiceIndex = 0;
+        }
+
+        /// <summary>
+        /// Get a nondet choice.
+        /// This may replay a nondet choice or make (and record) a new nondet choice.
+        /// </summary>
+        /// <param name="isBoolChoice">If true, a boolean choice; otherwise, an int choice.</param>
+        /// <param name="rand">Random</param>
+        /// <param name="contract">IContract</param>
+        public int MakeOrReplayNondetChoice(bool isBoolChoice, IRandomNumberGenerator rand, IContract contract)
+        {
+            contract.Assert(
+                rand != null || isBoolChoice,
+                "A DFS DPOR exploration of int nondeterminstic choices " +
+                "is not currently supported because this won't scale.");
+
+            if (NondetChoices == null)
+            {
+                NondetChoices = new List<NonDetChoice>();
+            }
+
+
+            if (NextNondetChoiceIndex < NondetChoices.Count)
+            {
+                // Replay:
+                NonDetChoice choice = NondetChoices[NextNondetChoiceIndex];
+                ++NextNondetChoiceIndex;
+                contract.Assert(choice.IsBoolChoice == isBoolChoice);
+                return choice.Choice;
+            }
+
+            // Adding a choice.
+            contract.Assert(NextNondetChoiceIndex == NondetChoices.Count);
+            NonDetChoice ndc = new NonDetChoice
+            {
+                IsBoolChoice = isBoolChoice,
+                Choice = rand == null ? 0 : (isBoolChoice ? rand.Next(2) : rand.Next())
+            };
+            NondetChoices.Add(ndc);
+            ++NextNondetChoiceIndex;
+            return ndc.Choice;
+        }
+
+        /// <summary>
+        /// This method is used in a DFS exploration of nondet choice.
+        /// It will pop off bool choices that are 1 until
+        /// it reaches a 0 that will then be changed to a 1.
+        /// The NextNondetChoiceIndex will be reset ready for replay.
+        /// </summary>
+        /// <param name="contract">IContract</param>
+        /// <returns>false if there are no more nondet choices to explore</returns>
+        public bool BacktrackNondetChoices(IContract contract)
+        {
+            if (NondetChoices == null)
+            {
+                return false;
+            }
+
+            contract.Assert(NextNondetChoiceIndex == NondetChoices.Count);
+
+            NextNondetChoiceIndex = 0;
+
+            while (NondetChoices.Count > 0)
+            {
+                NonDetChoice choice = NondetChoices[NondetChoices.Count - 1];
+                contract.Assert(choice.IsBoolChoice, "DFS DPOR only supports bool choices.");
+                if (choice.Choice == 0)
+                {
+                    choice.Choice = 1;
+                    NondetChoices[NondetChoices.Count - 1] = choice;
+                    return true;
+                }
+                contract.Assert(choice.Choice == 1, "Unexpected choice value.");
+                NondetChoices.RemoveAt(NondetChoices.Count - 1);
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Prepares the list of nondet choices for replay.
+        /// This is used by random DPOR, which does not need to
+        /// backtrack individual nondet choices, but may need to replay all of them.
+        /// </summary>
+        public void RewindNondetChoicesForReplay()
+        {
+            NextNondetChoiceIndex = 0;
+        }
+
+        /// <summary>
+        /// Add all enabled threads to the backtrack set.
+        /// </summary>
+        /// <param name="contract">IContract</param>
+        public void SetAllEnabledToBeBacktracked(IContract contract)
+        {
+            foreach (var tidEntry in List)
+            {
+                if (tidEntry.Enabled)
+                {
+                    tidEntry.Backtrack = true;
+                    // TODO: Remove?
+                    contract.Assert(tidEntry.Enabled);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Utility method to show the enabled threads.
+        /// </summary>
+        /// <returns>string</returns>
+        public string ShowEnabled()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.Append("[");
+            foreach (var tidEntry in List)
+            {
+                if (!tidEntry.Enabled)
+                {
+                    continue;
+                }
+                if (tidEntry.Id == SelectedEntry)
+                {
+                    sb.Append("*");
+                }
+                sb.Append("(");
+                sb.Append(tidEntry.Id);
+                sb.Append(", ");
+                sb.Append(tidEntry.OpType);
+                sb.Append(", ");
+                sb.Append(tidEntry.TargetType);
+                sb.Append("-");
+                sb.Append(tidEntry.TargetId);
+                sb.Append(") ");
+            }
+
+            sb.Append("]");
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Utility method to show the selected thread.
+        /// </summary>
+        /// <param name="contract">IContract</param>
+        public string ShowSelected(IContract contract)
+        {
+            int selectedIndex = TryGetSelected(contract);
+            if (selectedIndex < 0)
+            {
+                return "-";
+            }
+
+            TidEntry selected = List[selectedIndex];
+            int priorSend = selected.OpType == OperationType.Receive
+                ? selected.SendStepIndex
+                : -1;
+
+            return $"({selected.Id}, {selected.OpType}, {selected.TargetType}, {selected.TargetId}, {priorSend})";
+        }
+
+        /// <summary>
+        /// Utility method to show the threads in the backtrack set.
+        /// </summary>
+        /// <returns>string</returns>
+        public string ShowBacktrack()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.Append("[");
+            foreach (var tidEntry in List)
+            {
+                if (!tidEntry.Backtrack)
+                {
+                    continue;
+                }
+                if (tidEntry.Id == SelectedEntry)
+                {
+                    sb.Append("*");
+                }
+                sb.Append("(");
+                sb.Append(tidEntry.Id);
+                sb.Append(", ");
+                sb.Append(tidEntry.OpType);
+                sb.Append(", ");
+                sb.Append(tidEntry.TargetType);
+                sb.Append("-");
+                sb.Append(tidEntry.TargetId);
+                sb.Append(") ");
+            }
+
+            sb.Append("]");
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Gets the first thread in backtrack that is not slept.
+        /// </summary>
+        /// <returns></returns>
+        public int GetFirstBacktrackNotSlept(int startingFrom)
+        {
+            int size = List.Count;
+            int i = startingFrom;
+            bool foundSlept = false;
+            for (int count = 0; count < size; ++count)
+            {
+                if (List[i].Backtrack &&
+                    !List[i].Sleep)
+                {
+                    return i;
+                }
+                if (List[i].Sleep)
+                {
+                    foundSlept = true;
+                }
+                ++i;
+                if (i >= size)
+                {
+                    i = 0;
+                }
+            }
+
+            return foundSlept ? Stack.SLEEP_SET_BLOCKED : -1;
+        }
+
+        /// <summary>
+        /// Gets all threads in backtrack that are not slept and not selected.
+        /// </summary>
+        /// <param name="contract">IContract</param>
+        public List<int> GetAllBacktrackNotSleptNotSelected(IContract contract)
+        {
+            List<int> res = new List<int>();
+            for (int i = 0; i < List.Count; ++i)
+            {
+                if (List[i].Backtrack &&
+                    !List[i].Sleep &&
+                    List[i].Id != SelectedEntry)
+                {
+                    contract.Assert(List[i].Enabled);
+                    res.Add(i);
+                }
+            }
+
+            return res;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns>true if some threads are: in backtrack and not slept and not selected.</returns>
+        public bool HasBacktrackNotSleptNotSelected()
+        {
+            foreach (TidEntry t in List)
+            {
+                if (t.Backtrack &&
+                    !t.Sleep &&
+                    t.Id != SelectedEntry)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Sets the selected thread to be slept.
+        /// </summary>
+        /// <param name="contract">IContract</param>
+        public void SetSelectedToSleep(IContract contract)
+        {
+            List[GetSelected(contract)].Sleep = true;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns>true if all threads are done or slept.</returns>
+        public bool AllDoneOrSlept()
+        {
+            return GetFirstBacktrackNotSlept(0) < 0;
+        }
+
+        /// <summary>
+        /// Tries to get the single selected thread.
+        /// </summary>
+        /// <param name="contract">IContract</param>
+        /// <returns>The selected thread index or -1 if no thread is selected.</returns>
+        public int TryGetSelected(IContract contract)
+        {
+            return SelectedEntry;
+        }
+
+        /// <summary>
+        /// Are no threads selected?
+        /// </summary>
+        /// <param name="contract">IContract</param>
+        public bool IsNoneSelected(IContract contract)
+        {
+            return TryGetSelected(contract) < 0;
+        }
+
+        /// <summary>
+        /// Gets the selected thread.
+        /// Asserts that there is a selected thread.
+        /// </summary>
+        /// <param name="contract">IContract</param>
+        public int GetSelected(IContract contract)
+        {
+            int res = TryGetSelected(contract);
+            contract.Assert(res != -1, "DFS Strategy: No selected tid entry!");
+            return res;
+        }
+
+        /// <summary>
+        /// Deselect the selected thread.
+        /// </summary>
+        /// <param name="contract">IContract</param>
+        public void ClearSelected(IContract contract)
+        {
+            SelectedEntry = -1;
+        }
+
+        /// <summary>
+        /// Add the first enabled and not slept thread to the backtrack set.
+        /// </summary>
+        /// <param name="startingFrom">a thread id to start from</param>
+        /// <param name="contract">IContract</param>
+        public void AddFirstEnabledNotSleptToBacktrack(int startingFrom, IContract contract)
+        {
+            int size = List.Count;
+            int i = startingFrom;
+            for (int count = 0; count < size; ++count)
+            {
+                if (List[i].Enabled &&
+                    !List[i].Sleep)
+                {
+                    List[i].Backtrack = true;
+                    // TODO: Remove?
+                    contract.Assert(List[i].Enabled);
+                    return;
+                }
+                ++i;
+                if (i >= size)
+                {
+                    i = 0;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Add a random enabled and not slept thread to the backtrack set.
+        /// </summary>
+        /// <param name="rand"></param>
+        public void AddRandomEnabledNotSleptToBacktrack(IRandomNumberGenerator rand)
+        {
+            var enabledNotSlept = List.Where(e => e.Enabled && !e.Sleep).ToList();
+            if (enabledNotSlept.Count > 0)
+            {
+                int choice = rand.Next(enabledNotSlept.Count);
+                enabledNotSlept[choice].Backtrack = true;
+            }
+        }
+
+        /// <summary>
+        /// Sets the selected thread id.
+        /// There must not already be a selected thread id.
+        /// </summary>
+        /// <param name="tid">thread id to be set to selected</param>
+        /// <param name="contract">IContract</param>
+        public void SetSelected(int tid, IContract contract)
+        {
+            contract.Assert(SelectedEntry < 0);
+            contract.Assert(tid >= 0 && tid < List.Count);
+            SelectedEntry = tid;
+        }
+    }
+}

--- a/Source/SchedulingStrategies/Strategies/DPOR/TidEntryList.cs
+++ b/Source/SchedulingStrategies/Strategies/DPOR/TidEntryList.cs
@@ -147,6 +147,18 @@ namespace Microsoft.PSharp.TestingServices.SchedulingStrategies.DPOR
         }
 
         /// <summary>
+        /// Clears the list of nondet choices for replay from the next nondet choice onwards.
+        /// That is, nondet choices that have already been replayed remain in the list.
+        /// </summary>
+        public void ClearNondetChoicesFromNext()
+        {
+            if (NextNondetChoiceIndex < NondetChoices.Count)
+            {
+                NondetChoices.RemoveRange(NextNondetChoiceIndex, NondetChoices.Count - NextNondetChoiceIndex);
+            }
+        }
+
+        /// <summary>
         /// Add all enabled threads to the backtrack set.
         /// </summary>
         /// <param name="contract">IContract</param>
@@ -402,6 +414,17 @@ namespace Microsoft.PSharp.TestingServices.SchedulingStrategies.DPOR
                     i = 0;
                 }
             }
+        }
+
+        /// <summary>
+        /// Add a thread to the backtrack set.
+        /// </summary>
+        /// <param name="tid">a thread id to add</param>
+        /// <param name="contract">IContract</param>
+        public void AddToBacktrack(int tid, IContract contract)
+        {
+            List[tid].Backtrack = true;
+            contract.Assert(List[tid].Enabled);
         }
 
         /// <summary>

--- a/Source/SchedulingStrategies/Strategies/DPOR/TidEntryList.cs
+++ b/Source/SchedulingStrategies/Strategies/DPOR/TidEntryList.cs
@@ -152,7 +152,7 @@ namespace Microsoft.PSharp.TestingServices.SchedulingStrategies.DPOR
         /// </summary>
         public void ClearNondetChoicesFromNext()
         {
-            if (NextNondetChoiceIndex < NondetChoices.Count)
+            if (NondetChoices != null && NextNondetChoiceIndex < NondetChoices.Count)
             {
                 NondetChoices.RemoveRange(NextNondetChoiceIndex, NondetChoices.Count - NextNondetChoiceIndex);
             }

--- a/Source/SchedulingStrategies/Strategies/DPOR/TidForRaceReplay.cs
+++ b/Source/SchedulingStrategies/Strategies/DPOR/TidForRaceReplay.cs
@@ -1,0 +1,46 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="TidForRaceReplay.cs">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// 
+//      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Collections.Generic;
+
+namespace Microsoft.PSharp.TestingServices.SchedulingStrategies.DPOR
+{
+    /// <summary>
+    /// Stores a thread id for replaying a race.
+    /// Also stores the nondeterministic choices made by a thread.
+    /// </summary>
+    internal class TidForRaceReplay
+    {
+        /// <summary>
+        /// The thread id for replay.
+        /// </summary>
+        public readonly int Id;
+
+        /// <summary>
+        /// The list of nondet choices for replay.
+        /// </summary>
+        public readonly List<NonDetChoice> NondetChoices;
+
+        /// <summary>
+        /// Construct a thread id for replay.
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="nondetChoices"></param>
+        public TidForRaceReplay(int id, List<NonDetChoice> nondetChoices)
+        {
+            Id = id;
+            NondetChoices = nondetChoices;
+        }
+    }
+}

--- a/Source/SchedulingStrategies/Strategies/DelayBounded/DelayBoundingStrategy.cs
+++ b/Source/SchedulingStrategies/Strategies/DelayBounded/DelayBoundingStrategy.cs
@@ -160,6 +160,40 @@ namespace Microsoft.PSharp.TestingServices.SchedulingStrategies
         }
 
         /// <summary>
+        /// Forces the next choice to schedule.
+        /// </summary>
+        /// <param name="next">Next</param>
+        /// <param name="choices">Choices</param>
+        /// <param name="current">Curent</param>
+        /// <returns>Boolean</returns>
+        public void ForceNext(ISchedulable next, List<ISchedulable> choices, ISchedulable current)
+        {
+            ScheduledSteps++;
+        }
+
+        /// <summary>
+        /// Forces the next boolean choice.
+        /// </summary>
+        /// <param name="maxValue">Max value</param>
+        /// <param name="next">Next</param>
+        /// <returns>Boolean</returns>
+        public void ForceNextBooleanChoice(int maxValue, bool next)
+        {
+            ScheduledSteps++;
+        }
+
+        /// <summary>
+        /// Forces the next integer choice.
+        /// </summary>
+        /// <param name="maxValue">Max value</param>
+        /// <param name="next">Next</param>
+        /// <returns>Boolean</returns>
+        public void ForceNextIntegerChoice(int maxValue, int next)
+        {
+            ScheduledSteps++;
+        }
+
+        /// <summary>
         /// Prepares for the next scheduling iteration. This is invoked
         /// at the end of a scheduling iteration. It must return false
         /// if the scheduling strategy should stop exploring.

--- a/Source/SchedulingStrategies/Strategies/Probabilistic/PCTStrategy.cs
+++ b/Source/SchedulingStrategies/Strategies/Probabilistic/PCTStrategy.cs
@@ -107,17 +107,8 @@ namespace Microsoft.PSharp.TestingServices.SchedulingStrategies
         /// <returns>Boolean</returns>
         public bool GetNext(out ISchedulable next, List<ISchedulable> choices, ISchedulable current)
         {
-            var enabledChoices = choices.Where(choice => choice.IsEnabled).ToList();
-            if (enabledChoices.Count == 0)
-            {
-                next = null;
-                return false;
-            }
-
-            next = GetPrioritizedChoice(enabledChoices, current);
-            ScheduledSteps++;
-
-            return true;
+            next = null;
+            return GetNextHelper(ref next, choices, current);
         }
 
         /// <summary>
@@ -161,7 +152,33 @@ namespace Microsoft.PSharp.TestingServices.SchedulingStrategies
         /// <returns>Boolean</returns>
         public void ForceNext(ISchedulable next, List<ISchedulable> choices, ISchedulable current)
         {
+            GetNextHelper(ref next, choices, current);
+        }
+
+        /// <summary>
+        /// Returns or forces the next choice to schedule.
+        /// </summary>
+        /// <param name="next">Next</param>
+        /// <param name="choices">Choices</param>
+        /// <param name="current">Curent</param>
+        /// <returns>Boolean</returns>
+        private bool GetNextHelper(ref ISchedulable next, List<ISchedulable> choices, ISchedulable current)
+        {
+            var enabledChoices = choices.Where(choice => choice.IsEnabled).ToList();
+            if (enabledChoices.Count == 0)
+            {
+                return false;
+            }
+
+            ISchedulable highestEnabled = GetPrioritizedChoice(enabledChoices, current);
+            if (next == null)
+            {
+                next = highestEnabled;
+            }
+
             ScheduledSteps++;
+
+            return true;
         }
 
         /// <summary>

--- a/Source/SchedulingStrategies/Strategies/Probabilistic/PCTStrategy.cs
+++ b/Source/SchedulingStrategies/Strategies/Probabilistic/PCTStrategy.cs
@@ -153,6 +153,40 @@ namespace Microsoft.PSharp.TestingServices.SchedulingStrategies
         }
 
         /// <summary>
+        /// Forces the next choice to schedule.
+        /// </summary>
+        /// <param name="next">Next</param>
+        /// <param name="choices">Choices</param>
+        /// <param name="current">Curent</param>
+        /// <returns>Boolean</returns>
+        public void ForceNext(ISchedulable next, List<ISchedulable> choices, ISchedulable current)
+        {
+            ScheduledSteps++;
+        }
+
+        /// <summary>
+        /// Forces the next boolean choice.
+        /// </summary>
+        /// <param name="maxValue">Max value</param>
+        /// <param name="next">Next</param>
+        /// <returns>Boolean</returns>
+        public void ForceNextBooleanChoice(int maxValue, bool next)
+        {
+            ScheduledSteps++;
+        }
+
+        /// <summary>
+        /// Forces the next integer choice.
+        /// </summary>
+        /// <param name="maxValue">Max value</param>
+        /// <param name="next">Next</param>
+        /// <returns>Boolean</returns>
+        public void ForceNextIntegerChoice(int maxValue, int next)
+        {
+            ScheduledSteps++;
+        }
+
+        /// <summary>
         /// Prepares for the next scheduling iteration. This is invoked
         /// at the end of a scheduling iteration. It must return false
         /// if the scheduling strategy should stop exploring.

--- a/Source/SchedulingStrategies/Strategies/Probabilistic/RandomStrategy.cs
+++ b/Source/SchedulingStrategies/Strategies/Probabilistic/RandomStrategy.cs
@@ -116,6 +116,40 @@ namespace Microsoft.PSharp.TestingServices.SchedulingStrategies
         }
 
         /// <summary>
+        /// Forces the next choice to schedule.
+        /// </summary>
+        /// <param name="next">Next</param>
+        /// <param name="choices">Choices</param>
+        /// <param name="current">Curent</param>
+        /// <returns>Boolean</returns>
+        public void ForceNext(ISchedulable next, List<ISchedulable> choices, ISchedulable current)
+        {
+            ScheduledSteps++;
+        }
+
+        /// <summary>
+        /// Forces the next boolean choice.
+        /// </summary>
+        /// <param name="maxValue">Max value</param>
+        /// <param name="next">Next</param>
+        /// <returns>Boolean</returns>
+        public void ForceNextBooleanChoice(int maxValue, bool next)
+        {
+            ScheduledSteps++;
+        }
+
+        /// <summary>
+        /// Forces the next integer choice.
+        /// </summary>
+        /// <param name="maxValue">Max value</param>
+        /// <param name="next">Next</param>
+        /// <returns>Boolean</returns>
+        public void ForceNextIntegerChoice(int maxValue, int next)
+        {
+            ScheduledSteps++;
+        }
+
+        /// <summary>
         /// Prepares for the next scheduling iteration. This is invoked
         /// at the end of a scheduling iteration. It must return false
         /// if the scheduling strategy should stop exploring.

--- a/Source/SchedulingStrategies/Strategies/Special/BasicReductionStrategy.cs
+++ b/Source/SchedulingStrategies/Strategies/Special/BasicReductionStrategy.cs
@@ -1,0 +1,223 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="BasicReductionStrategy.cs">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// 
+//      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.PSharp.TestingServices.SchedulingStrategies
+{
+    /// <summary>
+    /// This strategy uses basic partial-order reduction to reduce
+    /// the choice-space for a provided child strategy.
+    /// </summary>
+    public sealed class BasicReductionStrategy : ISchedulingStrategy
+    {
+        /// <summary>
+        /// Type of reduction strategy.
+        /// </summary>
+        public enum ReductionStrategy
+        {
+            /// <summary>
+            /// No reduction.
+            /// </summary>
+            None,
+            /// <summary>
+            /// Reduction strategy that omits scheduling points.
+            /// </summary>
+            OmitSchedulingPoints,
+            /// <summary>
+            /// Reduction strategy that forces scheduling points.
+            /// </summary>
+            ForceSchedule
+        }
+
+        /// <summary>
+        /// The child strategy.
+        /// </summary>
+        private readonly ISchedulingStrategy ChildStrategy;
+
+        /// <summary>
+        /// The reduction strategy.
+        /// </summary>
+        private readonly ReductionStrategy Reduction;
+
+        private int ScheduledSteps;
+
+        private readonly int StepLimit;
+
+        private readonly bool ReportActualScheduledSteps;
+
+        /// <summary>
+        /// Creates a reduction strategy that reduces the choice-space for a child strategy.
+        /// </summary>
+        /// <param name="childStrategy">Child strategy.</param>
+        /// <param name="reductionStrategy">The reduction strategy used.</param>
+        /// <param name="stepLimit">The step limit.</param>
+        public BasicReductionStrategy(
+            ISchedulingStrategy childStrategy,
+            ReductionStrategy reductionStrategy,
+            int stepLimit = 0)
+        {
+            ChildStrategy = childStrategy;
+            Reduction = reductionStrategy;
+            ScheduledSteps = 0;
+            StepLimit = stepLimit;
+            ReportActualScheduledSteps = StepLimit != 0;
+        }
+
+        /// <summary>
+        /// Returns the next choice to schedule.
+        /// </summary>
+        /// <param name="next">Next</param>
+        /// <param name="choices">Choices</param>
+        /// <param name="current">Curent</param>
+        /// <returns>Boolean</returns>
+        public bool GetNext(out ISchedulable next, List<ISchedulable> choices, ISchedulable current)
+        {
+            ++ScheduledSteps;
+            switch (Reduction)
+            {
+                case ReductionStrategy.ForceSchedule:
+                {
+                    var partialOrderChoices =
+                        choices
+                            .Where(choice => choice.IsEnabled && IsPartialOrderOperation(choice.NextOperationType))
+                            .ToList();
+
+                    if (partialOrderChoices.Count > 0)
+                    {
+                        next = partialOrderChoices[0];
+                        return true;
+                    }
+
+                    // Normal schedule:
+                    return ChildStrategy.GetNext(out next, choices, current);
+                }
+                case ReductionStrategy.OmitSchedulingPoints:
+                {
+                    // Otherwise, don't schedule before non-Send.
+                    if (current.IsEnabled &&
+                        IsPartialOrderOperation(current.NextOperationType))
+                    {
+                        next = current;
+                        return true;
+                    }
+
+                    // Normal schedule:
+                    return ChildStrategy.GetNext(out next, choices, current);
+                }
+                case ReductionStrategy.None:
+                {
+                    // Normal schedule:
+                    return ChildStrategy.GetNext(out next, choices, current);
+                }
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        /// <summary>
+        /// Returns the next boolean choice.
+        /// </summary>
+        /// <param name="maxValue">Max value</param>
+        /// <param name="next">Next</param>
+        /// <returns>Boolean</returns>
+        public bool GetNextBooleanChoice(int maxValue, out bool next)
+        {
+            ++ScheduledSteps;
+            return ChildStrategy.GetNextBooleanChoice(maxValue, out next);
+        }
+
+        /// <summary>
+        /// Returns the next integer choice.
+        /// </summary>
+        /// <param name="maxValue">Max value</param>
+        /// <param name="next">Next</param>
+        /// <returns>Boolean</returns>
+        public bool GetNextIntegerChoice(int maxValue, out int next)
+        {
+            ++ScheduledSteps;
+            return ChildStrategy.GetNextIntegerChoice(maxValue, out next);
+        }
+
+        /// <summary>
+        /// Prepares for the next scheduling iteration. This is invoked
+        /// at the end of a scheduling iteration. It must return false
+        /// if the scheduling strategy should stop exploring.
+        /// </summary>
+        /// <returns>True to start the next iteration</returns>
+        public bool PrepareForNextIteration()
+        {
+            ScheduledSteps = 0;
+            return ChildStrategy.PrepareForNextIteration();
+        }
+
+        /// <summary>
+        /// Resets the scheduling strategy. This is typically invoked by
+        /// parent strategies to reset child strategies.
+        /// </summary>
+        public void Reset()
+        {
+            ScheduledSteps = 0;
+            ChildStrategy.Reset();
+        }
+
+        /// <summary>
+        /// Returns the scheduled steps.
+        /// </summary>
+        /// <returns>Scheduled steps</returns>
+        public int GetScheduledSteps()
+        {
+            return ReportActualScheduledSteps
+                ? ScheduledSteps
+                : ChildStrategy.GetScheduledSteps();
+        }
+
+        /// <summary>
+        /// True if the scheduling strategy has reached the max
+        /// scheduling steps for the given scheduling iteration.
+        /// </summary>
+        /// <returns>Boolean</returns>
+        public bool HasReachedMaxSchedulingSteps()
+        {
+            return ReportActualScheduledSteps
+                ? (StepLimit > 0 && ScheduledSteps >= StepLimit)
+                : ChildStrategy.HasReachedMaxSchedulingSteps();
+        }
+
+        /// <summary>
+        /// Checks if this is a fair scheduling strategy.
+        /// </summary>
+        /// <returns>Boolean</returns>
+        public bool IsFair()
+        {
+            return ChildStrategy.IsFair();
+        }
+
+        /// <summary>
+        /// Returns a textual description of the scheduling strategy.
+        /// </summary>
+        /// <returns>String</returns>
+        public string GetDescription()
+        {
+            return $"{ChildStrategy.GetDescription()}  w/ {Reduction}";
+        }
+
+        private static bool IsPartialOrderOperation(OperationType operationType)
+        {
+            return operationType != OperationType.Send;
+        }
+    }
+}

--- a/Source/SchedulingStrategies/Strategies/Special/BasicReductionStrategy.cs
+++ b/Source/SchedulingStrategies/Strategies/Special/BasicReductionStrategy.cs
@@ -153,6 +153,43 @@ namespace Microsoft.PSharp.TestingServices.SchedulingStrategies
         }
 
         /// <summary>
+        /// Forces the next choice to schedule.
+        /// </summary>
+        /// <param name="next">Next</param>
+        /// <param name="choices">Choices</param>
+        /// <param name="current">Curent</param>
+        /// <returns>Boolean</returns>
+        public void ForceNext(ISchedulable next, List<ISchedulable> choices, ISchedulable current)
+        {
+            ++ScheduledSteps;
+            ChildStrategy.ForceNext(next, choices, current);
+        }
+
+        /// <summary>
+        /// Forces the next boolean choice.
+        /// </summary>
+        /// <param name="maxValue">Max value</param>
+        /// <param name="next">Next</param>
+        /// <returns>Boolean</returns>
+        public void ForceNextBooleanChoice(int maxValue, bool next)
+        {
+            ++ScheduledSteps;
+            ChildStrategy.ForceNextBooleanChoice(maxValue, next);
+        }
+
+        /// <summary>
+        /// Forces the next integer choice.
+        /// </summary>
+        /// <param name="maxValue">Max value</param>
+        /// <param name="next">Next</param>
+        /// <returns>Boolean</returns>
+        public void ForceNextIntegerChoice(int maxValue, int next)
+        {
+            ++ScheduledSteps;
+            ChildStrategy.ForceNextIntegerChoice(maxValue, next);
+        }
+
+        /// <summary>
         /// Prepares for the next scheduling iteration. This is invoked
         /// at the end of a scheduling iteration. It must return false
         /// if the scheduling strategy should stop exploring.

--- a/Source/SchedulingStrategies/Strategies/Special/ComboStrategy.cs
+++ b/Source/SchedulingStrategies/Strategies/Special/ComboStrategy.cs
@@ -12,6 +12,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.PSharp.TestingServices.SchedulingStrategies
@@ -95,6 +96,61 @@ namespace Microsoft.PSharp.TestingServices.SchedulingStrategies
             else
             {
                 return this.PrefixStrategy.GetNextIntegerChoice(maxValue, out next);
+            }
+        }
+
+        /// <summary>
+        /// Forces the next choice to schedule.
+        /// </summary>
+        /// <param name="next">Next</param>
+        /// <param name="choices">Choices</param>
+        /// <param name="current">Curent</param>
+        /// <returns>Boolean</returns>
+        public void ForceNext(ISchedulable next, List<ISchedulable> choices, ISchedulable current)
+        {
+            if (this.PrefixStrategy.HasReachedMaxSchedulingSteps())
+            {
+                this.SuffixStrategy.ForceNext(next, choices, current);
+            }
+            else
+            {
+                this.PrefixStrategy.ForceNext(next, choices, current);
+            }
+        }
+
+        /// <summary>
+        /// Forces the next boolean choice.
+        /// </summary>
+        /// <param name="maxValue">Max value</param>
+        /// <param name="next">Next</param>
+        /// <returns>Boolean</returns>
+        public void ForceNextBooleanChoice(int maxValue, bool next)
+        {
+            if (this.PrefixStrategy.HasReachedMaxSchedulingSteps())
+            {
+                this.SuffixStrategy.ForceNextBooleanChoice(maxValue, next);
+            }
+            else
+            {
+                this.PrefixStrategy.ForceNextBooleanChoice(maxValue, next);
+            }
+        }
+
+        /// <summary>
+        /// Forces the next integer choice.
+        /// </summary>
+        /// <param name="maxValue">Max value</param>
+        /// <param name="next">Next</param>
+        /// <returns>Boolean</returns>
+        public void ForceNextIntegerChoice(int maxValue, int next)
+        {
+            if (this.PrefixStrategy.HasReachedMaxSchedulingSteps())
+            {
+                this.SuffixStrategy.ForceNextIntegerChoice(maxValue, next);
+            }
+            else
+            {
+                this.PrefixStrategy.ForceNextIntegerChoice(maxValue, next);
             }
         }
 

--- a/Source/SchedulingStrategies/Utilities/ContractAsserter.cs
+++ b/Source/SchedulingStrategies/Utilities/ContractAsserter.cs
@@ -1,0 +1,34 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ContractAsserter.cs">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// 
+//      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Diagnostics;
+
+namespace Microsoft.PSharp.TestingServices.SchedulingStrategies
+{
+    /// <summary>
+    /// Allows the caller to assert a condition that should be true.
+    /// </summary>
+    public class ContractAsserter : IContract
+    {
+        /// <summary>
+        /// Assert a condition that should be true.
+        /// </summary>
+        /// <param name="condition">The condition.</param>
+        /// <param name="msg">An error message if the condition is false.</param>
+        public void Assert(bool condition, string msg = "")
+        {
+            Debug.Assert(condition, msg);
+        }
+    }
+}

--- a/Source/SchedulingStrategies/Utilities/IContract.cs
+++ b/Source/SchedulingStrategies/Utilities/IContract.cs
@@ -1,0 +1,30 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="IContract.cs">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// 
+//      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace Microsoft.PSharp.TestingServices.SchedulingStrategies
+{
+    /// <summary>
+    /// Interface for a contract that can be used to assert that
+    /// a condition in a scheduling strategy should be true.
+    /// </summary>
+    public interface IContract
+    {
+        /// <summary>
+        /// Assert a condition that should be true.
+        /// </summary>
+        /// <param name="condition">The condition.</param>
+        /// <param name="msg">An error message if the condition is false.</param>
+        void Assert(bool condition, string msg = "");
+    }
+}

--- a/Source/TestingServices/Engines/AbstractTestingEngine.cs
+++ b/Source/TestingServices/Engines/AbstractTestingEngine.cs
@@ -364,6 +364,11 @@ namespace Microsoft.PSharp.TestingServices
                 Error.ReportAndExit("Portfolio testing strategy in only " +
                     "available in parallel testing.");
             }
+
+            if (!(Strategy is DPORStrategy) && !(Strategy is ReplayStrategy))
+            {
+                Strategy = new BasicReductionStrategy(Strategy, BasicReductionStrategy.ReductionStrategy.ForceSchedule);
+            }
         }
 
         #endregion

--- a/Source/TestingServices/Engines/AbstractTestingEngine.cs
+++ b/Source/TestingServices/Engines/AbstractTestingEngine.cs
@@ -364,11 +364,6 @@ namespace Microsoft.PSharp.TestingServices
                 Error.ReportAndExit("Portfolio testing strategy in only " +
                     "available in parallel testing.");
             }
-
-            if (!(Strategy is DPORStrategy) && !(Strategy is ReplayStrategy))
-            {
-                Strategy = new BasicReductionStrategy(Strategy, BasicReductionStrategy.ReductionStrategy.ForceSchedule);
-            }
         }
 
         #endregion

--- a/Source/TestingServices/Engines/AbstractTestingEngine.cs
+++ b/Source/TestingServices/Engines/AbstractTestingEngine.cs
@@ -333,6 +333,22 @@ namespace Microsoft.PSharp.TestingServices
                     this.SchedulingStrategyLogger);
                 this.Configuration.PerformFullExploration = false;
             }
+            else if (this.Configuration.SchedulingStrategy == SchedulingStrategy.DPOR)
+            {
+                this.Strategy = new DPORStrategy(
+                    new ContractAsserter(),
+                    null,
+                    -1,
+                    this.Configuration.MaxUnfairSchedulingSteps);
+            }
+            else if (this.Configuration.SchedulingStrategy == SchedulingStrategy.RDPOR)
+            {
+                this.Strategy = new DPORStrategy(
+                    new ContractAsserter(), 
+                    this.RandomNumberGenerator,
+                    -1,
+                    this.Configuration.MaxFairSchedulingSteps);
+            }
             else if (this.Configuration.SchedulingStrategy == SchedulingStrategy.DelayBounding)
             {
                 this.Strategy = new ExhaustiveDelayBoundingStrategy(this.Configuration.MaxUnfairSchedulingSteps,

--- a/Source/TestingServices/Runtime/BugFindingRuntime.cs
+++ b/Source/TestingServices/Runtime/BugFindingRuntime.cs
@@ -920,6 +920,7 @@ namespace Microsoft.PSharp.TestingServices
             if (caller != null && caller is Machine)
             {
                 this.AssertNoPendingTransitionStatement(caller as Machine, "Random");
+                (caller as Machine).Info.ProgramCounter++;
             }
 
             var choice = this.Scheduler.GetNextNondeterministicBooleanChoice(maxValue);
@@ -950,6 +951,7 @@ namespace Microsoft.PSharp.TestingServices
             if (caller != null && caller is Machine)
             {
                 this.AssertNoPendingTransitionStatement(caller as Machine, "FairRandom");
+                (caller as Machine).Info.ProgramCounter++;
             }
 
             var choice = this.Scheduler.GetNextNondeterministicBooleanChoice(2, uniqueId);
@@ -1511,6 +1513,7 @@ namespace Microsoft.PSharp.TestingServices
                 foreach (var machine in this.MachineMap.Values.OrderBy(mi => mi.Id.Value))
                 {
                     hash = hash * 31 + machine.GetCachedState();
+                    hash = hash * 31 + (int)(machine.Info as SchedulableInfo).NextOperationType;
                 }
 
                 foreach (var monitor in this.Monitors)

--- a/Source/TestingServices/Runtime/BugFindingRuntime.cs
+++ b/Source/TestingServices/Runtime/BugFindingRuntime.cs
@@ -372,7 +372,7 @@ namespace Microsoft.PSharp.TestingServices
 
                     IO.Debug.WriteLine($"<ScheduleDebug> Completed event handler of the test harness machine.");
                     (harness.Info as SchedulableInfo).NotifyEventHandlerCompleted();
-                    this.Scheduler.Schedule(OperationType.Stop);
+                    this.Scheduler.Schedule(OperationType.Stop, OperationTargetType.Schedulable, harness.Info.Id);
                     IO.Debug.WriteLine($"<ScheduleDebug> Exit event handler of the test harness machine.");
                 }
                 catch (ExecutionCanceledException)
@@ -385,7 +385,7 @@ namespace Microsoft.PSharp.TestingServices
                 }
             });
 
-            (harness.Info as SchedulableInfo).NotifyEventHandlerCreated(task.Id);
+            (harness.Info as SchedulableInfo).NotifyEventHandlerCreated(task.Id, 0);
             this.Scheduler.NotifyEventHandlerCreated(harness.Info as SchedulableInfo);
 
             task.Start();
@@ -408,7 +408,9 @@ namespace Microsoft.PSharp.TestingServices
                 this.AssertNoPendingTransitionStatement(creator, "CreateMachine");
             }
 
-            this.Scheduler.Schedule(OperationType.Create);
+            // Using ulong.MaxValue because a 'Create' operation cannot specify
+            // the id of its target, because the id does not exist yet.
+            this.Scheduler.Schedule(OperationType.Create, OperationTargetType.Schedulable, ulong.MaxValue);
 
             Machine machine = this.CreateMachine(type, friendlyName);
 
@@ -423,7 +425,7 @@ namespace Microsoft.PSharp.TestingServices
                 }
             }
 
-            this.RunMachineEventHandler(machine, e, true, false);
+            this.RunMachineEventHandler(machine, e, true, false, null);
 
             return machine.Id;
         }
@@ -445,7 +447,9 @@ namespace Microsoft.PSharp.TestingServices
                 this.AssertNoPendingTransitionStatement(creator, "CreateMachine");
             }
 
-            this.Scheduler.Schedule(OperationType.Create);
+            // Using ulong.MaxValue because a 'Create' operation cannot specify
+            // the id of its target, because the id does not exist yet.
+            this.Scheduler.Schedule(OperationType.Create, OperationTargetType.Schedulable, ulong.MaxValue);
 
             Machine machine = this.CreateMachine(type, friendlyName);
 
@@ -460,7 +464,7 @@ namespace Microsoft.PSharp.TestingServices
                 }
             }
 
-            this.RunMachineEventHandler(machine, e, true, true);
+            this.RunMachineEventHandler(machine, e, true, true, null);
 
             return await Task.FromResult(machine.Id);
         }
@@ -524,6 +528,8 @@ namespace Microsoft.PSharp.TestingServices
         /// <param name="operationGroupId">Operation group id</param>
         internal override void SendEvent(MachineId mid, Event e, AbstractMachine sender, Guid? operationGroupId)
         {
+            this.Scheduler.Schedule(OperationType.Send, OperationTargetType.Inbox, mid.Value);
+
             Machine machine = null;
             if (!this.MachineMap.TryGetValue(mid.Value, out machine))
             {
@@ -538,14 +544,12 @@ namespace Microsoft.PSharp.TestingServices
 
                 return;
             }
-
-            this.Scheduler.Schedule(OperationType.Send);
-
+            
             bool runNewHandler = false;
-            this.EnqueueEvent(machine, e, sender, operationGroupId, ref runNewHandler);
+            EventInfo eventInfo = this.EnqueueEvent(machine, e, sender, operationGroupId, ref runNewHandler);
             if (runNewHandler)
             {
-                this.RunMachineEventHandler(machine, null, false, false);
+                this.RunMachineEventHandler(machine, null, false, false, eventInfo);
             }
         }
 
@@ -559,6 +563,8 @@ namespace Microsoft.PSharp.TestingServices
         /// <param name="operationGroupId">Operation group id</param>
         internal override async Task SendEventAndExecute(MachineId mid, Event e, AbstractMachine sender, Guid? operationGroupId)
         {
+            this.Scheduler.Schedule(OperationType.Send, OperationTargetType.Inbox, mid.Value);
+
             Machine machine = null;
             if (!this.MachineMap.TryGetValue(mid.Value, out machine))
             {
@@ -574,13 +580,11 @@ namespace Microsoft.PSharp.TestingServices
                 return;
             }
 
-            this.Scheduler.Schedule(OperationType.Send);
-
             bool runNewHandler = false;
-            this.EnqueueEvent(machine, e, sender, operationGroupId, ref runNewHandler);
+            EventInfo eventInfo = this.EnqueueEvent(machine, e, sender, operationGroupId, ref runNewHandler);
             if (runNewHandler)
             {
-                this.RunMachineEventHandler(machine, null, false, true);
+                this.RunMachineEventHandler(machine, null, false, true, eventInfo);
             }
 
             await Task.CompletedTask;
@@ -607,7 +611,8 @@ namespace Microsoft.PSharp.TestingServices
         /// <param name="sender">Sender machine</param>
         /// <param name="operationGroupId">Operation group id</param>
         /// <param name="runNewHandler">Run a new handler</param>
-        private void EnqueueEvent(Machine machine, Event e, AbstractMachine sender, Guid? operationGroupId, ref bool runNewHandler)
+        /// <returns>EventInfo</returns>
+        private EventInfo EnqueueEvent(Machine machine, Event e, AbstractMachine sender, Guid? operationGroupId, ref bool runNewHandler)
         {
             if (sender != null && sender is Machine)
             {
@@ -626,7 +631,7 @@ namespace Microsoft.PSharp.TestingServices
                 originInfo = new EventOriginInfo(null, "Env", "Env");
             }
 
-            EventInfo eventInfo = new EventInfo(e, originInfo);
+            EventInfo eventInfo = new EventInfo(e, originInfo, Scheduler.ScheduledSteps);
             this.SetOperationGroupIdForEvent(eventInfo, sender, operationGroupId);
 
             if (sender != null)
@@ -651,17 +656,21 @@ namespace Microsoft.PSharp.TestingServices
             }
 
             machine.Enqueue(eventInfo, ref runNewHandler);
+
+            return eventInfo;
         }
 
         /// <summary>
         /// Runs a new asynchronous machine event handler.
         /// This is a fire and forget invocation.
         /// </summary>
-        /// <param name="machine">Machine</param>
-        /// <param name="e">Event</param>
-        /// <param name="isFresh">Is a new machine</param>
-        /// <param name="executeSynchronously">If true, this operation executes synchronously</param> 
-        private void RunMachineEventHandler(Machine machine, Event e, bool isFresh, bool executeSynchronously)
+        /// <param name="machine">Machine that executes this event handler.</param>
+        /// <param name="initialEvent">Event for initializing the machine.</param>
+        /// <param name="isFresh">If true, then this is a new machine.</param>
+        /// <param name="executeSynchronously">If true, this operation executes synchronously.</param>
+        /// <param name="enablingEvent">If non-null, the event info of the sent event that caused the event handler to be restarted.</param> 
+        private void RunMachineEventHandler(Machine machine, Event initialEvent, bool isFresh,
+            bool executeSynchronously, EventInfo enablingEvent)
         {
             Task task = new Task(async () =>
             {
@@ -673,7 +682,7 @@ namespace Microsoft.PSharp.TestingServices
 
                     if (isFresh)
                     {
-                        await machine.GotoStartState(e);
+                        await machine.GotoStartState(initialEvent);
                     }
 
                     await machine.RunEventHandler(executeSynchronously);
@@ -686,7 +695,16 @@ namespace Microsoft.PSharp.TestingServices
 
                     IO.Debug.WriteLine($"<ScheduleDebug> Completed event handler of '{machine.Id}'.");
                     (machine.Info as SchedulableInfo).NotifyEventHandlerCompleted();
-                    this.Scheduler.Schedule(machine.Info.IsHalted ? OperationType.Stop : OperationType.Wait);
+
+                    if (machine.Info.IsHalted)
+                    {
+                        this.Scheduler.Schedule(OperationType.Stop, OperationTargetType.Schedulable, machine.Info.Id);
+                    }
+                    else
+                    {
+                        this.Scheduler.Schedule(OperationType.Receive, OperationTargetType.Inbox, machine.Info.Id);
+                    }
+
                     IO.Debug.WriteLine($"<ScheduleDebug> Exit event handler of '{machine.Id}'.");
                 }
                 catch (ExecutionCanceledException)
@@ -701,12 +719,24 @@ namespace Microsoft.PSharp.TestingServices
 
             this.TaskMap.TryAdd(task.Id, machine);
 
-            (machine.Info as SchedulableInfo).NotifyEventHandlerCreated(task.Id);
+            (machine.Info as SchedulableInfo).NotifyEventHandlerCreated(task.Id, enablingEvent?.SendStep ?? 0);
             this.Scheduler.NotifyEventHandlerCreated(machine.Info as SchedulableInfo);
 
             task.Start(this.TaskScheduler);
 
             this.Scheduler.WaitForEventHandlerToStart(machine.Info as SchedulableInfo);
+        }
+
+        /// <summary>
+        /// Checks that a machine can start its event handler. Returns false if the event
+        /// handler should not be started. The bug finding runtime may return false because
+        /// it knows that there are currently no events in the inbox that can be handled.
+        /// </summary>
+        /// <param name="machine">Machine</param>
+        /// <returns>Boolean</returns>
+        internal override bool CheckStartEventHandler(Machine machine)
+        {
+            return machine.TryDequeueEvent(true) != null;
         }
 
         /// <summary>
@@ -732,6 +762,10 @@ namespace Microsoft.PSharp.TestingServices
                 "is not a subclass of Monitor.\n");
 
             MachineId mid = new MachineId(type, null, this);
+
+            SchedulableInfo info = new SchedulableInfo(mid);
+            Scheduler.NotifyMonitorRegistered(info);
+
             Monitor monitor = Activator.CreateInstance(type) as Monitor;
             monitor.Initialize(mid);
             monitor.InitializeStateInformation();
@@ -1104,10 +1138,14 @@ namespace Microsoft.PSharp.TestingServices
 
             // Skip `Receive` if the last operation exited the previous event handler,
             // to avoid scheduling duplicate `Receive` operations.
-            if ((machine.Info as SchedulableInfo).NextOperationType == OperationType.Wait &&
-                (machine.Info as SchedulableInfo).EventHandlerOperationCount > 0)
+            if ((machine.Info as SchedulableInfo).SkipNextReceiveSchedulingPoint)
             {
-                this.Scheduler.Schedule(OperationType.Receive);
+                (machine.Info as SchedulableInfo).SkipNextReceiveSchedulingPoint = false;
+            }
+            else
+            {
+                (machine.Info as SchedulableInfo).NextOperationMatchingSendIndex = (ulong) eventInfo.SendStep;
+                this.Scheduler.Schedule(OperationType.Receive, OperationTargetType.Inbox, machine.Info.Id);
             }
 
             this.Log($"<DequeueLog> Machine '{machine.Id}' dequeued event '{eventInfo.EventName}'.");
@@ -1162,18 +1200,26 @@ namespace Microsoft.PSharp.TestingServices
         }
 
         /// <summary>
-        /// Notifies that a machine is waiting to receive one
-        /// or more events.
+        /// Notifies that a machine is waiting to receive one or more events.
         /// </summary>
         /// <param name="machine">Machine</param>
-        internal override void NotifyWaitEvents(Machine machine)
+        /// <param name="eventInfoInInbox">The event info if it is in the inbox, else null</param>
+        internal override void NotifyWaitEvents(Machine machine, EventInfo eventInfoInInbox)
         {
-            string events = machine.GetEventWaitHandlerNames();
-            this.BugTrace.AddWaitToReceiveStep(machine.Id, machine.CurrentStateName, events);            
-            this.Log($"<ReceiveLog> Machine '{machine.Id}' is waiting on events:{events}.");
-            machine.Info.IsWaitingToReceive = true;
-            (machine.Info as SchedulableInfo).IsEnabled = false;
-            this.Scheduler.Schedule(OperationType.Wait);
+            if (eventInfoInInbox == null)
+            {
+                string events = machine.GetEventWaitHandlerNames();
+                this.BugTrace.AddWaitToReceiveStep(machine.Id, machine.CurrentStateName, events);
+                this.Log($"<ReceiveLog> Machine '{machine.Id}' is waiting on events:{events}.");
+                machine.Info.IsWaitingToReceive = true;
+                (machine.Info as SchedulableInfo).IsEnabled = false;
+            }
+            else
+            {
+                (machine.Info as SchedulableInfo).NextOperationMatchingSendIndex = (ulong) eventInfoInInbox.SendStep;
+            }
+
+            this.Scheduler.Schedule(OperationType.Receive, OperationTargetType.Inbox, machine.Info.Id);
         }
 
         /// <summary>
@@ -1187,6 +1233,7 @@ namespace Microsoft.PSharp.TestingServices
             this.Log($"<ReceiveLog> Machine '{machine.Id}' received event '{eventInfo.EventName}' and unblocked.");
             machine.Info.IsWaitingToReceive = false;
             (machine.Info as SchedulableInfo).IsEnabled = true;
+            (machine.Info as SchedulableInfo).NextOperationMatchingSendIndex = (ulong) eventInfo.SendStep;
         }
 
         /// <summary>
@@ -1201,11 +1248,26 @@ namespace Microsoft.PSharp.TestingServices
         }
 
         /// <summary>
-        /// Notifies that a default handler has been used.
+        /// Notifies that the inbox of the specified machine is about to be
+        /// checked to see if the default event handler should fire.
         /// </summary>
-        internal override void NotifyDefaultHandlerFired()
+        internal override void NotifyDefaultEventHandlerCheck(Machine machine)
         {
-            this.Scheduler.Schedule(OperationType.Send);
+            this.Scheduler.Schedule(OperationType.Send, OperationTargetType.Inbox, machine.Info.Id);
+            // If the default event handler fires, the next receive in NotifyDefaultHandlerFired
+            // will use this as its NextOperationMatchingSendIndex.
+            // If it does not fire, NextOperationMatchingSendIndex will be overwritten.
+            (machine.Info as SchedulableInfo).NextOperationMatchingSendIndex = (ulong) this.Scheduler.ScheduledSteps;
+        }
+
+        /// <summary>
+        /// Notifies that the default handler of the specified machine has been fired.
+        /// </summary>
+        /// <param name="machine">Machine</param>
+        internal override void NotifyDefaultHandlerFired(Machine machine)
+        {
+            // NextOperationMatchingSendIndex is set in NotifyDefaultEventHandlerCheck.
+            this.Scheduler.Schedule(OperationType.Receive, OperationTargetType.Inbox, machine.Info.Id);
         }
 
         #endregion

--- a/Source/TestingServices/Runtime/BugFindingRuntime.cs
+++ b/Source/TestingServices/Runtime/BugFindingRuntime.cs
@@ -114,6 +114,21 @@ namespace Microsoft.PSharp.TestingServices
             this.TaskScheduler = new AsynchronousTaskScheduler(this, this.TaskMap);
             this.CoverageInfo = new CoverageInfo();
 
+            if (!(strategy is DPORStrategy) && !(strategy is ReplayStrategy))
+            {
+                var reductionStrategy = BasicReductionStrategy.ReductionStrategy.None;
+                if (configuration.ReductionStrategy == Utilities.ReductionStrategy.OmitSchedulingPoints)
+                {
+                    reductionStrategy = BasicReductionStrategy.ReductionStrategy.OmitSchedulingPoints;
+                }
+                else if (configuration.ReductionStrategy == Utilities.ReductionStrategy.ForceSchedule)
+                {
+                    reductionStrategy = BasicReductionStrategy.ReductionStrategy.ForceSchedule;
+                }
+
+                strategy = new BasicReductionStrategy(strategy, reductionStrategy);
+            }
+
             if (configuration.EnableLivenessChecking && configuration.EnableCycleDetection)
             {
                 this.Scheduler = new BugFindingScheduler(this, new CycleDetectionStrategy(

--- a/Source/TestingServices/Scheduling/BugFindingScheduler.cs
+++ b/Source/TestingServices/Scheduling/BugFindingScheduler.cs
@@ -153,6 +153,7 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
             this.ScheduledMachine = next as SchedulableInfo;
 
             this.Runtime.ScheduleTrace.AddSchedulingChoice(next.Id);
+            (next as MachineInfo).ProgramCounter = 0;
 
             Debug.WriteLine($"<ScheduleDebug> Schedule '{next.Name}' with task id '{this.ScheduledMachine.TaskId}'.");
 

--- a/Source/TestingServices/SchedulingStrategies/Liveness/CycleDetectionStrategy.cs
+++ b/Source/TestingServices/SchedulingStrategies/Liveness/CycleDetectionStrategy.cs
@@ -165,6 +165,8 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
                     return SchedulingStrategy.GetNext(out next, choices, current);
                 }
 
+                SchedulingStrategy.ForceNext(next, choices, current);
+
                 CurrentCycleIndex++;
                 if (CurrentCycleIndex == PotentialCycle.Count)
                 {
@@ -202,6 +204,8 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
                 Debug.WriteLine("<LivenessDebug> Replaying '{0}' '{1}'.", nextStep.Index, nextStep.BooleanChoice.Value);
 
                 next = nextStep.BooleanChoice.Value;
+
+                SchedulingStrategy.ForceNextBooleanChoice(maxValue, next);
 
                 CurrentCycleIndex++;
                 if (CurrentCycleIndex == PotentialCycle.Count)
@@ -241,6 +245,8 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
                 Debug.WriteLine("<LivenessDebug> Replaying '{0}' '{1}'.", nextStep.Index, nextStep.IntegerChoice.Value);
 
                 next = nextStep.IntegerChoice.Value;
+
+                SchedulingStrategy.ForceNextIntegerChoice(maxValue, next);
 
                 CurrentCycleIndex++;
                 if (CurrentCycleIndex == PotentialCycle.Count)

--- a/Source/TestingServices/SchedulingStrategies/Liveness/LivenessCheckingStrategy.cs
+++ b/Source/TestingServices/SchedulingStrategies/Liveness/LivenessCheckingStrategy.cs
@@ -12,6 +12,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using Microsoft.PSharp.TestingServices.SchedulingStrategies;
 
@@ -84,6 +85,40 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         /// <param name="next">Next</param>
         /// <returns>Boolean</returns>
         public abstract bool GetNextIntegerChoice(int maxValue, out int next);
+
+        /// <summary>
+        /// Forces the next choice to schedule.
+        /// </summary>
+        /// <param name="next">Next</param>
+        /// <param name="choices">Choices</param>
+        /// <param name="current">Curent</param>
+        /// <returns>Boolean</returns>
+        public void ForceNext(ISchedulable next, List<ISchedulable> choices, ISchedulable current)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Forces the next boolean choice.
+        /// </summary>
+        /// <param name="maxValue">Max value</param>
+        /// <param name="next">Next</param>
+        /// <returns>Boolean</returns>
+        public void ForceNextBooleanChoice(int maxValue, bool next)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Forces the next integer choice.
+        /// </summary>
+        /// <param name="maxValue">Max value</param>
+        /// <param name="next">Next</param>
+        /// <returns>Boolean</returns>
+        public void ForceNextIntegerChoice(int maxValue, int next)
+        {
+            throw new NotImplementedException();
+        }
 
         /// <summary>
         /// Prepares for the next scheduling iteration. This is invoked

--- a/Source/TestingServices/SchedulingStrategies/Special/InteractiveStrategy.cs
+++ b/Source/TestingServices/SchedulingStrategies/Special/InteractiveStrategy.cs
@@ -331,6 +331,40 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         }
 
         /// <summary>
+        /// Forces the next choice to schedule.
+        /// </summary>
+        /// <param name="next">Next</param>
+        /// <param name="choices">Choices</param>
+        /// <param name="current">Curent</param>
+        /// <returns>Boolean</returns>
+        public void ForceNext(ISchedulable next, List<ISchedulable> choices, ISchedulable current)
+        {
+            
+        }
+
+        /// <summary>
+        /// Forces the next boolean choice.
+        /// </summary>
+        /// <param name="maxValue">Max value</param>
+        /// <param name="next">Next</param>
+        /// <returns>Boolean</returns>
+        public void ForceNextBooleanChoice(int maxValue, bool next)
+        {
+            
+        }
+
+        /// <summary>
+        /// Forces the next integer choice.
+        /// </summary>
+        /// <param name="maxValue">Max value</param>
+        /// <param name="next">Next</param>
+        /// <returns>Boolean</returns>
+        public void ForceNextIntegerChoice(int maxValue, int next)
+        {
+            
+        }
+
+        /// <summary>
         /// Prepares for the next scheduling iteration. This is invoked
         /// at the end of a scheduling iteration. It must return false
         /// if the scheduling strategy should stop exploring.

--- a/Source/TestingServices/SchedulingStrategies/Special/ReplayStrategy.cs
+++ b/Source/TestingServices/SchedulingStrategies/Special/ReplayStrategy.cs
@@ -225,6 +225,40 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         }
 
         /// <summary>
+        /// Forces the next choice to schedule.
+        /// </summary>
+        /// <param name="next">Next</param>
+        /// <param name="choices">Choices</param>
+        /// <param name="current">Curent</param>
+        /// <returns>Boolean</returns>
+        public void ForceNext(ISchedulable next, List<ISchedulable> choices, ISchedulable current)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Forces the next boolean choice.
+        /// </summary>
+        /// <param name="maxValue">Max value</param>
+        /// <param name="next">Next</param>
+        /// <returns>Boolean</returns>
+        public void ForceNextBooleanChoice(int maxValue, bool next)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Forces the next integer choice.
+        /// </summary>
+        /// <param name="maxValue">Max value</param>
+        /// <param name="next">Next</param>
+        /// <returns>Boolean</returns>
+        public void ForceNextIntegerChoice(int maxValue, int next)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
         /// Prepares for the next scheduling iteration. This is invoked
         /// at the end of a scheduling iteration. It must return false
         /// if the scheduling strategy should stop exploring.

--- a/Tests/TestingServices.Tests.Integration/Advanced/ChainReplicationTest.cs
+++ b/Tests/TestingServices.Tests.Integration/Advanced/ChainReplicationTest.cs
@@ -1447,8 +1447,9 @@ namespace Microsoft.PSharp.TestingServices.Tests.Integration
             configuration.SchedulingStrategy = Utilities.SchedulingStrategy.FairPCT;
             configuration.PrioritySwitchBound = 1;
             configuration.MaxSchedulingSteps = 100;
-            configuration.RandomSchedulingSeed = 624;
-            configuration.SchedulingIterations = 1;
+            configuration.RandomSchedulingSeed = 32;
+            configuration.SchedulingIterations = 2;
+            configuration.IncrementalSchedulingSeed = true;
 
             var test = new Action<PSharpRuntime>((r) => {
                 r.RegisterMonitor(typeof(InvariantMonitor));

--- a/Tests/TestingServices.Tests.Integration/Advanced/ChordTest.cs
+++ b/Tests/TestingServices.Tests.Integration/Advanced/ChordTest.cs
@@ -843,7 +843,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Integration
             configuration.MaxUnfairSchedulingSteps = 200;
             configuration.MaxFairSchedulingSteps = 2000;
             configuration.LivenessTemperatureThreshold = 1000;
-            configuration.RandomSchedulingSeed = 32;
+            configuration.RandomSchedulingSeed = 663;
             configuration.SchedulingIterations = 1;
 
             var test = new Action<PSharpRuntime>((r) => {
@@ -862,7 +862,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Integration
             var configuration = base.GetConfiguration();
             configuration.EnableCycleDetection = true;
             configuration.MaxSchedulingSteps = 100;
-            configuration.RandomSchedulingSeed = 211;
+            configuration.RandomSchedulingSeed = 377;
             configuration.SchedulingIterations = 1;
 
             var test = new Action<PSharpRuntime>((r) => {

--- a/Tests/TestingServices.Tests.Integration/Advanced/DiningPhilosophersTest.cs
+++ b/Tests/TestingServices.Tests.Integration/Advanced/DiningPhilosophersTest.cs
@@ -198,8 +198,10 @@ namespace Microsoft.PSharp.TestingServices.Tests.Integration
         {
             var configuration = GetConfiguration();
             configuration.EnableCycleDetection = true;
-            configuration.MaxSchedulingSteps = 100;
-            configuration.RandomSchedulingSeed = 128;
+            configuration.MaxUnfairSchedulingSteps = 100;
+            configuration.MaxFairSchedulingSteps = 1000;
+            configuration.LivenessTemperatureThreshold = 500;
+            configuration.RandomSchedulingSeed = 6;
             configuration.SchedulingIterations = 1;
 
             var test = new Action<PSharpRuntime>((r) => {

--- a/Tests/TestingServices.Tests.Integration/Advanced/FailureDetectorTest.cs
+++ b/Tests/TestingServices.Tests.Integration/Advanced/FailureDetectorTest.cs
@@ -483,7 +483,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Integration
             configuration.MaxUnfairSchedulingSteps = 200;
             configuration.MaxFairSchedulingSteps = 2000;
             configuration.LivenessTemperatureThreshold = 1000;
-            configuration.RandomSchedulingSeed = 117421;
+            configuration.RandomSchedulingSeed = 100813;
             configuration.SchedulingIterations = 1;
 
             var test = new Action<PSharpRuntime>((r) => {
@@ -503,7 +503,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Integration
             configuration.MaxUnfairSchedulingSteps = 200;
             configuration.MaxFairSchedulingSteps = 2000;
             configuration.LivenessTemperatureThreshold = 1000;
-            configuration.RandomSchedulingSeed = 32258;
+            configuration.RandomSchedulingSeed = 4986;
             configuration.SchedulingIterations = 1;
 
             var test = new Action<PSharpRuntime>((r) => {
@@ -524,7 +524,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Integration
             configuration.SchedulingStrategy = Utilities.SchedulingStrategy.FairPCT;
             configuration.PrioritySwitchBound = 1;
             configuration.MaxSchedulingSteps = 100;
-            configuration.RandomSchedulingSeed = 82;
+            configuration.RandomSchedulingSeed = 270;
             configuration.SchedulingIterations = 1;
 
             var test = new Action<PSharpRuntime>((r) => {

--- a/Tests/TestingServices.Tests.Integration/Advanced/ProcessSchedulerTest.cs
+++ b/Tests/TestingServices.Tests.Integration/Advanced/ProcessSchedulerTest.cs
@@ -581,12 +581,11 @@ namespace Microsoft.PSharp.TestingServices.Tests.Integration
         {
             var configuration = GetConfiguration();
             configuration.EnableCycleDetection = true;
-            configuration.SchedulingStrategy = Utilities.SchedulingStrategy.FairPCT;
             configuration.PrioritySwitchBound = 1;
             configuration.MaxUnfairSchedulingSteps = 100;
             configuration.MaxFairSchedulingSteps = 1000;
             configuration.LivenessTemperatureThreshold = 500;
-            configuration.RandomSchedulingSeed = 684;
+            configuration.RandomSchedulingSeed = 16;
             configuration.SchedulingIterations = 1;
 
             var test = new Action<PSharpRuntime>((r) => {

--- a/Tests/TestingServices.Tests.Integration/Advanced/RaftTest.cs
+++ b/Tests/TestingServices.Tests.Integration/Advanced/RaftTest.cs
@@ -1155,7 +1155,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Integration
             configuration.MaxUnfairSchedulingSteps = 100;
             configuration.MaxFairSchedulingSteps = 1000;
             configuration.LivenessTemperatureThreshold = 500;
-            configuration.RandomSchedulingSeed = 963;
+            configuration.RandomSchedulingSeed = 885;
             configuration.SchedulingIterations = 1;
 
             var test = new Action<PSharpRuntime>((r) => {

--- a/Tests/TestingServices.Tests.Integration/Advanced/ReplicatingStorageTest.cs
+++ b/Tests/TestingServices.Tests.Integration/Advanced/ReplicatingStorageTest.cs
@@ -795,12 +795,10 @@ namespace Microsoft.PSharp.TestingServices.Tests.Integration
         {
             var configuration = GetConfiguration();
             configuration.EnableCycleDetection = true;
-            configuration.SchedulingStrategy = Utilities.SchedulingStrategy.FairPCT;
-            configuration.PrioritySwitchBound = 1;
             configuration.MaxUnfairSchedulingSteps = 100;
             configuration.MaxFairSchedulingSteps = 1000;
             configuration.LivenessTemperatureThreshold = 500;
-            configuration.RandomSchedulingSeed = 867;
+            configuration.RandomSchedulingSeed = 2;
             configuration.SchedulingIterations = 1;
 
             var test = new Action<PSharpRuntime>((r) => {

--- a/Tests/TestingServices.Tests.Integration/BaseTest.cs
+++ b/Tests/TestingServices.Tests.Integration/BaseTest.cs
@@ -32,13 +32,14 @@ namespace Microsoft.PSharp.TestingServices.Tests.Integration
             AssertSucceeded(configuration, test);
         }
 
-        protected void AssertSucceeded(Configuration configuration, Action<PSharpRuntime> test)
+        protected ITestingEngine AssertSucceeded(Configuration configuration, Action<PSharpRuntime> test)
         {
             InMemoryLogger logger = new InMemoryLogger();
+            BugFindingEngine engine = null;
 
             try
             {
-                BugFindingEngine engine = BugFindingEngine.Create(configuration, test);
+                engine = BugFindingEngine.Create(configuration, test);
                 engine.SetLogger(logger);
                 engine.Run();
 
@@ -53,6 +54,8 @@ namespace Microsoft.PSharp.TestingServices.Tests.Integration
             {
                 logger.Dispose();
             }
+
+            return engine;
         }
 
         #endregion

--- a/Tests/TestingServices.Tests.Integration/SchedulingStrategies/DPORTest.cs
+++ b/Tests/TestingServices.Tests.Integration/SchedulingStrategies/DPORTest.cs
@@ -1,0 +1,234 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="DPORTest.cs">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// 
+//      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.PSharp.Utilities;
+
+using Xunit;
+
+namespace Microsoft.PSharp.TestingServices.Tests.Integration
+{
+    public class DPORTest : BaseTest
+    {
+        class Ping : Event { }
+
+        class SenderInitEvent : Event
+        {
+            public readonly MachineId WaiterMachineId;
+            public readonly bool SendPing;
+            public readonly bool DoNonDet;
+
+            public SenderInitEvent(MachineId waiter, bool sendPing = false, bool doNonDet = false)
+            {
+                WaiterMachineId = waiter;
+                SendPing = sendPing;
+                DoNonDet = doNonDet;
+            }
+        }
+
+        class InitEvent : Event { }
+        class DummyEvent : Event { }
+
+        class Waiter : Machine
+        {
+            [Start]
+            [OnEventDoAction(typeof(Ping), nameof(Nothing))]
+            private class Init : MachineState { }
+
+            private void Nothing() { }
+        }
+
+        class Sender : Machine
+        {
+            private SenderInitEvent initEvent;
+
+            [Start]
+            [OnEntry(nameof(Initialize))]
+            [OnEventDoAction(typeof(Ping), nameof(SendPing))]
+            [OnEventDoAction(typeof(DummyEvent), nameof(Nothing))]
+            private class Init : MachineState { }
+
+            private void Initialize()
+            {
+                initEvent = ((SenderInitEvent)ReceivedEvent);
+            }
+
+            private void SendPing()
+            {
+                if (initEvent.SendPing)
+                {
+                    Send(initEvent.WaiterMachineId, new Ping());
+                }
+
+                if (initEvent.DoNonDet)
+                {
+                    Random();
+                    Random();
+                }
+
+                Send(Id, new DummyEvent());
+            }
+
+            private void Nothing() { }
+        }
+
+        class ReceiverAddressEvent : Event
+        {
+            public readonly MachineId Receiver;
+
+            public ReceiverAddressEvent(MachineId receiver)
+            {
+                Receiver = receiver;
+            }
+        }
+
+        class LevelOne : Machine
+        {
+            [Start]
+            [OnEntry(nameof(Initialize))]
+            private class Init : MachineState { }
+
+            private void Initialize()
+            {
+                var r = (ReceiverAddressEvent) ReceivedEvent;
+                CreateMachine(typeof(LevelTwo), r);
+                CreateMachine(typeof(LevelTwo), r);
+            }
+        }
+
+        class LevelTwo : Machine
+        {
+            [Start]
+            [OnEntry(nameof(Initialize))]
+            private class Init : MachineState { }
+
+            private void Initialize()
+            {
+                var r = (ReceiverAddressEvent) ReceivedEvent;
+                var a = CreateMachine(typeof(Sender),
+                    new SenderInitEvent(r.Receiver, true));
+                Send(a, new Ping());
+                var b = CreateMachine(typeof(Sender),
+                    new SenderInitEvent(r.Receiver, true));
+                Send(b, new Ping());
+            }
+        }
+
+        class ReceiveWaiter : Machine
+        {
+            [Start]
+            [OnEntry(nameof(Initialize))]
+            private class Init : MachineState { }
+
+            private async Task Initialize()
+            {
+                await Receive(typeof(Ping));
+                await Receive(typeof(Ping));
+            }
+        }
+
+        [Fact]
+        public void TestDPOR1Reduces()
+        {
+            var test = new Action<PSharpRuntime>(r =>
+            {
+                MachineId waiter = r.CreateMachine(typeof(Waiter));
+                MachineId sender1 = r.CreateMachine(typeof(Sender), new SenderInitEvent(waiter));
+                MachineId sender2 = r.CreateMachine(typeof(Sender), new SenderInitEvent(waiter));
+                MachineId sender3 = r.CreateMachine(typeof(Sender), new SenderInitEvent(waiter));
+                r.SendEvent(sender1, new Ping());
+                r.SendEvent(sender2, new Ping());
+                r.SendEvent(sender3, new Ping());
+            });
+
+            var configuration = GetConfiguration();
+            configuration.SchedulingIterations = 10;
+
+            // DPOR: 1 schedule.
+            configuration.SchedulingStrategy = SchedulingStrategy.DPOR;
+            var runtime = AssertSucceeded(configuration, test);
+            Assert.Equal(1, runtime.TestReport.NumOfExploredUnfairSchedules);
+
+            // DFS: at least 6 schedules.
+            configuration.SchedulingStrategy = SchedulingStrategy.DFS;
+            runtime = AssertSucceeded(configuration, test);
+            Assert.True(runtime.TestReport.NumOfExploredUnfairSchedules >= 6);
+        }
+
+        [Fact]
+        public void TestDPOR2NonDet()
+        {
+            var test = new Action<PSharpRuntime>(r =>
+            {
+                MachineId waiter = r.CreateMachine(typeof(Waiter));
+                MachineId sender1 = r.CreateMachine(typeof(Sender), new SenderInitEvent(waiter, false, true));
+                MachineId sender2 = r.CreateMachine(typeof(Sender), new SenderInitEvent(waiter));
+                MachineId sender3 = r.CreateMachine(typeof(Sender), new SenderInitEvent(waiter));
+                r.SendEvent(sender1, new Ping());
+                r.SendEvent(sender2, new Ping());
+                r.SendEvent(sender3, new Ping());
+            });
+
+            var configuration = GetConfiguration();
+            configuration.SchedulingIterations = 10;
+
+            // DPOR: 4 schedules because there are 2 nondet choices.
+            configuration.SchedulingStrategy = SchedulingStrategy.DPOR;
+            var runtime = AssertSucceeded(configuration, test);
+            Assert.Equal(4, runtime.TestReport.NumOfExploredUnfairSchedules);
+        }
+
+        [Fact]
+        public void TestDPOR3CreatingMany()
+        {
+            var test = new Action<PSharpRuntime>(r =>
+            {
+                MachineId waiter = r.CreateMachine(typeof(Waiter));
+                r.CreateMachine(typeof(LevelOne),
+                    new ReceiverAddressEvent(waiter));
+                r.CreateMachine(typeof(LevelOne),
+                    new ReceiverAddressEvent(waiter));
+            });
+
+            var configuration = GetConfiguration();
+            configuration.SchedulingIterations = 10;
+
+            configuration.SchedulingStrategy = SchedulingStrategy.DPOR;
+            AssertSucceeded(configuration, test);
+        }
+
+        [Fact]
+        public void TestDPOR4UseReceive()
+        {
+            var test = new Action<PSharpRuntime>(r =>
+            {
+                MachineId waiter = r.CreateMachine(typeof(ReceiveWaiter));
+
+                var a = r.CreateMachine(typeof(Sender),
+                    new SenderInitEvent(waiter, true));
+                r.SendEvent(a, new Ping());
+                var b = r.CreateMachine(typeof(Sender),
+                    new SenderInitEvent(waiter, true));
+                r.SendEvent(b, new Ping());
+            });
+
+            var configuration = GetConfiguration();
+            configuration.SchedulingIterations = 1000;
+
+            configuration.SchedulingStrategy = SchedulingStrategy.DPOR;
+            AssertSucceeded(configuration, test);
+        }
+    }
+}

--- a/Tests/TestingServices.Tests.Unit/EventHandling/MaxInstances1FailTest.cs
+++ b/Tests/TestingServices.Tests.Unit/EventHandling/MaxInstances1FailTest.cs
@@ -141,6 +141,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
         public void TestMaxInstances1AssertionFailure()
         {
             var configuration = base.GetConfiguration();
+            configuration.ReductionStrategy = ReductionStrategy.None;
             configuration.SchedulingStrategy = SchedulingStrategy.DFS;
             configuration.MaxSchedulingSteps = 6;
             var test = new Action<PSharpRuntime>((r) => { r.CreateMachine(typeof(RealMachine)); });

--- a/Tools/Testing/Tester/Utilities/TesterCommandLineOptions.cs
+++ b/Tools/Testing/Tester/Utilities/TesterCommandLineOptions.cs
@@ -153,6 +153,27 @@ namespace Microsoft.PSharp.Utilities
                         "experimental strategies also exist, but are not listed here).");
                 }
             }
+            else if (option.ToLower().StartsWith("/reduction:"))
+            {
+                string reduction = option.ToLower().Substring(11);
+                if (reduction.ToLower().Equals("none"))
+                {
+                    base.Configuration.ReductionStrategy = ReductionStrategy.None;
+                }
+                else if (reduction.ToLower().Equals("omit"))
+                {
+                    base.Configuration.ReductionStrategy = ReductionStrategy.OmitSchedulingPoints;
+                }
+                else if (reduction.ToLower().Equals("force"))
+                {
+                    base.Configuration.ReductionStrategy = ReductionStrategy.ForceSchedule;
+                }
+                else
+                {
+                    Error.ReportAndExit("Please give a valid reduction strategy " +
+                        "'/reduction:[x]', where [x] is 'none', 'omit' or 'force'.");
+                }
+            }
             else if (option.ToLower().StartsWith("/i:") && option.Length > 3)
             {
                 int i = 0;

--- a/Tools/Testing/Tester/Utilities/TesterCommandLineOptions.cs
+++ b/Tools/Testing/Tester/Utilities/TesterCommandLineOptions.cs
@@ -112,6 +112,14 @@ namespace Microsoft.PSharp.Utilities
                 {
                     base.Configuration.SchedulingStrategy = SchedulingStrategy.IDDFS;
                 }
+                else if (scheduler.ToLower().Equals("dpor"))
+                {
+                    base.Configuration.SchedulingStrategy = SchedulingStrategy.DPOR;
+                }
+                else if (scheduler.ToLower().Equals("rdpor"))
+                {
+                    base.Configuration.SchedulingStrategy = SchedulingStrategy.RDPOR;
+                }
                 else if (scheduler.StartsWith("db"))
                 {
                     int i = 0;
@@ -333,6 +341,8 @@ namespace Microsoft.PSharp.Utilities
                 base.Configuration.SchedulingStrategy != SchedulingStrategy.FairPCT &&
                 base.Configuration.SchedulingStrategy != SchedulingStrategy.DFS &&
                 base.Configuration.SchedulingStrategy != SchedulingStrategy.IDDFS &&
+                base.Configuration.SchedulingStrategy != SchedulingStrategy.DPOR &&
+                base.Configuration.SchedulingStrategy != SchedulingStrategy.RDPOR &&
                 base.Configuration.SchedulingStrategy != SchedulingStrategy.DelayBounding &&
                 base.Configuration.SchedulingStrategy != SchedulingStrategy.RandomDelayBounding)
             {


### PR DESCRIPTION
* Adds the DPOR and random DPOR scheduling strategies.
* Several other changes have been made to scheduling points. 
* There are two integration "unit" tests for DPOR. 
* Also fixed default event handler scheduling points (see #206). 

`TestCycleDetectionCounterResetBug` fails and I can't understand why. 

The `FailureDetectorTest` tests fail, but I assume they are false positives. 
