### PR TITLE
Operation grouping

### DIFF
--- a/Source/Core/Library/Events/EventInfo.cs
+++ b/Source/Core/Library/Events/EventInfo.cs
@@ -24,8 +24,6 @@ namespace Microsoft.PSharp
     [DataContract]
     internal class EventInfo
     {
-        #region fields
-
         /// <summary>
         /// Contained event.
         /// </summary>
@@ -48,9 +46,10 @@ namespace Microsoft.PSharp
         [DataMember]
         internal EventOriginInfo OriginInfo { get; private set; }
 
-        #endregion
-
-        #region constructor
+        /// <summary>
+        /// The operation group id associated with this event.
+        /// </summary>
+        internal ulong OperationGroupId { get; private set; }
 
         /// <summary>
         /// Constructor.
@@ -76,6 +75,13 @@ namespace Microsoft.PSharp
             this.OriginInfo = originInfo;
         }
 
-        #endregion
+        /// <summary>
+        /// Sets the operation group id associated with this event.
+        /// </summary>
+        /// <param name="operationGroupId">Operation group id.</param>
+        internal void SetOperationGroupId(ulong operationGroupId)
+        {
+            this.OperationGroupId = operationGroupId;
+        }
     }
 }

--- a/Source/Core/Library/Machine.cs
+++ b/Source/Core/Library/Machine.cs
@@ -299,7 +299,7 @@ namespace Microsoft.PSharp
             this.Assert(mid != null, $"Machine '{base.Id}' is sending to a null machine.");
             // If the event is null, then report an error and exit.
             this.Assert(e != null, $"Machine '{base.Id}' is sending a null event.");
-            base.Runtime.SendEvent(mid, e, this);
+            base.Runtime.SendEvent(mid, e, this, false);
         }
 
         /// <summary>
@@ -313,7 +313,7 @@ namespace Microsoft.PSharp
             this.Assert(mid != null, $"Machine '{base.Id}' is sending to a null machine.");
             // If the event is null, then report an error and exit.
             this.Assert(e != null, $"Machine '{base.Id}' is sending a null event.");
-            base.Runtime.SendEventRemotely(mid, e, this);
+            base.Runtime.SendEventRemotely(mid, e, this, false);
         }
 
         /// <summary>
@@ -353,7 +353,7 @@ namespace Microsoft.PSharp
             this.Assert(e != null, $"Machine '{base.Id}' is raising a null event.");
             this.RaisedEvent = new EventInfo(e, new EventOriginInfo(
                 base.Id, this.GetType().Name, StateGroup.GetQualifiedStateName(this.CurrentState)));
-            base.Runtime.NotifyRaisedEvent(this, this.RaisedEvent);
+            base.Runtime.NotifyRaisedEvent(this, this.RaisedEvent, false);
         }
 
         /// <summary>

--- a/Source/Core/Runtime/PSharpRuntime.cs
+++ b/Source/Core/Runtime/PSharpRuntime.cs
@@ -207,7 +207,8 @@ namespace Microsoft.PSharp
         /// </summary>
         /// <param name="target">Target machine id</param>
         /// <param name="e">Event</param>
-        public abstract void SendEvent(MachineId target, Event e);
+        /// <param name="isStarter">True if the event is starting a new operation group.</param>
+        public abstract void SendEvent(MachineId target, Event e, bool isStarter = false);
 
         /// <summary>
         /// Synchronously delivers an <see cref="Event"/> to a machine and
@@ -215,14 +216,16 @@ namespace Microsoft.PSharp
         /// </summary>
         /// <param name="target">Target machine id</param>
         /// <param name="e">Event</param>
-        public abstract Task SendEventAndExecute(MachineId target, Event e);
+        /// <param name="isStarter">True if the event is starting a new operation group.</param>
+        public abstract Task SendEventAndExecute(MachineId target, Event e, bool isStarter = false);
 
         /// <summary>
         /// Sends an asynchronous <see cref="Event"/> to a remote machine.
         /// </summary>
         /// <param name="target">Target machine id</param>
         /// <param name="e">Event</param>
-        public abstract void RemoteSendEvent(MachineId target, Event e);
+        /// <param name="isStarter">True if the event is starting a new operation group.</param>
+        public abstract void RemoteSendEvent(MachineId target, Event e, bool isStarter = false);
 
         /// <summary>
         /// Registers a new specification monitor of the specified <see cref="Type"/>.
@@ -322,7 +325,8 @@ namespace Microsoft.PSharp
         /// <param name="mid">MachineId</param>
         /// <param name="e">Event</param>
         /// <param name="sender">Sender machine</param>
-        internal abstract void SendEvent(MachineId mid, Event e, AbstractMachine sender);
+        /// <param name="isStarter">True if the event is starting a new operation group.</param>
+        internal abstract void SendEvent(MachineId mid, Event e, AbstractMachine sender, bool isStarter);
 
         /// <summary>
         /// Sends an asynchronous <see cref="Event"/> to a machine and
@@ -331,7 +335,8 @@ namespace Microsoft.PSharp
         /// <param name="mid">MachineId</param>
         /// <param name="e">Event</param>
         /// <param name="sender">Sender machine</param>
-        internal abstract Task SendEventAndExecute(MachineId mid, Event e, AbstractMachine sender);
+        /// <param name="isStarter">True if the event is starting a new operation group.</param>
+        internal abstract Task SendEventAndExecute(MachineId mid, Event e, AbstractMachine sender, bool isStarter);
 
         /// <summary>
         /// Sends an asynchronous <see cref="Event"/> to a remote machine.
@@ -339,7 +344,8 @@ namespace Microsoft.PSharp
         /// <param name="mid">MachineId</param>
         /// <param name="e">Event</param>
         /// <param name="sender">Sender machine</param>
-        internal abstract void SendEventRemotely(MachineId mid, Event e, AbstractMachine sender);
+        /// <param name="isStarter">True if the event is starting a new operation group.</param>
+        internal abstract void SendEventRemotely(MachineId mid, Event e, AbstractMachine sender, bool isStarter);
 
         #endregion
 
@@ -495,8 +501,9 @@ namespace Microsoft.PSharp
         /// </summary>
         /// <param name="machine">Machine</param>
         /// <param name="eventInfo">EventInfo</param>
+        /// <param name="isStarter">True if the event is starting a new operation group.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal virtual void NotifyRaisedEvent(Machine machine, EventInfo eventInfo)
+        internal virtual void NotifyRaisedEvent(Machine machine, EventInfo eventInfo, bool isStarter)
         {
             // Override to implement the notification.
         }

--- a/Source/Core/Runtime/StateMachineRuntime.cs
+++ b/Source/Core/Runtime/StateMachineRuntime.cs
@@ -15,7 +15,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 
@@ -165,13 +164,14 @@ namespace Microsoft.PSharp
         /// </summary>
         /// <param name="target">Target machine id</param>
         /// <param name="e">Event</param>
-        public override void SendEvent(MachineId target, Event e)
+        /// <param name="isStarter">True if the event is starting a new operation group.</param>
+        public override void SendEvent(MachineId target, Event e, bool isStarter = false)
         {
             // If the target machine is null then report an error and exit.
             base.Assert(target != null, "Cannot send to a null machine.");
             // If the event is null then report an error and exit.
             base.Assert(e != null, "Cannot send a null event.");
-            this.SendEvent(target, e, null);
+            this.SendEvent(target, e, null, isStarter);
         }
 
         /// <summary>
@@ -180,13 +180,14 @@ namespace Microsoft.PSharp
         /// </summary>
         /// <param name="target">Target machine id</param>
         /// <param name="e">Event</param>
-        public override Task SendEventAndExecute(MachineId target, Event e)
+        /// <param name="isStarter">True if the event is starting a new operation group.</param>
+        public override Task SendEventAndExecute(MachineId target, Event e, bool isStarter = false)
         {
             // If the target machine is null then report an error and exit.
             base.Assert(target != null, "Cannot send to a null machine.");
             // If the event is null then report an error and exit.
             base.Assert(e != null, "Cannot send a null event.");
-            return this.SendEventAndExecute(target, e, null);
+            return this.SendEventAndExecute(target, e, null, isStarter);
         }
 
         /// <summary>
@@ -194,13 +195,14 @@ namespace Microsoft.PSharp
         /// </summary>
         /// <param name="target">Target machine id</param>
         /// <param name="e">Event</param>
-        public override void RemoteSendEvent(MachineId target, Event e)
+        /// <param name="isStarter">True if the event is starting a new operation group.</param>
+        public override void RemoteSendEvent(MachineId target, Event e, bool isStarter = false)
         {
             // If the target machine is null then report an error and exit.
             base.Assert(target != null, "Cannot send to a null machine.");
             // If the event is null then report an error and exit.
             base.Assert(e != null, "Cannot send a null event.");
-            this.SendEventRemotely(target, e, null);
+            this.SendEventRemotely(target, e, null, isStarter);
         }
 
         /// <summary>
@@ -317,7 +319,8 @@ namespace Microsoft.PSharp
         /// <param name="mid">MachineId</param>
         /// <param name="e">Event</param>
         /// <param name="sender">Sender machine</param>
-        internal override void SendEvent(MachineId mid, Event e, AbstractMachine sender)
+        /// <param name="isStarter">True if the event is starting a new operation group.</param>
+        internal override void SendEvent(MachineId mid, Event e, AbstractMachine sender, bool isStarter)
         {
             Machine machine = null;
             if (!this.MachineMap.TryGetValue(mid.Value, out machine))
@@ -349,7 +352,8 @@ namespace Microsoft.PSharp
         /// <param name="mid">MachineId</param>
         /// <param name="e">Event</param>
         /// <param name="sender">Sender machine</param>
-        internal override async Task SendEventAndExecute(MachineId mid, Event e, AbstractMachine sender)
+        /// <param name="isStarter">True if the event is starting a new operation group.</param>
+        internal override async Task SendEventAndExecute(MachineId mid, Event e, AbstractMachine sender, bool isStarter)
         {
             Machine machine = null;
             if (!this.MachineMap.TryGetValue(mid.Value, out machine))
@@ -380,7 +384,8 @@ namespace Microsoft.PSharp
         /// <param name="mid">MachineId</param>
         /// <param name="e">Event</param>
         /// <param name="sender">Sender machine</param>
-        internal override void SendEventRemotely(MachineId mid, Event e, AbstractMachine sender)
+        /// <param name="isStarter">True if the event is starting a new operation group.</param>
+        internal override void SendEventRemotely(MachineId mid, Event e, AbstractMachine sender, bool isStarter)
         {
             base.NetworkProvider.RemoteSend(mid, e);
         }
@@ -742,7 +747,8 @@ namespace Microsoft.PSharp
         /// </summary>
         /// <param name="machine">Machine</param>
         /// <param name="eventInfo">EventInfo</param>
-        internal override void NotifyRaisedEvent(Machine machine, EventInfo eventInfo)
+        /// <param name="isStarter">True if the event is starting a new operation group.</param>
+        internal override void NotifyRaisedEvent(Machine machine, EventInfo eventInfo, bool isStarter)
         {
             if (base.Configuration.Verbose <= 1)
             {

--- a/Source/SchedulingStrategies/ISchedulable.cs
+++ b/Source/SchedulingStrategies/ISchedulable.cs
@@ -64,5 +64,11 @@ namespace Microsoft.PSharp.TestingServices.SchedulingStrategies
         /// Monotonically increasing operation count.
         /// </summary>
         ulong OperationCount { get; }
+
+        /// <summary>
+        /// Unique id of the group of operations that is
+        /// associated with the next operation.
+        /// </summary>
+        ulong NextOperationGroupId { get; }
     }
 }

--- a/Source/TestingServices/Scheduling/SchedulableInfo.cs
+++ b/Source/TestingServices/Scheduling/SchedulableInfo.cs
@@ -66,6 +66,12 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
         public ulong OperationCount { get; private set; }
 
         /// <summary>
+        /// Unique id of the group of operations that
+        /// contains the next operation.
+        /// </summary>
+        public ulong NextOperationGroupId { get; private set; }
+
+        /// <summary>
         /// Monotonically increasing operation count for the current event handler.
         /// </summary>
         internal ulong EventHandlerOperationCount { get; private set; }
@@ -100,6 +106,7 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
             HasStarted = false;
             IsCompleted = false;
             OperationCount = 0;
+            NextOperationGroupId = 0;
             EventHandlerOperationCount = 0;
         }
 
@@ -116,6 +123,15 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
             NextOperationType = operation;
             OperationCount++;
             EventHandlerOperationCount++;
+        }
+
+        /// <summary>
+        /// Sets the operation group id associated with this schedulable info.
+        /// </summary>
+        /// <param name="operationGroupId">Operation group id.</param>
+        internal void SetNextOperationGroupId(ulong operationGroupId)
+        {
+            this.NextOperationGroupId = operationGroupId;
         }
 
         /// <summary>

--- a/Tests/TestingServices.Tests.Unit/Features/OperationGroupingTest.cs
+++ b/Tests/TestingServices.Tests.Unit/Features/OperationGroupingTest.cs
@@ -1,0 +1,371 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="OperationGroupingTest.cs">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// 
+//      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+
+using Xunit;
+
+using Microsoft.PSharp.TestingServices.SchedulingStrategies;
+
+namespace Microsoft.PSharp.TestingServices.Tests.Unit
+{
+    public class OperationGroupingTest : BaseTest
+    {
+        class E : Event
+        {
+            public MachineId Id;
+
+            public E() { }
+
+            public E(MachineId id)
+            {
+                Id = id;
+            }
+        }
+
+        class M1 : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            class Init : MachineState { }
+
+            void InitOnEntry()
+            {
+                var id = (Info as ISchedulable).NextOperationGroupId;
+                Assert(id == 0, $"NextOperationGroupId is not '0', but {id}.");
+            }
+        }
+
+        class M2 : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            [OnEventDoAction(typeof(E), nameof(CheckEvent))]
+            class Init : MachineState { }
+
+            void InitOnEntry()
+            {
+                Send(Id, new E());
+            }
+
+            void CheckEvent()
+            {
+                var id = (Info as ISchedulable).NextOperationGroupId;
+                Assert(id == 0, $"NextOperationGroupId is not '0', but {id}.");
+            }
+        }
+
+        class M2S : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            [OnEventDoAction(typeof(E), nameof(CheckEvent))]
+            class Init : MachineState { }
+
+            void InitOnEntry()
+            {
+                Runtime.SendEvent(Id, new E(), true);
+            }
+
+            void CheckEvent()
+            {
+                var id = (Info as ISchedulable).NextOperationGroupId;
+                Assert(id == 1, $"NextOperationGroupId is not '1', but {id}.");
+            }
+        }
+
+        class M3 : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            class Init : MachineState { }
+
+            void InitOnEntry()
+            {
+                var target = CreateMachine(typeof(M4));
+            }
+        }
+
+        class M4 : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            class Init : MachineState { }
+
+            void InitOnEntry()
+            {
+                var id = (Info as ISchedulable).NextOperationGroupId;
+                Assert(id == 0, $"NextOperationGroupId is not '0', but {id}.");
+            }
+        }
+
+        class M5 : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            class Init : MachineState { }
+
+            void InitOnEntry()
+            {
+                var target = CreateMachine(typeof(M6));
+                Send(target, new E());
+            }
+        }
+
+        class M6 : Machine
+        {
+            [Start]
+            [OnEventDoAction(typeof(E), nameof(CheckEvent))]
+            class Init : MachineState { }
+
+            void CheckEvent()
+            {
+                var id = (Info as ISchedulable).NextOperationGroupId;
+                Assert(id == 0, $"NextOperationGroupId is not '0', but {id}.");
+            }
+        }
+
+        class M5S : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            class Init : MachineState { }
+
+            void InitOnEntry()
+            {
+                var target = CreateMachine(typeof(M6S));
+                Runtime.SendEvent(target, new E(), true);
+            }
+        }
+
+        class M6S : Machine
+        {
+            [Start]
+            [OnEventDoAction(typeof(E), nameof(CheckEvent))]
+            class Init : MachineState { }
+
+            void CheckEvent()
+            {
+                var id = (Info as ISchedulable).NextOperationGroupId;
+                Assert(id == 1, $"NextOperationGroupId is not '1', but {id}.");
+            }
+        }
+
+        class M7 : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            [OnEventDoAction(typeof(E), nameof(CheckEvent))]
+            class Init : MachineState { }
+
+            void InitOnEntry()
+            {
+                var target = CreateMachine(typeof(M8));
+                Runtime.SendEvent(target, new E(Id), true);
+            }
+
+            void CheckEvent()
+            {
+                var id = (Info as ISchedulable).NextOperationGroupId;
+                Assert(id == 1, $"NextOperationGroupId is not '1', but {id}.");
+            }
+        }
+
+        class M8 : Machine
+        {
+            [Start]
+            [OnEventDoAction(typeof(E), nameof(CheckEvent))]
+            class Init : MachineState { }
+
+            void CheckEvent()
+            {
+                var id = (Info as ISchedulable).NextOperationGroupId;
+                Assert(id == 1, $"NextOperationGroupId is not '1', but {id}.");
+                Send((ReceivedEvent as E).Id, new E());
+            }
+        }
+
+        class M7S : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            [OnEventDoAction(typeof(E), nameof(CheckEvent))]
+            class Init : MachineState { }
+
+            void InitOnEntry()
+            {
+                var target = CreateMachine(typeof(M8S));
+                Runtime.SendEvent(target, new E(Id), true);
+            }
+
+            void CheckEvent()
+            {
+                var id = (Info as ISchedulable).NextOperationGroupId;
+                Assert(id == 2, $"NextOperationGroupId is not '2', but {id}.");
+            }
+        }
+
+        class M8S : Machine
+        {
+            [Start]
+            [OnEventDoAction(typeof(E), nameof(CheckEvent))]
+            class Init : MachineState { }
+
+            void CheckEvent()
+            {
+                var id = (Info as ISchedulable).NextOperationGroupId;
+                Assert(id == 1, $"NextOperationGroupId is not '1', but {id}.");
+                Runtime.SendEvent((ReceivedEvent as E).Id, new E(), true);
+            }
+        }
+
+        class M9S : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            [OnEventDoAction(typeof(E), nameof(CheckEvent))]
+            class Init : MachineState { }
+
+            void InitOnEntry()
+            {
+                var target = CreateMachine(typeof(M10S));
+                Runtime.SendEvent(target, new E(Id), true);
+            }
+
+            void CheckEvent()
+            {
+                var id = (Info as ISchedulable).NextOperationGroupId;
+                Assert(id == 2, $"NextOperationGroupId is not '2', but {id}.");
+            }
+        }
+
+        class M10S : Machine
+        {
+            [Start]
+            [OnEventDoAction(typeof(E), nameof(CheckEvent))]
+            class Init : MachineState { }
+
+            void CheckEvent()
+            {
+                var target = CreateMachine(typeof(M11S));
+                var id = (Info as ISchedulable).NextOperationGroupId;
+                Assert(id == 1, $"NextOperationGroupId is not '1', but {id}.");
+                Runtime.SendEvent((ReceivedEvent as E).Id, new E(), true);
+            }
+        }
+
+        class M11S : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            class Init : MachineState { }
+
+            void InitOnEntry()
+            {
+                var id = (Info as ISchedulable).NextOperationGroupId;
+                Assert(id == 1, $"NextOperationGroupId is not '1', but {id}.");
+            }
+        }
+
+        [Fact]
+        public void TestOperationGroupingSingleMachineNoSend()
+        {
+            var test = new Action<PSharpRuntime>((r) => {
+                r.CreateMachine(typeof(M1));
+            });
+
+            AssertSucceeded(test);
+        }
+
+        [Fact]
+        public void TestOperationGroupingSingleMachineSend()
+        {
+            var test = new Action<PSharpRuntime>((r) => {
+                r.CreateMachine(typeof(M2));
+            });
+
+            AssertSucceeded(test);
+        }
+
+        [Fact]
+        public void TestOperationGroupingSingleMachineSendStarter()
+        {
+            var test = new Action<PSharpRuntime>((r) => {
+                r.CreateMachine(typeof(M2S));
+            });
+
+            AssertSucceeded(test);
+        }
+
+        [Fact]
+        public void TestOperationGroupingTwoMachinesCreate()
+        {
+            var test = new Action<PSharpRuntime>((r) => {
+                r.CreateMachine(typeof(M3));
+            });
+
+            AssertSucceeded(test);
+        }
+
+        [Fact]
+        public void TestOperationGroupingTwoMachinesSend()
+        {
+            var test = new Action<PSharpRuntime>((r) => {
+                r.CreateMachine(typeof(M5));
+            });
+
+            AssertSucceeded(test);
+        }
+
+        [Fact]
+        public void TestOperationGroupingTwoMachinesSendStarter()
+        {
+            var test = new Action<PSharpRuntime>((r) => {
+                r.CreateMachine(typeof(M5S));
+            });
+
+            AssertSucceeded(test);
+        }
+
+        [Fact]
+        public void TestOperationGroupingTwoMachinesSendBack()
+        {
+            var test = new Action<PSharpRuntime>((r) => {
+                r.CreateMachine(typeof(M7));
+            });
+
+            AssertSucceeded(test);
+        }
+
+        [Fact]
+        public void TestOperationGroupingTwoMachinesSendBackStarter()
+        {
+            var test = new Action<PSharpRuntime>((r) => {
+                r.CreateMachine(typeof(M7S));
+            });
+
+            AssertSucceeded(test);
+        }
+
+        [Fact]
+        public void TestOperationGroupingThreeMachinesSendStarter()
+        {
+            var test = new Action<PSharpRuntime>((r) => {
+                r.CreateMachine(typeof(M9S));
+            });
+
+            AssertSucceeded(test);
+        }
+    }
+}


### PR DESCRIPTION
Operations can now be grouped (this is based on the previous "operation bounding" implementation).
- `SchedulableInfo` and `EventInfo` now expose a `NextOperationGroupId` which can be used for grouping _events_/_operations_ in a chain (e.g. initialization, failure injection).
- A new operation group can start using the optional parameter `isStarter` from `Runtime.SendEvent(...)`. 
- `ISchedulable` exposes `NextOperationGroupId`, which we can use to further reduce the schedule space with DPOR.