### PR TITLE
Support for inheriting handlers from machine states

### DIFF
--- a/Samples/PingPong/PingPong.PSharpLanguage/Client.psharp
+++ b/Samples/PingPong/PingPong.PSharpLanguage/Client.psharp
@@ -2,7 +2,7 @@ namespace PingPong.PSharpLanguage
 {
     /// <summary>
     /// A P# machine that models a simple client.
-    /// 
+    ///
     /// It sends 'Ping' events to a server, and handles received 'Pong' event.
     /// </summary>
     internal machine Client
@@ -50,7 +50,10 @@ namespace PingPong.PSharpLanguage
             }
         }
 
-        state Active
+        // Illustrating state inheritance.
+        state Active : ActiveBaseState { }
+
+        state ActiveBaseState
         {
             entry
             {

--- a/Samples/PingPong/PingPong.PSharpLanguage/Test.cs
+++ b/Samples/PingPong/PingPong.PSharpLanguage/Test.cs
@@ -5,15 +5,15 @@ namespace PingPong.PSharpLanguage
 {
     /// <summary>
     /// A simple PingPong application written using the P# high-level syntax.
-    /// 
+    ///
     /// The P# runtime starts by creating the P# machine 'NetworkEnvironment'. The
     /// 'NetworkEnvironment' machine then creates a 'Server' and a 'Client' machine,
     /// which then communicate by sending 'Ping' and 'Pong' events to each other for
     /// a limited amount of turns.
-    /// 
+    ///
     /// The P# compiler rewrites '.psharp' files to an intermediate C# representation
     /// (see the 'PingPong.PSharpLibrary' sample) before invoking the Roslyn compiler.
-    /// 
+    ///
     /// Note: this is an abstract implementation aimed primarily to showcase the testing
     /// capabilities of P#.
     /// </summary>
@@ -39,7 +39,7 @@ namespace PingPong.PSharpLanguage
         /// <summary>
         /// The P# testing engine uses a method annotated with the 'Microsoft.PSharp.Test'
         /// attribute as an entry point.
-        /// 
+        ///
         /// During testing, the testing engine takes control of the underlying scheduler
         /// and any declared in P# sources of non-determinism (e.g. P# asynchronous APIs,
         /// P# non-determinstic choices) and systematically executes the test method a user

--- a/Samples/Raft/Raft.PSharpLanguage/SafetyMonitor.psharp
+++ b/Samples/Raft/Raft.PSharpLanguage/SafetyMonitor.psharp
@@ -8,14 +8,14 @@ namespace Raft.PSharpLanguage
 {
     monitor SafetyMonitor
     {
-		int CurrentTerm;
+		//unused: int CurrentTerm;
         HashSet<int> TermsWithLeader;
 
 		start state Init
 		{
 			entry
 			{
-				this.CurrentTerm = -1;
+				//this.CurrentTerm = -1;
 				this.TermsWithLeader = new HashSet<int>();
 				raise(LocalEvent);
 			}

--- a/Samples/Raft/Raft.PSharpLibrary/SafetyMonitor.cs
+++ b/Samples/Raft/Raft.PSharpLibrary/SafetyMonitor.cs
@@ -19,7 +19,7 @@ namespace Raft.PSharpLibrary
 
         private class LocalEvent : Event { }
 
-        private int CurrentTerm;
+        //unused: private int CurrentTerm;
         private HashSet<int> TermsWithLeader;
 
         [Start]
@@ -29,7 +29,7 @@ namespace Raft.PSharpLibrary
 
         void InitOnEntry()
         {
-            this.CurrentTerm = -1;
+            //this.CurrentTerm = -1;
             this.TermsWithLeader = new HashSet<int>();
             this.Raise(new LocalEvent());
         }

--- a/Samples/ReplicatingStorage/ReplicatingStorage.PSharpLanguage/Environment.psharp
+++ b/Samples/ReplicatingStorage/ReplicatingStorage.PSharpLanguage/Environment.psharp
@@ -6,7 +6,7 @@ namespace ReplicatingStorage.PSharpLanguage
     machine Environment
     {
 		MachineId NodeManager;
-        int NumberOfReplicas;	// Note: commented out below
+        int NumberOfReplicas;
 		List<machine> AliveNodes;
         int NumberOfFaults;
 		machine Client;
@@ -16,24 +16,19 @@ namespace ReplicatingStorage.PSharpLanguage
 		{
 			entry
 			{
-				/*this.NumberOfReplicas = 3;
+				this.NumberOfReplicas = 3;
 				this.NumberOfFaults = 1;
 				this.AliveNodes = new List<machine>();
 
-				create(LivenessMonitor);
 				monitor<LivenessMonitor>(LConfigureEvent, this.NumberOfReplicas);
 
 				this.NodeManager = create(NodeManager);
 				this.Client = create(Client);
 
-				this.FailureTimer = create(FailureTimer);
-				send(this.FailureTimer, FConfigureEvent, this.Id);
-
-				raise(LocalEvent);*/
+				raise(LocalEvent);
 			}
 
-	        /*on LocalEvent goto Configuring;
-			defer Timeout;*/
+	        on LocalEvent goto Configuring;
 		}
 
 		state Configuring
@@ -66,27 +61,36 @@ namespace ReplicatingStorage.PSharpLanguage
         {
             var node = (trigger as NotifyNode).Node;
             this.AliveNodes.Add(node);
+
+			if (this.AliveNodes.Count == this.NumberOfReplicas &&
+				this.FailureTimer == null)
+			{
+				this.FailureTimer = create(FailureTimer);
+				send(this.FailureTimer, FConfigureEvent, this.Id);
+			}
         }
 
 		void InjectFault()
         {
-            if (this.NumberOfFaults == 0)
+            if (this.NumberOfFaults == 0 ||
+                this.AliveNodes.Count == 0)
             {
                 return;
             }
 
-            foreach (var node in this.AliveNodes)
-            {
-                if (*)
-                {
-                    this.Logger.WriteLine("\n [Environment] injecting fault.\n");
+            var nodeId = this.RandomInteger(this.AliveNodes.Count);
+            var node = this.AliveNodes[nodeId];
 
-                    send(node, FaultInject);
-                    send(this.NodeManager, NotifyFailure, node);
-                    this.AliveNodes.Remove(node);
-                    this.NumberOfFaults--;
-                    break;
-                }
+            this.Logger.WriteLine("\n [Environment] injecting fault.\n");
+
+            send(node, FaultInject);
+            send(this.NodeManager, NotifyFailure, node);
+            this.AliveNodes.Remove(node);
+
+            this.NumberOfFaults--;
+            if (this.NumberOfFaults == 0)
+            {
+                send(this.FailureTimer, halt);
             }
         }
     }

--- a/Samples/TwoPhaseCommit/TwoPhaseCommit.PSharpLibrary/Coordinator.cs
+++ b/Samples/TwoPhaseCommit/TwoPhaseCommit.PSharpLibrary/Coordinator.cs
@@ -68,7 +68,6 @@ namespace TwoPhaseCommit.PSharpLibrary
         private Dictionary<int, int> Data;
         private List<MachineId> Replicas;
         private PendingWriteRequest PendingWriteReq;
-        private MachineId Replica;
         private int CurrSeqNum;
         private int Counter;
         private MachineId Timer;

--- a/Source/Core/Library/Machine.cs
+++ b/Source/Core/Library/Machine.cs
@@ -1366,6 +1366,11 @@ namespace Microsoft.PSharp
                     foreach (var type in StateTypeMap[machineType])
                     {
                         Type stateType = type;
+                        if (type.IsAbstract)
+                        {
+                            continue;
+                        }
+
                         if (type.IsGenericType)
                         {
                             // If the state type is generic (only possible if inherited by a
@@ -1392,7 +1397,15 @@ namespace Microsoft.PSharp
                             Expression.New(constructor)).Compile();
                         MachineState state = lambda();
 
-                        state.InitializeState();
+                        try
+                        {
+                            state.InitializeState();
+                        }
+                        catch (InvalidOperationException ex)
+                        {
+                            this.Assert(false, $"Machine '{base.Id}' {ex.Message} in state '{state}'.");
+                        }
+                        
                         StateMap[machineType].Add(state);
                     }
                 }

--- a/Source/Core/Library/MachineState.cs
+++ b/Source/Core/Library/MachineState.cs
@@ -23,8 +23,6 @@ namespace Microsoft.PSharp
     /// </summary>
     public abstract class MachineState
     {
-        #region fields
-        
         /// <summary>
         /// The entry action of the state.
         /// </summary>
@@ -65,10 +63,6 @@ namespace Microsoft.PSharp
         /// </summary>
         internal bool IsStart { get; private set; }
 
-        #endregion
-
-        #region P# internal methods
-
         /// <summary>
         /// Constructor.
         /// </summary>
@@ -88,8 +82,8 @@ namespace Microsoft.PSharp
             this.IgnoredEvents = new HashSet<Type>();
             this.DeferredEvents = new HashSet<Type>();
 
-            var entryAttribute = this.GetType().GetCustomAttribute(typeof(OnEntry), false) as OnEntry;
-            var exitAttribute = this.GetType().GetCustomAttribute(typeof(OnExit), false) as OnExit;
+            var entryAttribute = this.GetType().GetCustomAttribute(typeof(OnEntry), true) as OnEntry;
+            var exitAttribute = this.GetType().GetCustomAttribute(typeof(OnExit), true) as OnExit;
 
             if (entryAttribute != null)
             {
@@ -101,15 +95,35 @@ namespace Microsoft.PSharp
                 this.ExitAction = exitAttribute.Action;
             }
 
+            // Events with already declared handlers.
+            var handledEvents = new HashSet<Type>();
+
+            // Install event handlers.
+            this.InstallGotoTransitions(handledEvents);
+            this.InstallPushTransitions(handledEvents);
+            this.InstallActionHandlers(handledEvents);
+            this.InstallIgnoreHandlers(handledEvents);
+            this.InstallDeferHandlers(handledEvents);
+
+            if (this.GetType().IsDefined(typeof(Start), false))
+            {
+                this.IsStart = true;
+            }
+        }
+
+        /// <summary>
+        /// Declares goto event handlers, if there are any.
+        /// </summary>
+        /// <param name="handledEvents">Set of handled events.</param>
+        private void InstallGotoTransitions(HashSet<Type> handledEvents)
+        {
             var gotoAttributes = this.GetType().GetCustomAttributes(typeof(OnEventGotoState), false)
                 as OnEventGotoState[];
-            var pushAttributes = this.GetType().GetCustomAttributes(typeof(OnEventPushState), false)
-                as OnEventPushState[];
-            var doAttributes = this.GetType().GetCustomAttributes(typeof(OnEventDoAction), false)
-                as OnEventDoAction[];
 
             foreach (var attr in gotoAttributes)
             {
+                CheckEventHandlerAlreadyDeclared(attr.Event, handledEvents);
+
                 if (attr.Action == null)
                 {
                     this.GotoTransitions.Add(attr.Event, new GotoStateTransition(attr.State));
@@ -118,37 +132,305 @@ namespace Microsoft.PSharp
                 {
                     this.GotoTransitions.Add(attr.Event, new GotoStateTransition(attr.State, attr.Action));
                 }
+
+                handledEvents.Add(attr.Event);
             }
+
+            this.InheritGotoTransitions(this.GetType().BaseType, handledEvents);
+        }
+
+        /// <summary>
+        /// Inherits goto event handlers from a base state, if there is one.
+        /// </summary>
+        /// <param name="baseState">Base state.</param>
+        /// <param name="handledEvents">Set of handled events.</param>
+        private void InheritGotoTransitions(Type baseState, HashSet<Type> handledEvents)
+        {
+            if (!baseState.IsSubclassOf(typeof(MachineState)))
+            {
+                return;
+            }
+
+            var gotoAttributesInherited = baseState.GetCustomAttributes(typeof(OnEventGotoState), false)
+                as OnEventGotoState[];
+
+            var gotoTransitionsInherited = new Dictionary<Type, GotoStateTransition>();
+            foreach (var attr in gotoAttributesInherited)
+            {
+                if (this.GotoTransitions.ContainsKey(attr.Event))
+                {
+                    continue;
+                }
+
+                CheckEventHandlerAlreadyInherited(attr.Event, baseState, handledEvents);
+
+                if (attr.Action == null)
+                {
+                    gotoTransitionsInherited.Add(attr.Event, new GotoStateTransition(attr.State));
+                }
+                else
+                {
+                    gotoTransitionsInherited.Add(attr.Event, new GotoStateTransition(attr.State, attr.Action));
+                }
+
+                handledEvents.Add(attr.Event);
+            }
+
+            foreach (var kvp in gotoTransitionsInherited)
+            {
+                this.GotoTransitions.Add(kvp.Key, kvp.Value);
+            }
+
+            this.InheritGotoTransitions(baseState.BaseType, handledEvents);
+        }
+
+        /// <summary>
+        /// Declares push event handlers, if there are any.
+        /// </summary>
+        /// <param name="handledEvents">Set of handled events.</param>
+        private void InstallPushTransitions(HashSet<Type> handledEvents)
+        {
+            var pushAttributes = this.GetType().GetCustomAttributes(typeof(OnEventPushState), false)
+                as OnEventPushState[];
 
             foreach (var attr in pushAttributes)
             {
+                CheckEventHandlerAlreadyDeclared(attr.Event, handledEvents);
+
                 this.PushTransitions.Add(attr.Event, new PushStateTransition(attr.State));
+                handledEvents.Add(attr.Event);
             }
+
+            this.InheritPushTransitions(this.GetType().BaseType, handledEvents);
+        }
+
+        /// <summary>
+        /// Inherits push event handlers from a base state, if there is one.
+        /// </summary>
+        /// <param name="baseState">Base state.</param>
+        /// <param name="handledEvents">Set of handled events.</param>
+        private void InheritPushTransitions(Type baseState, HashSet<Type> handledEvents)
+        {
+            if (!baseState.IsSubclassOf(typeof(MachineState)))
+            {
+                return;
+            }
+
+            var pushAttributesInherited = baseState.GetCustomAttributes(typeof(OnEventPushState), false)
+                as OnEventPushState[];
+
+            var pushTransitionsInherited = new Dictionary<Type, PushStateTransition>();
+            foreach (var attr in pushAttributesInherited)
+            {
+                if (this.PushTransitions.ContainsKey(attr.Event))
+                {
+                    continue;
+                }
+
+                CheckEventHandlerAlreadyInherited(attr.Event, baseState, handledEvents);
+
+                pushTransitionsInherited.Add(attr.Event, new PushStateTransition(attr.State));
+                handledEvents.Add(attr.Event);
+            }
+
+            foreach (var kvp in pushTransitionsInherited)
+            {
+                this.PushTransitions.Add(kvp.Key, kvp.Value);
+            }
+
+            this.InheritPushTransitions(baseState.BaseType, handledEvents);
+        }
+
+        /// <summary>
+        /// Declares action event handlers, if there are any.
+        /// </summary>
+        /// <param name="handledEvents">Set of handled events.</param>
+        private void InstallActionHandlers(HashSet<Type> handledEvents)
+        {
+            var doAttributes = this.GetType().GetCustomAttributes(typeof(OnEventDoAction), false)
+                as OnEventDoAction[];
 
             foreach (var attr in doAttributes)
             {
+                CheckEventHandlerAlreadyDeclared(attr.Event, handledEvents);
+
                 this.ActionBindings.Add(attr.Event, new ActionBinding(attr.Action));
+                handledEvents.Add(attr.Event);
             }
 
+            this.InheritActionHandlers(this.GetType().BaseType, handledEvents);
+        }
+
+        /// <summary>
+        /// Inherits action event handlers from a base state, if there is one.
+        /// </summary>
+        /// <param name="baseState">Base state.</param>
+        /// <param name="handledEvents">Set of handled events.</param>
+        private void InheritActionHandlers(Type baseState, HashSet<Type> handledEvents)
+        {
+            if (!baseState.IsSubclassOf(typeof(MachineState)))
+            {
+                return;
+            }
+
+            var doAttributesInherited = baseState.GetCustomAttributes(typeof(OnEventDoAction), false)
+                as OnEventDoAction[];
+
+            var actionBindingsInherited = new Dictionary<Type, ActionBinding>();
+            foreach (var attr in doAttributesInherited)
+            {
+                if (this.ActionBindings.ContainsKey(attr.Event))
+                {
+                    continue;
+                }
+
+                CheckEventHandlerAlreadyInherited(attr.Event, baseState, handledEvents);
+
+                actionBindingsInherited.Add(attr.Event, new ActionBinding(attr.Action));
+                handledEvents.Add(attr.Event);
+            }
+
+            foreach (var kvp in actionBindingsInherited)
+            {
+                this.ActionBindings.Add(kvp.Key, kvp.Value);
+            }
+
+            this.InheritActionHandlers(baseState.BaseType, handledEvents);
+        }
+
+        /// <summary>
+        /// Declares ignore event handlers, if there are any.
+        /// </summary>
+        /// <param name="handledEvents">Set of handled events.</param>
+        private void InstallIgnoreHandlers(HashSet<Type> handledEvents)
+        {
             var ignoreEventsAttribute = this.GetType().GetCustomAttribute(typeof(IgnoreEvents), false) as IgnoreEvents;
-            var deferEventsAttribute = this.GetType().GetCustomAttribute(typeof(DeferEvents), false) as DeferEvents;
 
             if (ignoreEventsAttribute != null)
             {
+                foreach (var e in ignoreEventsAttribute.Events)
+                {
+                    CheckEventHandlerAlreadyDeclared(e, handledEvents);
+                }
+
                 this.IgnoredEvents.UnionWith(ignoreEventsAttribute.Events);
+                handledEvents.UnionWith(ignoreEventsAttribute.Events);
             }
 
+            this.InheritIgnoreHandlers(this.GetType().BaseType, handledEvents);
+        }
+
+        /// <summary>
+        /// Inherits ignore event handlers from a base state, if there is one.
+        /// </summary>
+        /// <param name="baseState">Base state.</param>
+        /// <param name="handledEvents">Set of handled events.</param>
+        private void InheritIgnoreHandlers(Type baseState, HashSet<Type> handledEvents)
+        {
+            if (!baseState.IsSubclassOf(typeof(MachineState)))
+            {
+                return;
+            }
+
+            var ignoreEventsAttribute = baseState.GetCustomAttribute(typeof(IgnoreEvents), false) as IgnoreEvents;
+
+            if (ignoreEventsAttribute != null)
+            {
+                foreach (var e in ignoreEventsAttribute.Events)
+                {
+                    if (this.IgnoredEvents.Contains(e))
+                    {
+                        continue;
+                    }
+
+                    CheckEventHandlerAlreadyInherited(e, baseState, handledEvents);
+                }
+
+                this.IgnoredEvents.UnionWith(ignoreEventsAttribute.Events);
+                handledEvents.UnionWith(ignoreEventsAttribute.Events);
+            }
+
+            this.InheritIgnoreHandlers(baseState.BaseType, handledEvents);
+        }
+
+        /// <summary>
+        /// Declares defer event handlers, if there are any.
+        /// </summary>
+        /// <param name="handledEvents">Set of handled events.</param>
+        private void InstallDeferHandlers(HashSet<Type> handledEvents)
+        {
+            var deferEventsAttribute = this.GetType().GetCustomAttribute(typeof(DeferEvents), false) as DeferEvents;
             if (deferEventsAttribute != null)
             {
+                foreach (var e in deferEventsAttribute.Events)
+                {
+                    CheckEventHandlerAlreadyDeclared(e, handledEvents);
+                }
+
                 this.DeferredEvents.UnionWith(deferEventsAttribute.Events);
+                handledEvents.UnionWith(deferEventsAttribute.Events);
             }
 
-            if (this.GetType().IsDefined(typeof(Start), false))
+            this.InheritDeferHandlers(this.GetType().BaseType, handledEvents);
+        }
+
+        /// <summary>
+        /// Inherits defer event handlers from a base state, if there is one.
+        /// </summary>
+        /// <param name="baseState">Base state.</param>
+        /// <param name="handledEvents">Set of handled events.</param>
+        private void InheritDeferHandlers(Type baseState, HashSet<Type> handledEvents)
+        {
+            if (!baseState.IsSubclassOf(typeof(MachineState)))
             {
-                this.IsStart = true;
+                return;
+            }
+
+            var deferEventsAttribute = baseState.GetCustomAttribute(typeof(DeferEvents), false) as DeferEvents;
+            if (deferEventsAttribute != null)
+            {
+                foreach (var e in deferEventsAttribute.Events)
+                {
+                    if (this.DeferredEvents.Contains(e))
+                    {
+                        continue;
+                    }
+
+                    CheckEventHandlerAlreadyInherited(e, baseState, handledEvents);
+                }
+
+                this.DeferredEvents.UnionWith(deferEventsAttribute.Events);
+                handledEvents.UnionWith(deferEventsAttribute.Events);
+            }
+
+            this.InheritDeferHandlers(baseState.BaseType, handledEvents);
+        }
+
+        /// <summary>
+        /// Checks if an event handler has been already declared.
+        /// </summary>
+        /// <param name="e">Event.</param>
+        /// <param name="handledEvents">Set of handled events.</param>
+        private void CheckEventHandlerAlreadyDeclared(Type e, HashSet<Type> handledEvents)
+        {
+            if (handledEvents.Contains(e))
+            {
+                throw new InvalidOperationException($"declared multiple handlers for '{e}'");
             }
         }
 
-        #endregion
+        /// <summary>
+        /// Checks if an event handler has been already inherited.
+        /// </summary>
+        /// <param name="e">Event.</param>
+        /// <param name="baseState">Base state.</param>
+        /// <param name="handledEvents">Set of handled events.</param>
+        private void CheckEventHandlerAlreadyInherited(Type e, Type baseState, HashSet<Type> handledEvents)
+        {
+            if (handledEvents.Contains(e))
+            {
+                throw new InvalidOperationException($"inherited multiple handlers for '{e}' from state '{baseState}'");
+            }
+        }
     }
 }

--- a/Source/Core/Library/Monitor.cs
+++ b/Source/Core/Library/Monitor.cs
@@ -653,6 +653,11 @@ namespace Microsoft.PSharp
                 foreach (var type in StateTypeMap[monitorType])
                 {
                     Type stateType = type;
+                    if (type.IsAbstract)
+                    {
+                        continue;
+                    }
+
                     if (type.IsGenericType)
                     {
                         // If the state type is generic (only possible if inherited by a

--- a/Source/LanguageServices/Parsing/Visitors/Syntax/Declarations/MachineDeclarationVisitor.cs
+++ b/Source/LanguageServices/Parsing/Visitors/Syntax/Declarations/MachineDeclarationVisitor.cs
@@ -201,6 +201,7 @@ namespace Microsoft.PSharp.LanguageServices.Parsing.Syntax
                         base.TokenStream.SkipWhiteSpaceAndCommentTokens();
                         break;
 
+                    case TokenType.Abstract:
                     case TokenType.StartState:
                     case TokenType.HotState:
                     case TokenType.ColdState:

--- a/Source/LanguageServices/Parsing/Visitors/Syntax/Declarations/StateDeclarationVisitor.cs
+++ b/Source/LanguageServices/Parsing/Visitors/Syntax/Declarations/StateDeclarationVisitor.cs
@@ -68,6 +68,24 @@ namespace Microsoft.PSharp.LanguageServices.Parsing.Syntax
             base.TokenStream.Index++;
             base.TokenStream.SkipWhiteSpaceAndCommentTokens();
 
+            // Check for inherited state.
+            if (!base.TokenStream.Done && base.TokenStream.Peek().Type == TokenType.Colon)
+            {
+                base.TokenStream.Index++;
+                base.TokenStream.SkipWhiteSpaceAndCommentTokens();
+                if (base.TokenStream.Done || base.TokenStream.Peek().Type != TokenType.Identifier)
+                {
+                    throw new ParsingException("Expected state identifier.",
+                        new List<TokenType> { TokenType.Identifier });
+                }
+
+                base.TokenStream.Swap(new Token(base.TokenStream.Peek().TextUnit,
+                    TokenType.StateIdentifier));
+                node.BaseStateToken = base.TokenStream.Peek();
+                base.TokenStream.Index++;
+                base.TokenStream.SkipWhiteSpaceAndCommentTokens();
+            }
+
             if (base.TokenStream.Done ||
                 base.TokenStream.Peek().Type != TokenType.LeftCurlyBracket)
             {
@@ -323,12 +341,7 @@ namespace Microsoft.PSharp.LanguageServices.Parsing.Syntax
                     new List<TokenType>());
             }
 
-            if (modSet.InheritanceModifier == InheritanceModifier.Abstract)
-            {
-                throw new ParsingException("A machine state cannot be abstract.",
-                    new List<TokenType>());
-            }
-            else if (modSet.InheritanceModifier == InheritanceModifier.Virtual)
+            if (modSet.InheritanceModifier == InheritanceModifier.Virtual)
             {
                 throw new ParsingException("A machine state cannot be virtual.",
                     new List<TokenType>());

--- a/Tests/LanguageServices.Tests.Unit/Declarations/EventTests.cs
+++ b/Tests/LanguageServices.Tests.Unit/Declarations/EventTests.cs
@@ -381,7 +381,7 @@ abstract event e;
 {
 }
 }";
-            LanguageTestUtilities.AssertFailedTestLog("Unexpected token 'abstract'.", test);
+            LanguageTestUtilities.AssertFailedTestLog("An event cannot be declared as abstract.", test);
         }
 
         [Fact]

--- a/Tests/LanguageServices.Tests.Unit/Declarations/MachineStateInheritanceTests.cs
+++ b/Tests/LanguageServices.Tests.Unit/Declarations/MachineStateInheritanceTests.cs
@@ -1,0 +1,613 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="MachineStateInheritanceTests.cs">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// 
+//      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Xunit;
+
+namespace Microsoft.PSharp.LanguageServices.Tests.Unit
+{
+    public class MachineStateInheritanceTests
+    {
+        #region correct tests
+
+        [Fact]
+        public void TestAbstractBaseStateWithOnEventDeclaration()
+        {
+            var test = @"
+namespace Foo {
+    machine Machine1 {
+        start state Init : BaseState {
+            entry {
+                send(this.Id, E);
+            }
+        }
+
+        abstract state BaseState {
+            on E do Check;
+        }
+
+        void Check() {
+            assert(false, ""Check reached."")
+        }
+    }
+}";
+            var expected = @"
+using Microsoft.PSharp;
+
+namespace Foo
+{
+    class Machine1 : Machine
+    {
+        [Microsoft.PSharp.Start]
+        [OnEntry(nameof(psharp_Init_on_entry_action))]
+        class Init : BaseState
+        {
+        }
+
+        [OnEventDoAction(typeof(E), nameof(Check))]
+        abstract class BaseState : MachineState
+        {
+        }
+
+        void Check()
+        {
+            this.Assert(false, ""Check reached."")
+        }
+
+        protected void psharp_Init_on_entry_action()
+        {
+            this.Send(this.Id,new E());
+        }
+    }
+}";
+            AssertWithEntryExitReplacement(expected, test);
+        }
+
+        [Fact]
+        public void TestBaseStateWithOnEventDeclaration()
+        {
+            var test = @"
+namespace Foo {
+    event E;
+    
+    machine Machine1 {
+        start state Init : BaseState {
+            entry {
+                send(this.Id, E);
+            }
+        }
+
+        state BaseState {
+            on E do Check;
+        }
+
+        void Check() {
+            assert(false, ""Check reached."")
+        }
+    }
+}";
+            var expected = @"
+using Microsoft.PSharp;
+
+namespace Foo
+{
+    public class E : Event
+    {
+        public E()
+            : base()
+        {
+        }
+    }
+
+    class Machine1 : Machine
+    {
+        [Microsoft.PSharp.Start]
+        [OnEntry(nameof(psharp_Init_on_entry_action))]
+        class Init : BaseState
+        {
+        }
+
+        [OnEventDoAction(typeof(E), nameof(Check))]
+        class BaseState : MachineState
+        {
+        }
+
+        void Check()
+        {
+            this.Assert(false, ""Check reached."")
+        }
+
+        protected void psharp_Init_on_entry_action()
+        {
+            this.Send(this.Id,new E());
+        }
+    }
+}";
+            AssertWithEntryExitReplacement(expected, test);
+        }
+
+        [Fact]
+        public void TestBaseAndDerivedOnEntry()
+        {
+            var test = @"
+namespace Foo {
+    event E1;
+    event E2;
+    
+    machine Machine1 {
+        start state Init : BaseState {
+            entry {
+                send(this.Id, E1);
+            }
+        }
+
+        abstract state BaseState {
+            entry {
+                send(this.Id, E2);
+            }
+        }
+    }
+}";
+            var expected = @"
+using Microsoft.PSharp;
+
+namespace Foo
+{
+    public class E1 : Event
+    {
+        public E1()
+            : base()
+        {
+        }
+    }
+
+    public class E2 : Event
+    {
+        public E2()
+            : base()
+        {
+        }
+    }
+
+    class Machine1 : Machine
+    {
+        [Microsoft.PSharp.Start]
+        [OnEntry(nameof(psharp_Init_on_entry_action))]
+        class Init : BaseState
+        {
+        }
+
+        [OnEntry(nameof(psharp_BaseState_on_entry_action))]
+        abstract class BaseState : MachineState
+        {
+        }
+
+        protected void psharp_Init_on_entry_action()
+        {
+            this.Send(this.Id,new E1());
+        }
+
+        protected void psharp_BaseState_on_entry_action()
+        {
+            this.Send(this.Id,new E2());
+        }
+    }
+}";
+            AssertWithEntryExitReplacement(expected, test);
+        }
+
+        [Fact]
+        public void TestBaseAndDerivedEachWithOnEntryAndDoAction()
+        {
+            var test = @"
+namespace Foo {
+    machine Machine1 {
+        start state Init : BaseState {
+            entry {
+                send(this.Id, E1);
+            }
+            on E1 do Check1;
+        }
+
+        abstract state BaseState {
+            entry {
+                send(this.Id, E2);
+            }
+            on E2 do Check2;
+        }
+
+        void Check1() {
+            assert(false, ""Check1 reached."")
+        }
+
+        void Check2() {
+            assert(false, ""Check2 reached."")
+        }
+    }
+}";
+            var expected = @"
+using Microsoft.PSharp;
+
+namespace Foo
+{
+    class Machine1 : Machine
+    {
+        [Microsoft.PSharp.Start]
+        [OnEntry(nameof(psharp_Init_on_entry_action))]
+        [OnEventDoAction(typeof(E1), nameof(Check1))]
+        class Init : BaseState
+        {
+        }
+
+        [OnEntry(nameof(psharp_BaseState_on_entry_action))]
+        [OnEventDoAction(typeof(E2), nameof(Check2))]
+        abstract class BaseState : MachineState
+        {
+        }
+
+        void Check1()
+        {
+            this.Assert(false, ""Check1 reached."")
+        }
+
+        void Check2()
+        {
+            this.Assert(false, ""Check2 reached."")
+        }
+
+        protected void psharp_Init_on_entry_action()
+        {
+            this.Send(this.Id,new E1());
+        }
+
+        protected void psharp_BaseState_on_entry_action()
+        {
+            this.Send(this.Id,new E2());
+        }
+    }
+}";
+            AssertWithEntryExitReplacement(expected, test);
+        }
+
+        [Fact]
+        public void TestThirdUnderivedState()
+        {
+            var test = @"
+namespace Foo {
+    machine Machine1 {
+        start state SecondState : BaseState {
+            entry { send(this.Id, E1); }
+        }
+
+        state BaseState {
+            entry { send(this.Id, E2); }
+        }
+
+        state ThirdState : SecondState {
+            entry { send(this.Id, E3); }
+        }
+    }
+}";
+            var expected = @"
+using Microsoft.PSharp;
+
+namespace Foo
+{
+    class Machine1 : Machine
+    {
+        [Microsoft.PSharp.Start]
+        [OnEntry(nameof(psharp_SecondState_on_entry_action))]
+        class SecondState : BaseState
+        {
+        }
+
+        [OnEntry(nameof(psharp_BaseState_on_entry_action))]
+        class BaseState : MachineState
+        {
+        }
+
+        [OnEntry(nameof(psharp_ThirdState_on_entry_action))]
+        class ThirdState : SecondState
+        {
+        }
+
+        protected void psharp_SecondState_on_entry_action()
+        { this.Send(this.Id,new E1()); }
+
+        protected void psharp_BaseState_on_entry_action()
+        { this.Send(this.Id,new E2()); }
+
+        protected void psharp_ThirdState_on_entry_action()
+        { this.Send(this.Id,new E3()); }
+    }
+}";
+            AssertWithEntryExitReplacement(expected, test);
+        }
+
+        [Fact]
+        public void TestNestedDerivedState()
+        {
+            var test = @"
+namespace Foo {
+    machine Machine1 {
+        start state Init : ThirdState {
+            entry {
+                send(this.Id, E1);
+            }
+        }
+
+        state BaseState {
+            entry {
+                send(this.Id, E2);
+            }
+        }
+
+        state ThirdState : BaseState {
+            entry {
+                send(this.Id, E3);
+            }
+        }
+    }
+}";
+            var expected = @"
+using Microsoft.PSharp;
+
+namespace Foo
+{
+    class Machine1 : Machine
+    {
+        [Microsoft.PSharp.Start]
+        [OnEntry(nameof(psharp_Init_on_entry_action))]
+        class Init : ThirdState
+        {
+        }
+
+        [OnEntry(nameof(psharp_BaseState_on_entry_action))]
+        class BaseState : MachineState
+        {
+        }
+
+        [OnEntry(nameof(psharp_ThirdState_on_entry_action))]
+        class ThirdState : BaseState
+        {
+        }
+
+        protected void psharp_Init_on_entry_action()
+        {
+            this.Send(this.Id,new E1());
+        }
+
+        protected void psharp_BaseState_on_entry_action()
+        {
+            this.Send(this.Id,new E2());
+        }
+
+        protected void psharp_ThirdState_on_entry_action()
+        {
+            this.Send(this.Id,new E3());
+        }
+    }
+}";
+            AssertWithEntryExitReplacement(expected, test);
+        }
+
+        [Fact]
+        public void TestBaseAsyncEntryDeclaration()
+        {
+            var test = @"
+namespace Foo {
+    machine M {
+        start state Init : BaseState {
+            entry { send(this.Id, E1); }
+        }
+
+        state BaseState {
+            async entry { await Task.Delay(42); }
+        }
+    }
+}";
+            var expected = @"
+using Microsoft.PSharp;
+
+namespace Foo
+{
+    class M : Machine
+    {
+        [Microsoft.PSharp.Start]
+        [OnEntry(nameof(psharp_Init_on_entry_action))]
+        class Init : BaseState
+        {
+        }
+
+        [OnEntry(nameof(psharp_BaseState_on_entry_action_async))]
+        class BaseState : MachineState
+        {
+        }
+
+        protected void psharp_Init_on_entry_action()
+        { this.Send(this.Id,new E1()); }
+
+        protected async System.Threading.Tasks.Task psharp_BaseState_on_entry_action_async()
+        { await Task.Delay(42); }
+    }
+}";
+            AssertWithEntryExitReplacement(expected, test);
+        }
+
+        [Fact]
+        public void TestDerivedAsyncEntryDeclaration()
+        {
+            var test = @"
+namespace Foo {
+    machine M {
+        start state Init : BaseState {
+            async entry { await Task.Delay(42); }
+        }
+
+        state BaseState {
+            entry { send(this.Id, E1); }
+        }
+    }
+}";
+            var expected = @"
+using Microsoft.PSharp;
+
+namespace Foo
+{
+    class M : Machine
+    {
+        [Microsoft.PSharp.Start]
+        [OnEntry(nameof(psharp_Init_on_entry_action_async))]
+        class Init : BaseState
+        {
+        }
+
+        [OnEntry(nameof(psharp_BaseState_on_entry_action))]
+        class BaseState : MachineState
+        {
+        }
+
+        protected async System.Threading.Tasks.Task psharp_Init_on_entry_action_async()
+        { await Task.Delay(42); }
+
+        protected void psharp_BaseState_on_entry_action()
+        { this.Send(this.Id,new E1()); }
+    }
+}";
+            AssertWithEntryExitReplacement(expected, test);
+        }
+
+        [Fact]
+        public void TestBaseAndDerivedAsyncEntryDeclaration()
+        {
+            var test = @"
+namespace Foo {
+    machine M {
+        start state Init : BaseState {
+            async entry { await Task.Delay(42); }
+        }
+
+        state BaseState {
+            async entry { await Task.Delay(43); }
+        }
+    }
+}";
+            var expected = @"
+using Microsoft.PSharp;
+
+namespace Foo
+{
+    class M : Machine
+    {
+        [Microsoft.PSharp.Start]
+        [OnEntry(nameof(psharp_Init_on_entry_action_async))]
+        class Init : BaseState
+        {
+        }
+
+        [OnEntry(nameof(psharp_BaseState_on_entry_action_async))]
+        class BaseState : MachineState
+        {
+        }
+
+        protected async System.Threading.Tasks.Task psharp_Init_on_entry_action_async()
+        { await Task.Delay(42); }
+
+        protected async System.Threading.Tasks.Task psharp_BaseState_on_entry_action_async()
+        { await Task.Delay(43); }
+    }
+}";
+            AssertWithEntryExitReplacement(expected, test);
+        }
+
+        [Fact]
+        public void TestInheritedOnEventGotoStateDeclaration()
+        {
+            var test = @"
+namespace Foo {
+    machine M {
+        abstract state BaseState
+        {
+            on e goto BaseDest;
+        }
+        start state Init : BaseState
+        {
+            on e goto InitDest;
+        }
+    }
+}";
+            var expected = @"
+using Microsoft.PSharp;
+
+namespace Foo
+{
+    class M : Machine
+    {
+        [OnEventGotoState(typeof(e), typeof(BaseDest))]
+        abstract class BaseState : MachineState
+        {
+        }
+
+        [Microsoft.PSharp.Start]
+        [OnEventGotoState(typeof(e), typeof(InitDest))]
+        class Init : BaseState
+        {
+        }
+    }
+}";
+            LanguageTestUtilities.AssertRewritten(expected, test);
+        }
+
+
+        #endregion
+
+        #region failure tests
+
+        [Fact]
+        public void TestOnlyOneStartState()
+        {
+            var test = @"
+namespace Foo {
+    machine Machine1 {
+        start state Init : BaseState {
+        }
+
+        start state BaseState {
+        }
+    }
+}";
+            LanguageTestUtilities.AssertFailedTestLog("A machine can declare only a single start state.", test);
+        }
+
+        #endregion
+
+        #region utility methods
+        private string ReplaceEntryWithExitInTest(string test)
+        {
+            return test.Replace("entry {", "exit {").Replace("entry{", "exit{");
+        }
+
+        private string ReplaceEntryWithExitInExpected(string expected)
+        {
+            return expected.Replace("OnEntry(", "OnExit(").Replace("_entry_", "_exit_");
+        }
+
+        private void AssertWithEntryExitReplacement(string expected, string test)
+        {
+            // Test both Entry and Exit combination
+            LanguageTestUtilities.AssertRewritten(expected, test);
+            LanguageTestUtilities.AssertRewritten(ReplaceEntryWithExitInExpected(expected), ReplaceEntryWithExitInTest(test));
+        }
+        #endregion
+    }
+}

--- a/Tests/LanguageServices.Tests.Unit/Declarations/StateTests.cs
+++ b/Tests/LanguageServices.Tests.Unit/Declarations/StateTests.cs
@@ -1108,6 +1108,93 @@ namespace Foo
             LanguageTestUtilities.AssertRewritten(expected, test);
         }
 
+        [Fact]
+        public void TestMultipleEventsSameAnonymousDo()
+        {
+            var test = @"
+namespace Foo {
+    machine M {
+        start state S
+        {
+            on E1, E2, E3 do {
+                assert(false, ""handler for all 3 events"");
+            }
+        }
+    }
+}";
+            var expected = @"
+using Microsoft.PSharp;
+
+namespace Foo
+{
+    class M : Machine
+    {
+        [Microsoft.PSharp.Start]
+        [OnEventDoAction(typeof(E1), nameof(psharp_S_E1_action))]
+        [OnEventDoAction(typeof(E2), nameof(psharp_S_E2_action))]
+        [OnEventDoAction(typeof(E3), nameof(psharp_S_E3_action))]
+        class S : MachineState
+        {
+        }
+
+        protected void psharp_S_E1_action()
+        {
+            this.Assert(false, ""handler for all 3 events"");
+        }
+
+        protected void psharp_S_E2_action()
+        {
+            this.Assert(false, ""handler for all 3 events"");
+        }
+
+        protected void psharp_S_E3_action()
+        {
+            this.Assert(false, ""handler for all 3 events"");
+        }
+    }
+}";
+            LanguageTestUtilities.AssertRewritten(expected, test);
+        }
+
+        [Fact]
+        public void TestMultipleEventsSameNamedDo()
+        {
+            var test = @"
+namespace Foo {
+    machine M {
+        start state S
+        {
+            on E1, E2, E3 do Check;
+        }
+        void Check() {
+            assert(false, ""handler for all 3 events"");
+        }
+    }
+}";
+            var expected = @"
+using Microsoft.PSharp;
+
+namespace Foo
+{
+    class M : Machine
+    {
+        [Microsoft.PSharp.Start]
+        [OnEventDoAction(typeof(E1), nameof(Check))]
+        [OnEventDoAction(typeof(E2), nameof(Check))]
+        [OnEventDoAction(typeof(E3), nameof(Check))]
+        class S : MachineState
+        {
+        }
+
+        void Check()
+        {
+            this.Assert(false, ""handler for all 3 events"");
+        }
+    }
+}";
+            LanguageTestUtilities.AssertRewritten(expected, test);
+        }
+
         #endregion
 
         #region failure tests

--- a/Tests/TestingServices.Tests.Unit/Asynchrony/AsyncAwaitTest.cs
+++ b/Tests/TestingServices.Tests.Unit/Asynchrony/AsyncAwaitTest.cs
@@ -72,7 +72,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
             });
 
             var bugReport = "Detected synchronization context that is not controlled by the P# runtime.";
-            base.AssertFailed(test, bugReport);
+            base.AssertFailed(test, bugReport, true);
         }
     }
 }

--- a/Tests/TestingServices.Tests.Unit/Asynchrony/ReceiveTest.cs
+++ b/Tests/TestingServices.Tests.Unit/Asynchrony/ReceiveTest.cs
@@ -46,7 +46,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
             });
 
             var bugReport = "Detected an assertion failure.";
-            base.AssertFailed(test, bugReport);
+            base.AssertFailed(test, bugReport, true);
         }
     }
 }

--- a/Tests/TestingServices.Tests.Unit/Asynchrony/ReceiveWaitTest.cs
+++ b/Tests/TestingServices.Tests.Unit/Asynchrony/ReceiveWaitTest.cs
@@ -46,7 +46,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
             });
 
             var bugReport = "Detected an assertion failure.";
-            base.AssertFailed(test, bugReport);
+            base.AssertFailed(test, bugReport, true);
         }
     }
 }

--- a/Tests/TestingServices.Tests.Unit/BaseTest.cs
+++ b/Tests/TestingServices.Tests.Unit/BaseTest.cs
@@ -60,35 +60,35 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
 
         #region tests that fail an assertion
 
-        protected void AssertFailed(Action<PSharpRuntime> test, int numExpectedErrors)
+        protected void AssertFailed(Action<PSharpRuntime> test, int numExpectedErrors, bool replay)
         {
             var configuration = GetConfiguration();
-            AssertFailed(configuration, test, numExpectedErrors);
+            AssertFailed(configuration, test, numExpectedErrors, replay);
         }
 
-        protected void AssertFailed(Action<PSharpRuntime> test, string expectedOutput)
+        protected void AssertFailed(Action<PSharpRuntime> test, string expectedOutput, bool replay)
         {
             var configuration = GetConfiguration();
-            AssertFailed(configuration, test, 1, new HashSet<string> { expectedOutput });
+            AssertFailed(configuration, test, 1, new HashSet<string> { expectedOutput }, replay);
         }
 
-        protected void AssertFailed(Action<PSharpRuntime> test, int numExpectedErrors, ISet<string> expectedOutputs)
+        protected void AssertFailed(Action<PSharpRuntime> test, int numExpectedErrors, ISet<string> expectedOutputs, bool replay)
         {
             var configuration = GetConfiguration();
-            AssertFailed(configuration, test, numExpectedErrors, expectedOutputs);
+            AssertFailed(configuration, test, numExpectedErrors, expectedOutputs, replay);
         }
 
-        protected void AssertFailed(Configuration configuration, Action<PSharpRuntime> test, int numExpectedErrors)
+        protected void AssertFailed(Configuration configuration, Action<PSharpRuntime> test, int numExpectedErrors, bool replay)
         {
-            AssertFailed(configuration, test, numExpectedErrors, new HashSet<string>());
+            AssertFailed(configuration, test, numExpectedErrors, new HashSet<string>(), replay);
         }
 
-        protected void AssertFailed(Configuration configuration, Action<PSharpRuntime> test, string expectedOutput)
+        protected void AssertFailed(Configuration configuration, Action<PSharpRuntime> test, string expectedOutput, bool replay)
         {
-            AssertFailed(configuration, test, 1, new HashSet<string> { expectedOutput });
+            AssertFailed(configuration, test, 1, new HashSet<string> { expectedOutput }, replay);
         }
 
-        protected void AssertFailed(Configuration configuration, Action<PSharpRuntime> test, int numExpectedErrors, ISet<string> expectedOutputs)
+        protected void AssertFailed(Configuration configuration, Action<PSharpRuntime> test, int numExpectedErrors, ISet<string> expectedOutputs, bool replay)
         {
             InMemoryLogger logger = new InMemoryLogger();
 
@@ -100,7 +100,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
 
                 CheckErrors(bfEngine, numExpectedErrors, expectedOutputs);
 
-                if (!configuration.EnableCycleDetection)
+                if (replay && !configuration.EnableCycleDetection)
                 {
                     var rEngine = ReplayEngine.Create(configuration, test, bfEngine.ReproducableTrace);
                     rEngine.SetLogger(logger);
@@ -145,13 +145,13 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
 
         #region tests that throw an exception
 
-        protected void AssertFailedWithException(Action<PSharpRuntime> test, Type exceptionType)
+        protected void AssertFailedWithException(Action<PSharpRuntime> test, Type exceptionType, bool replay)
         {
             var configuration = GetConfiguration();
-            AssertFailedWithException(configuration, test, exceptionType);
+            AssertFailedWithException(configuration, test, exceptionType, replay);
         }
 
-        protected void AssertFailedWithException(Configuration configuration, Action<PSharpRuntime> test, Type exceptionType)
+        protected void AssertFailedWithException(Configuration configuration, Action<PSharpRuntime> test, Type exceptionType, bool replay)
         {
             Assert.True(exceptionType.IsSubclassOf(typeof(Exception)), "Please configure the test correctly. " +
                 $"Type '{exceptionType}' is not an exception type.");
@@ -166,7 +166,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
 
                 CheckErrors(bfEngine, exceptionType);
 
-                if (!configuration.EnableCycleDetection)
+                if (replay && !configuration.EnableCycleDetection)
                 {
                     var rEngine = ReplayEngine.Create(configuration, test, bfEngine.ReproducableTrace);
                     rEngine.SetLogger(logger);

--- a/Tests/TestingServices.Tests.Unit/Concurrency/ExternalConcurrencyTest.cs
+++ b/Tests/TestingServices.Tests.Unit/Concurrency/ExternalConcurrencyTest.cs
@@ -58,7 +58,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
         {
             var test = new Action<PSharpRuntime>((r) => { r.CreateMachine(typeof(M)); });
             string bugReport = @"Detected task with id '' that is not controlled by the P# runtime.";
-            base.AssertFailed(test, bugReport);
+            base.AssertFailed(test, bugReport, true);
         }
 
         [Fact]
@@ -66,7 +66,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
         {
             var test = new Action<PSharpRuntime>((r) => { r.CreateMachine(typeof(N)); });
             string bugReport = @"Detected task with id '' that is not controlled by the P# runtime.";
-            base.AssertFailed(test, bugReport);
+            base.AssertFailed(test, bugReport, true);
         }
     }
 }

--- a/Tests/TestingServices.Tests.Unit/EntryPoint/EntryPointEventSendingTest.cs
+++ b/Tests/TestingServices.Tests.Unit/EntryPoint/EntryPointEventSendingTest.cs
@@ -52,7 +52,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
             });
 
             var bugReport = "Value is 0.";
-            base.AssertFailed(test, bugReport);
+            base.AssertFailed(test, bugReport, true);
         }
     }
 }

--- a/Tests/TestingServices.Tests.Unit/EntryPoint/EntryPointMachineExecutionTest.cs
+++ b/Tests/TestingServices.Tests.Unit/EntryPoint/EntryPointMachineExecutionTest.cs
@@ -47,7 +47,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
             });
 
             var bugReport = "Reached test assertion.";
-            base.AssertFailed(test, bugReport);
+            base.AssertFailed(test, bugReport, true);
         }
     }
 }

--- a/Tests/TestingServices.Tests.Unit/EntryPoint/EntryPointThrowExceptionTest.cs
+++ b/Tests/TestingServices.Tests.Unit/EntryPoint/EntryPointThrowExceptionTest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
                 throw new InvalidOperationException();
             });
 
-            base.AssertFailedWithException(test, typeof(InvalidOperationException));
+            base.AssertFailedWithException(test, typeof(InvalidOperationException), true);
         }
 
         [Fact]
@@ -44,7 +44,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
                 throw new InvalidOperationException();
             });
 
-            base.AssertFailedWithException(test, typeof(InvalidOperationException));
+            base.AssertFailedWithException(test, typeof(InvalidOperationException), true);
         }
     }
 }

--- a/Tests/TestingServices.Tests.Unit/EventHandling/Actions1FailTest.cs
+++ b/Tests/TestingServices.Tests.Unit/EventHandling/Actions1FailTest.cs
@@ -139,7 +139,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
             var configuration = base.GetConfiguration();
             configuration.SchedulingStrategy = SchedulingStrategy.DFS;
             var test = new Action<PSharpRuntime>((r) => { r.CreateMachine(typeof(Real)); });
-            base.AssertFailed(configuration, test, 1);
+            base.AssertFailed(configuration, test, 1, true);
         }
     }
 }

--- a/Tests/TestingServices.Tests.Unit/EventHandling/Actions5FailTest.cs
+++ b/Tests/TestingServices.Tests.Unit/EventHandling/Actions5FailTest.cs
@@ -143,7 +143,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
             var configuration = base.GetConfiguration();
             configuration.SchedulingStrategy = SchedulingStrategy.DFS;
             var test = new Action<PSharpRuntime>((r) => { r.CreateMachine(typeof(Real)); });
-            base.AssertFailed(configuration, test, 1);
+            base.AssertFailed(configuration, test, 1, true);
         }
     }
 }

--- a/Tests/TestingServices.Tests.Unit/EventHandling/Actions6FailTest.cs
+++ b/Tests/TestingServices.Tests.Unit/EventHandling/Actions6FailTest.cs
@@ -136,7 +136,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
             var configuration = base.GetConfiguration();
             configuration.SchedulingStrategy = SchedulingStrategy.DFS;
             var test = new Action<PSharpRuntime>((r) => { r.CreateMachine(typeof(Real)); });
-            base.AssertFailed(configuration, test, 1);
+            base.AssertFailed(configuration, test, 1, true);
         }
     }
 }

--- a/Tests/TestingServices.Tests.Unit/EventHandling/MaxInstances1FailTest.cs
+++ b/Tests/TestingServices.Tests.Unit/EventHandling/MaxInstances1FailTest.cs
@@ -145,7 +145,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
             configuration.SchedulingStrategy = SchedulingStrategy.DFS;
             configuration.MaxSchedulingSteps = 6;
             var test = new Action<PSharpRuntime>((r) => { r.CreateMachine(typeof(RealMachine)); });
-            base.AssertFailed(configuration, test, 1);
+            base.AssertFailed(configuration, test, 1, true);
         }
     }
 }

--- a/Tests/TestingServices.Tests.Unit/EventHandling/ReceiveEvent/ReceiveEventFailTest.cs
+++ b/Tests/TestingServices.Tests.Unit/EventHandling/ReceiveEvent/ReceiveEventFailTest.cs
@@ -110,7 +110,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
             var test = new Action<PSharpRuntime>((r) => { r.CreateMachine(typeof(Server)); });
             var bugReport = "Livelock detected. 'Microsoft.PSharp.TestingServices.Tests.Unit.ReceiveEventFailTest+" +
                 "Client()' is waiting for an event, but no other schedulable choices are enabled.";
-            base.AssertFailed(configuration, test, bugReport);
+            base.AssertFailed(configuration, test, bugReport, true);
         }
 
         [Fact]
@@ -125,7 +125,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
             var bugReport = "Livelock detected. 'Microsoft.PSharp.TestingServices.Tests.Unit.ReceiveEventFailTest+" +
                 "Client()' and 'Microsoft.PSharp.TestingServices.Tests.Unit.ReceiveEventFailTest+Client()' " +
                 "are waiting for an event, but no other schedulable choices are enabled.";
-            base.AssertFailed(configuration, test, bugReport);
+            base.AssertFailed(configuration, test, bugReport, true);
         }
 
         [Fact]
@@ -142,7 +142,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
                 "Client()', 'Microsoft.PSharp.TestingServices.Tests.Unit.ReceiveEventFailTest+Client()' " +
                 "and 'Microsoft.PSharp.TestingServices.Tests.Unit.ReceiveEventFailTest+Client()' " +
                 "are waiting for an event, but no other schedulable choices are enabled.";
-            base.AssertFailed(configuration, test, bugReport);
+            base.AssertFailed(configuration, test, bugReport, true);
         }
     }
 }

--- a/Tests/TestingServices.Tests.Unit/Liveness/CycleDetection/CycleDetectionBasicTest.cs
+++ b/Tests/TestingServices.Tests.Unit/Liveness/CycleDetection/CycleDetectionBasicTest.cs
@@ -100,7 +100,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
             });
 
             string bugReport = "Monitor 'WatchDog' detected infinite execution that violates a liveness property.";
-            base.AssertFailed(configuration, test, bugReport);
+            base.AssertFailed(configuration, test, bugReport, true);
         }
     }
 }

--- a/Tests/TestingServices.Tests.Unit/Liveness/CycleDetection/CycleDetectionCounterTest.cs
+++ b/Tests/TestingServices.Tests.Unit/Liveness/CycleDetection/CycleDetectionCounterTest.cs
@@ -119,7 +119,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
             });
 
             string bugReport = "Monitor 'WatchDog' detected infinite execution that violates a liveness property.";
-            base.AssertFailed(configuration, test, bugReport);
+            base.AssertFailed(configuration, test, bugReport, true);
         }
 
         [Fact]
@@ -136,7 +136,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
             });
 
             string bugReport = "Monitor 'WatchDog' detected infinite execution that violates a liveness property.";
-            base.AssertFailed(configuration, test, bugReport);
+            base.AssertFailed(configuration, test, bugReport, true);
         }
     }
 }

--- a/Tests/TestingServices.Tests.Unit/Liveness/CycleDetection/CycleDetectionDefaultHandlerTest.cs
+++ b/Tests/TestingServices.Tests.Unit/Liveness/CycleDetection/CycleDetectionDefaultHandlerTest.cs
@@ -98,7 +98,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
             });
 
             string bugReport = "Monitor 'WatchDog' detected infinite execution that violates a liveness property.";
-            base.AssertFailed(configuration, test, bugReport);
+            base.AssertFailed(configuration, test, bugReport, true);
         }
     }
 }

--- a/Tests/TestingServices.Tests.Unit/Liveness/CycleDetection/CycleDetectionRandomChoiceTest.cs
+++ b/Tests/TestingServices.Tests.Unit/Liveness/CycleDetection/CycleDetectionRandomChoiceTest.cs
@@ -118,7 +118,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
             });
 
             string bugReport = "Monitor 'WatchDog' detected infinite execution that violates a liveness property.";
-            base.AssertFailed(configuration, test, bugReport);
+            base.AssertFailed(configuration, test, bugReport, true);
         }
     }
 }

--- a/Tests/TestingServices.Tests.Unit/Liveness/CycleDetection/CycleDetectionRingOfNodesTest.cs
+++ b/Tests/TestingServices.Tests.Unit/Liveness/CycleDetection/CycleDetectionRingOfNodesTest.cs
@@ -137,7 +137,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
             });
 
             string bugReport = "Monitor 'WatchDog' detected infinite execution that violates a liveness property.";
-            base.AssertFailed(configuration, test, bugReport);
+            base.AssertFailed(configuration, test, bugReport, true);
         }
     }
 }

--- a/Tests/TestingServices.Tests.Unit/Liveness/CycleDetection/Liveness2Test.cs
+++ b/Tests/TestingServices.Tests.Unit/Liveness/CycleDetection/Liveness2Test.cs
@@ -88,7 +88,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
             });
 
             string bugReport = "Monitor 'WatchDog' detected infinite execution that violates a liveness property.";
-            base.AssertFailed(configuration, test, bugReport);
+            base.AssertFailed(configuration, test, bugReport, true);
         }
     }
 }

--- a/Tests/TestingServices.Tests.Unit/Liveness/CycleDetection/Liveness3Test.cs
+++ b/Tests/TestingServices.Tests.Unit/Liveness/CycleDetection/Liveness3Test.cs
@@ -99,7 +99,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
             });
 
             string bugReport = "Monitor 'WatchDog' detected infinite execution that violates a liveness property.";
-            base.AssertFailed(configuration, test, bugReport);
+            base.AssertFailed(configuration, test, bugReport, true);
         }
     }
 }

--- a/Tests/TestingServices.Tests.Unit/Liveness/CycleDetection/Nondet1Test.cs
+++ b/Tests/TestingServices.Tests.Unit/Liveness/CycleDetection/Nondet1Test.cs
@@ -98,7 +98,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
             });
 
             string bugReport = "Monitor 'WatchDog' detected infinite execution that violates a liveness property.";
-            base.AssertFailed(configuration, test, bugReport);
+            base.AssertFailed(configuration, test, bugReport, true);
         }
     }
 }

--- a/Tests/TestingServices.Tests.Unit/Liveness/CycleDetection/WarmStateBugTest.cs
+++ b/Tests/TestingServices.Tests.Unit/Liveness/CycleDetection/WarmStateBugTest.cs
@@ -87,7 +87,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
             });
 
             string bugReport = "Monitor 'WatchDog' detected infinite execution that violates a liveness property.";
-            base.AssertFailed(configuration, test, bugReport);
+            base.AssertFailed(configuration, test, bugReport, true);
         }
     }
 }

--- a/Tests/TestingServices.Tests.Unit/Liveness/HotStateTest.cs
+++ b/Tests/TestingServices.Tests.Unit/Liveness/HotStateTest.cs
@@ -159,7 +159,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
             string bugReport = "Monitor 'M' detected liveness bug in hot state " +
                 "'Microsoft.PSharp.TestingServices.Tests.Unit.HotStateTest+M.Init' " +
                 "at the end of program execution.";
-            base.AssertFailed(configuration, test, bugReport);
+            base.AssertFailed(configuration, test, bugReport, true);
         }
     }
 }

--- a/Tests/TestingServices.Tests.Unit/Liveness/Liveness2BugFoundTest.cs
+++ b/Tests/TestingServices.Tests.Unit/Liveness/Liveness2BugFoundTest.cs
@@ -89,7 +89,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
             string bugReport = "Monitor 'WatchDog' detected liveness bug in hot state " +
                 "'Microsoft.PSharp.TestingServices.Tests.Unit.Liveness2BugFoundTest+WatchDog.CannotGetUserInput' " +
                 "at the end of program execution.";
-            base.AssertFailed(configuration, test, bugReport);
+            base.AssertFailed(configuration, test, bugReport, true);
         }
     }
 }

--- a/Tests/TestingServices.Tests.Unit/Liveness/Liveness2LoopMachineTest.cs
+++ b/Tests/TestingServices.Tests.Unit/Liveness/Liveness2LoopMachineTest.cs
@@ -99,7 +99,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
 
             var bugReport = "Monitor 'LivenessMonitor' detected potential liveness bug in hot state " +
                 "'Microsoft.PSharp.TestingServices.Tests.Unit.Liveness2LoopMachineTest+LivenessMonitor.CannotGetUserInput'.";
-            base.AssertFailed(configuration, test, bugReport);
+            base.AssertFailed(configuration, test, bugReport, true);
         }
     }
 }

--- a/Tests/TestingServices.Tests.Unit/Machines/Declarations/DuplicateEventHandlersTest.cs
+++ b/Tests/TestingServices.Tests.Unit/Machines/Declarations/DuplicateEventHandlersTest.cs
@@ -1,0 +1,219 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="DuplicateEventHandlersTest.cs">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// 
+//      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+
+using Xunit;
+
+namespace Microsoft.PSharp.TestingServices.Tests.Unit
+{
+    public class DuplicateEventHandlersTest : BaseTest
+    {
+        class E : Event { }
+
+        class M1: Machine
+        {
+            [Start]
+            [OnEventDoAction(typeof(E), nameof(Check1))]
+            [OnEventDoAction(typeof(E), nameof(Check2))]
+            class Init : MachineState { }
+
+            void Check1() { }
+
+            void Check2() { }
+        }
+
+        class M2 : Machine
+        {
+            [Start]
+            [OnEventGotoState(typeof(E), typeof(S1))]
+            [OnEventGotoState(typeof(E), typeof(S2))]
+            class Init : MachineState { }
+
+            class S1 : MachineState { }
+
+            class S2 : MachineState { }
+        }
+
+        class M3 : Machine
+        {
+            [Start]
+            [OnEventPushState(typeof(E), typeof(S1))]
+            [OnEventPushState(typeof(E), typeof(S2))]
+            class Init : MachineState { }
+
+            class S1 : MachineState { }
+
+            class S2 : MachineState { }
+        }
+
+        class M4 : Machine
+        {
+            [Start]
+            class Init : BaseState { }
+
+            [OnEventDoAction(typeof(E), nameof(Check1))]
+            [OnEventDoAction(typeof(E), nameof(Check2))]
+            class BaseState : MachineState { }
+
+            void Check1() { }
+
+            void Check2() { }
+        }
+
+        class M5 : Machine
+        {
+            [Start]
+            class Init : BaseState { }
+
+            [OnEventGotoState(typeof(E), typeof(S1))]
+            [OnEventGotoState(typeof(E), typeof(S2))]
+            class BaseState : MachineState { }
+
+            class S1 : MachineState { }
+
+            class S2 : MachineState { }
+        }
+
+        class M6 : Machine
+        {
+            [Start]
+            class Init : BaseState { }
+
+            [OnEventPushState(typeof(E), typeof(S1))]
+            [OnEventPushState(typeof(E), typeof(S2))]
+            class BaseState : MachineState { }
+
+            class S1 : MachineState { }
+
+            class S2 : MachineState { }
+        }
+
+        class M7 : Machine
+        {
+            [Start]
+            [OnEventDoAction(typeof(E), nameof(Check))]
+            [OnEventGotoState(typeof(E), typeof(S1))]
+            [OnEventPushState(typeof(E), typeof(S2))]
+            class Init : MachineState { }
+
+            class S1 : MachineState { }
+
+            class S2 : MachineState { }
+
+            void Check() { }
+        }
+
+        [Fact]
+        public void TestMachineDuplicateEventHandlerDo()
+        {
+            var test = new Action<PSharpRuntime>((r) =>
+            {
+                r.CreateMachine(typeof(M1));
+            });
+
+            var bugReport = "Machine 'Microsoft.PSharp.TestingServices.Tests.Unit.DuplicateEventHandlersTest+M1()' declared multiple " +
+                "handlers for 'Microsoft.PSharp.TestingServices.Tests.Unit.DuplicateEventHandlersTest+E' in state " +
+                "'Microsoft.PSharp.TestingServices.Tests.Unit.DuplicateEventHandlersTest+M1+Init'.";
+            AssertFailed(test, bugReport, false);
+        }
+
+        [Fact]
+        public void TestMachineDuplicateEventHandlerGoto()
+        {
+            var test = new Action<PSharpRuntime>((r) =>
+            {
+                r.CreateMachine(typeof(M2));
+            });
+
+            var bugReport = "Machine 'Microsoft.PSharp.TestingServices.Tests.Unit.DuplicateEventHandlersTest+M2()' declared multiple " +
+                "handlers for 'Microsoft.PSharp.TestingServices.Tests.Unit.DuplicateEventHandlersTest+E' in state " +
+                "'Microsoft.PSharp.TestingServices.Tests.Unit.DuplicateEventHandlersTest+M2+Init'.";
+            AssertFailed(test, bugReport, false);
+        }
+
+        [Fact]
+        public void TestMachineDuplicateEventHandlerPush()
+        {
+            var test = new Action<PSharpRuntime>((r) =>
+            {
+                r.CreateMachine(typeof(M3));
+            });
+
+            var bugReport = "Machine 'Microsoft.PSharp.TestingServices.Tests.Unit.DuplicateEventHandlersTest+M3()' declared multiple " +
+                "handlers for 'Microsoft.PSharp.TestingServices.Tests.Unit.DuplicateEventHandlersTest+E' in state " +
+                "'Microsoft.PSharp.TestingServices.Tests.Unit.DuplicateEventHandlersTest+M3+Init'.";
+            AssertFailed(test, bugReport, false);
+        }
+
+        [Fact]
+        public void TestMachineDuplicateEventHandlerInheritanceDo()
+        {
+            var test = new Action<PSharpRuntime>((r) =>
+            {
+                r.CreateMachine(typeof(M4));
+            });
+
+            var bugReport = "Machine 'Microsoft.PSharp.TestingServices.Tests.Unit.DuplicateEventHandlersTest+M4()' inherited multiple " +
+                "handlers for 'Microsoft.PSharp.TestingServices.Tests.Unit.DuplicateEventHandlersTest+E' from state " +
+                "'Microsoft.PSharp.TestingServices.Tests.Unit.DuplicateEventHandlersTest+M4+BaseState' in state " +
+                "'Microsoft.PSharp.TestingServices.Tests.Unit.DuplicateEventHandlersTest+M4+Init'.";
+            AssertFailed(test, bugReport, false);
+        }
+
+        [Fact]
+        public void TestMachineDuplicateEventHandlerInheritanceGoto()
+        {
+            var test = new Action<PSharpRuntime>((r) =>
+            {
+                r.CreateMachine(typeof(M5));
+            });
+
+            var bugReport = "Machine 'Microsoft.PSharp.TestingServices.Tests.Unit.DuplicateEventHandlersTest+M5()' inherited multiple " +
+                "handlers for 'Microsoft.PSharp.TestingServices.Tests.Unit.DuplicateEventHandlersTest+E' from state " +
+                "'Microsoft.PSharp.TestingServices.Tests.Unit.DuplicateEventHandlersTest+M5+BaseState' in state " +
+                "'Microsoft.PSharp.TestingServices.Tests.Unit.DuplicateEventHandlersTest+M5+Init'.";
+            AssertFailed(test, bugReport, false);
+        }
+
+        [Fact]
+        public void TestMachineDuplicateEventHandlerInheritancePush()
+        {
+            var test = new Action<PSharpRuntime>((r) =>
+            {
+                r.CreateMachine(typeof(M6));
+            });
+
+            var bugReport = "Machine 'Microsoft.PSharp.TestingServices.Tests.Unit.DuplicateEventHandlersTest+M6()' inherited multiple " +
+                "handlers for 'Microsoft.PSharp.TestingServices.Tests.Unit.DuplicateEventHandlersTest+E' from state " +
+                "'Microsoft.PSharp.TestingServices.Tests.Unit.DuplicateEventHandlersTest+M6+BaseState' in state " +
+                "'Microsoft.PSharp.TestingServices.Tests.Unit.DuplicateEventHandlersTest+M6+Init'.";
+            AssertFailed(test, bugReport, false);
+        }
+
+        [Fact]
+        public void TestMachineDuplicateEventHandlerMixed()
+        {
+            var test = new Action<PSharpRuntime>((r) =>
+            {
+                r.CreateMachine(typeof(M7));
+            });
+
+            var bugReport = "Machine 'Microsoft.PSharp.TestingServices.Tests.Unit.DuplicateEventHandlersTest+M7()' declared multiple " +
+                "handlers for 'Microsoft.PSharp.TestingServices.Tests.Unit.DuplicateEventHandlersTest+E' in state " +
+                "'Microsoft.PSharp.TestingServices.Tests.Unit.DuplicateEventHandlersTest+M7+Init'.";
+            AssertFailed(test, bugReport, false);
+        }
+    }
+}

--- a/Tests/TestingServices.Tests.Unit/Machines/Declarations/GroupStateTest.cs
+++ b/Tests/TestingServices.Tests.Unit/Machines/Declarations/GroupStateTest.cs
@@ -115,7 +115,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
             });
 
             var bugReport = "Detected an assertion failure.";
-            base.AssertFailed(test, bugReport);
+            base.AssertFailed(test, bugReport, true);
         }
     }
 }

--- a/Tests/TestingServices.Tests.Unit/Machines/Declarations/MachineStateInheritanceTest.cs
+++ b/Tests/TestingServices.Tests.Unit/Machines/Declarations/MachineStateInheritanceTest.cs
@@ -1,0 +1,620 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="MachineStateInheritanceTest.cs">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// 
+//      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+
+using Xunit;
+
+namespace Microsoft.PSharp.TestingServices.Tests.Unit
+{
+    public class MachineStateInheritanceTest : BaseTest
+    {
+        class E : Event { }
+
+        class M1 : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            class Init : BaseState { }
+
+            [OnEventDoAction(typeof(E), nameof(Check))]
+            abstract class BaseState : MachineState { }
+
+            void InitOnEntry()
+            {
+                Send(Id, new E());
+            }
+
+            void Check()
+            {
+                Assert(false, "Error reached.");
+            }
+        }
+
+        class M2 : Machine
+        {
+            [Start]
+            class Init : BaseState { }
+
+            [Start]
+            class BaseState : MachineState { }
+        }
+
+        class M3 : Machine
+        {
+            [Start]
+            class Init : BaseState { }
+
+            [OnEntry(nameof(BaseOnEntry))]
+            class BaseState : MachineState { }
+
+            void BaseOnEntry()
+            {
+                Assert(false, "Error reached.");
+            }
+        }
+
+        class M4 : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            class Init : BaseState { }
+
+            [OnEntry(nameof(BaseOnEntry))]
+            class BaseState : MachineState { }
+
+            void InitOnEntry() { }
+
+            void BaseOnEntry()
+            {
+                Assert(false, "Error reached.");
+            }
+        }
+
+        class M5 : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            class Init : BaseState { }
+
+            [OnEventDoAction(typeof(E), nameof(Check))]
+            class BaseState : MachineState { }
+
+            void InitOnEntry()
+            {
+                Send(Id, new E());
+            }
+
+            void Check()
+            {
+                Assert(false, "Error reached.");
+            }
+        }
+
+        class M6 : Machine
+        {
+            [Start]
+            [OnEventDoAction(typeof(E), nameof(Check))]
+            [OnEntry(nameof(InitOnEntry))]
+            class Init : BaseState { }
+
+            [OnEventDoAction(typeof(E), nameof(BaseCheck))]
+            class BaseState : MachineState { }
+
+            void InitOnEntry()
+            {
+                Send(Id, new E());
+            }
+
+            void Check() { }
+
+            void BaseCheck()
+            {
+                Assert(false, "Error reached.");
+            }
+        }
+
+        class M7 : Machine
+        {
+            [Start]
+            [OnEventDoAction(typeof(E), nameof(Check))]
+            [OnEntry(nameof(InitOnEntry))]
+            class Init : BaseState { }
+
+            [OnEventDoAction(typeof(E), nameof(BaseCheck))]
+            class BaseState : BaseBaseState { }
+
+            [OnEventDoAction(typeof(E), nameof(BaseBaseCheck))]
+            class BaseBaseState : MachineState { }
+
+            void InitOnEntry()
+            {
+                Send(Id, new E());
+            }
+
+            void Check() { }
+
+            void BaseCheck()
+            {
+                Assert(false, "Error reached.");
+            }
+
+            void BaseBaseCheck()
+            {
+                Assert(false, "Error reached.");
+            }
+        }
+
+        class M8 : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            class Init : BaseState { }
+
+            [OnEventDoAction(typeof(E), nameof(BaseCheck))]
+            class BaseState : BaseBaseState { }
+
+            [OnEventDoAction(typeof(E), nameof(BaseBaseCheck))]
+            class BaseBaseState : MachineState { }
+
+            void InitOnEntry()
+            {
+                Send(Id, new E());
+            }
+
+            void BaseCheck() { }
+
+            void BaseBaseCheck()
+            {
+                Assert(false, "Error reached.");
+            }
+        }
+
+        class M9 : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            class Init : BaseState { }
+
+            [OnEventGotoState(typeof(E), typeof(Done))]
+            class BaseState : MachineState { }
+
+            [OnEntry(nameof(DoneOnEntry))]
+            class Done : MachineState { }
+
+            void InitOnEntry()
+            {
+                Send(Id, new E());
+            }
+
+            void DoneOnEntry()
+            {
+                Assert(false, "Done reached.");
+            }
+        }
+
+        class M10 : Machine
+        {
+            [Start]
+            [OnEventGotoState(typeof(E), typeof(Done))]
+            [OnEntry(nameof(InitOnEntry))]
+            class Init : BaseState { }
+
+            [OnEventGotoState(typeof(E), typeof(Error))]
+            class BaseState : MachineState { }
+
+            [OnEntry(nameof(DoneOnEntry))]
+            class Done : MachineState { }
+
+            [OnEntry(nameof(ErrorOnEntry))]
+            class Error : MachineState { }
+
+            void InitOnEntry()
+            {
+                Send(Id, new E());
+            }
+
+            void DoneOnEntry()
+            {
+                Assert(false, "Done reached.");
+            }
+
+            void ErrorOnEntry()
+            {
+                Assert(false, "Error reached.");
+            }
+        }
+
+        class M11 : Machine
+        {
+            [Start]
+            [OnEventGotoState(typeof(E), typeof(Done))]
+            [OnEntry(nameof(InitOnEntry))]
+            class Init : BaseState { }
+
+            [OnEventGotoState(typeof(E), typeof(Error))]
+            class BaseState : BaseBaseState { }
+
+            [OnEventGotoState(typeof(E), typeof(Error))]
+            class BaseBaseState : MachineState { }
+
+            [OnEntry(nameof(DoneOnEntry))]
+            class Done : MachineState { }
+
+            [OnEntry(nameof(ErrorOnEntry))]
+            class Error : MachineState { }
+
+            void InitOnEntry()
+            {
+                Send(Id, new E());
+            }
+
+            void DoneOnEntry()
+            {
+                Assert(false, "Done reached.");
+            }
+
+            void ErrorOnEntry()
+            {
+                Assert(false, "Error reached.");
+            }
+        }
+
+        class M12 : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            class Init : BaseState { }
+
+            [OnEventGotoState(typeof(E), typeof(Done))]
+            class BaseState : BaseBaseState { }
+
+            [OnEventGotoState(typeof(E), typeof(Error))]
+            class BaseBaseState : MachineState { }
+
+            [OnEntry(nameof(DoneOnEntry))]
+            class Done : MachineState { }
+
+            [OnEntry(nameof(ErrorOnEntry))]
+            class Error : MachineState { }
+
+            void InitOnEntry()
+            {
+                Send(Id, new E());
+            }
+
+            void DoneOnEntry()
+            {
+                Assert(false, "Done reached.");
+            }
+
+            void ErrorOnEntry()
+            {
+                Assert(false, "Error reached.");
+            }
+        }
+
+        class M13 : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            class Init : BaseState { }
+
+            [OnEventPushState(typeof(E), typeof(Done))]
+            class BaseState : MachineState { }
+
+            [OnEntry(nameof(DoneOnEntry))]
+            class Done : MachineState { }
+
+            void InitOnEntry()
+            {
+                Send(Id, new E());
+            }
+
+            void DoneOnEntry()
+            {
+                Assert(false, "Done reached.");
+            }
+        }
+
+        class M14 : Machine
+        {
+            [Start]
+            [OnEventPushState(typeof(E), typeof(Done))]
+            [OnEntry(nameof(InitOnEntry))]
+            class Init : BaseState { }
+
+            [OnEventPushState(typeof(E), typeof(Error))]
+            class BaseState : MachineState { }
+
+            [OnEntry(nameof(DoneOnEntry))]
+            class Done : MachineState { }
+
+            [OnEntry(nameof(ErrorOnEntry))]
+            class Error : MachineState { }
+
+            void InitOnEntry()
+            {
+                Send(Id, new E());
+            }
+
+            void DoneOnEntry()
+            {
+                Assert(false, "Done reached.");
+            }
+
+            void ErrorOnEntry()
+            {
+                Assert(false, "Error reached.");
+            }
+        }
+
+        class M15 : Machine
+        {
+            [Start]
+            [OnEventPushState(typeof(E), typeof(Done))]
+            [OnEntry(nameof(InitOnEntry))]
+            class Init : BaseState { }
+
+            [OnEventPushState(typeof(E), typeof(Error))]
+            class BaseState : BaseBaseState { }
+
+            [OnEventPushState(typeof(E), typeof(Error))]
+            class BaseBaseState : MachineState { }
+
+            [OnEntry(nameof(DoneOnEntry))]
+            class Done : MachineState { }
+
+            [OnEntry(nameof(ErrorOnEntry))]
+            class Error : MachineState { }
+
+            void InitOnEntry()
+            {
+                Send(Id, new E());
+            }
+
+            void DoneOnEntry()
+            {
+                Assert(false, "Done reached.");
+            }
+
+            void ErrorOnEntry()
+            {
+                Assert(false, "Error reached.");
+            }
+        }
+
+        class M16 : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            class Init : BaseState { }
+
+            [OnEventPushState(typeof(E), typeof(Done))]
+            class BaseState : BaseBaseState { }
+
+            [OnEventPushState(typeof(E), typeof(Error))]
+            class BaseBaseState : MachineState { }
+
+            [OnEntry(nameof(DoneOnEntry))]
+            class Done : MachineState { }
+
+            [OnEntry(nameof(ErrorOnEntry))]
+            class Error : MachineState { }
+
+            void InitOnEntry()
+            {
+                Send(Id, new E());
+            }
+
+            void DoneOnEntry()
+            {
+                Assert(false, "Done reached.");
+            }
+
+            void ErrorOnEntry()
+            {
+                Assert(false, "Error reached.");
+            }
+        }
+
+        [Fact]
+        public void TestMachineStateInheritingAbstractState()
+        {
+            var test = new Action<PSharpRuntime>((r) =>
+            {
+                r.CreateMachine(typeof(M1));
+            });
+
+            var bugReport = "Error reached.";
+            AssertFailed(test, bugReport, false);
+        }
+
+        [Fact]
+        public void TestMachineStateInheritingStateDuplicateStart()
+        {
+            var test = new Action<PSharpRuntime>((r) =>
+            {
+                r.CreateMachine(typeof(M2));
+            });
+
+            var bugReport = "Machine 'Microsoft.PSharp.TestingServices.Tests.Unit.MachineStateInheritanceTest+M2()' " +
+                "can not declare more than one start states.";
+            AssertFailed(test, bugReport, false);
+        }
+
+        [Fact]
+        public void TestMachineStateInheritingStateOnEntry()
+        {
+            var test = new Action<PSharpRuntime>((r) =>
+            {
+                r.CreateMachine(typeof(M3));
+            });
+
+            var bugReport = "Error reached.";
+            AssertFailed(test, bugReport, false);
+        }
+
+        [Fact]
+        public void TestMachineStateOverridingStateOnEntry()
+        {
+            var test = new Action<PSharpRuntime>((r) => {
+                r.CreateMachine(typeof(M4));
+            });
+
+            AssertSucceeded(test);
+        }
+
+        [Fact]
+        public void TestMachineStateInheritingStateOnEventDoAction()
+        {
+            var test = new Action<PSharpRuntime>((r) =>
+            {
+                r.CreateMachine(typeof(M5));
+            });
+
+            var bugReport = "Error reached.";
+            AssertFailed(test, bugReport, false);
+        }
+
+        [Fact]
+        public void TestMachineStateOverridingStateOnEventDoAction()
+        {
+            var test = new Action<PSharpRuntime>((r) =>
+            {
+                r.CreateMachine(typeof(M6));
+            });
+
+            AssertSucceeded(test);
+        }
+
+        [Fact]
+        public void TestMachineStateOverridingTwoStatesOnEventDoAction()
+        {
+            var test = new Action<PSharpRuntime>((r) =>
+            {
+                r.CreateMachine(typeof(M7));
+            });
+
+            AssertSucceeded(test);
+        }
+
+        [Fact]
+        public void TestMachineStateOverridingDeepStateOnEventDoAction()
+        {
+            var test = new Action<PSharpRuntime>((r) =>
+            {
+                r.CreateMachine(typeof(M8));
+            });
+
+            AssertSucceeded(test);
+        }
+
+        [Fact]
+        public void TestMachineStateInheritingStateOnEventGotoState()
+        {
+            var test = new Action<PSharpRuntime>((r) =>
+            {
+                r.CreateMachine(typeof(M9));
+            });
+
+            var bugReport = "Done reached.";
+            AssertFailed(test, bugReport, false);
+        }
+
+        [Fact]
+        public void TestMachineStateOverridingStateOnEventGotoState()
+        {
+            var test = new Action<PSharpRuntime>((r) =>
+            {
+                r.CreateMachine(typeof(M10));
+            });
+
+            var bugReport = "Done reached.";
+            AssertFailed(test, bugReport, false);
+        }
+
+        [Fact]
+        public void TestMachineStateOverridingTwoStatesOnEventGotoState()
+        {
+            var test = new Action<PSharpRuntime>((r) =>
+            {
+                r.CreateMachine(typeof(M11));
+            });
+
+            var bugReport = "Done reached.";
+            AssertFailed(test, bugReport, false);
+        }
+
+        [Fact]
+        public void TestMachineStateOverridingDeepStateOnEventGotoState()
+        {
+            var test = new Action<PSharpRuntime>((r) =>
+            {
+                r.CreateMachine(typeof(M12));
+            });
+
+            var bugReport = "Done reached.";
+            AssertFailed(test, bugReport, false);
+        }
+
+        [Fact]
+        public void TestMachineStateInheritingStateOnEventPushState()
+        {
+            var test = new Action<PSharpRuntime>((r) =>
+            {
+                r.CreateMachine(typeof(M13));
+            });
+
+            var bugReport = "Done reached.";
+            AssertFailed(test, bugReport, false);
+        }
+
+        [Fact]
+        public void TestMachineStateOverridingStateOnEventPushState()
+        {
+            var test = new Action<PSharpRuntime>((r) =>
+            {
+                r.CreateMachine(typeof(M14));
+            });
+
+            var bugReport = "Done reached.";
+            AssertFailed(test, bugReport, false);
+        }
+
+        [Fact]
+        public void TestMachineStateOverridingTwoStatesOnEventPushState()
+        {
+            var test = new Action<PSharpRuntime>((r) =>
+            {
+                r.CreateMachine(typeof(M15));
+            });
+
+            var bugReport = "Done reached.";
+            AssertFailed(test, bugReport, false);
+        }
+
+        [Fact]
+        public void TestMachineStateOverridingDeepStateOnEventPushState()
+        {
+            var test = new Action<PSharpRuntime>((r) =>
+            {
+                r.CreateMachine(typeof(M16));
+            });
+
+            var bugReport = "Done reached.";
+            AssertFailed(test, bugReport, false);
+        }
+    }
+}

--- a/Tests/TestingServices.Tests.Unit/Machines/Statements/PopTest.cs
+++ b/Tests/TestingServices.Tests.Unit/Machines/Statements/PopTest.cs
@@ -57,7 +57,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
         {
             var test = new Action<PSharpRuntime>((r) => { r.CreateMachine(typeof(M), "M"); });
             var bugReport = "Machine 'M()' popped with no matching push.";
-            base.AssertFailed(test, bugReport);
+            base.AssertFailed(test, bugReport, true);
         }
 
         [Fact]
@@ -65,7 +65,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
         {
             var test = new Action<PSharpRuntime>((r) => { r.CreateMachine(typeof(N), "N"); });
             var bugReport = "Machine 'N()' has called raise/goto/pop inside an OnExit method.";
-            base.AssertFailed(test, bugReport);
+            base.AssertFailed(test, bugReport, true);
         }
     }
 }

--- a/Tests/TestingServices.Tests.Unit/Machines/Transitions/GotoTransitions/GotoStateExitFailTest.cs
+++ b/Tests/TestingServices.Tests.Unit/Machines/Transitions/GotoTransitions/GotoStateExitFailTest.cs
@@ -48,7 +48,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
                 r.CreateMachine(typeof(Program));
             });
 
-            base.AssertFailed(test, 1);
+            base.AssertFailed(test, 1, true);
         }
     }
 }

--- a/Tests/TestingServices.Tests.Unit/Machines/Transitions/GotoTransitions/GotoStateFailTest.cs
+++ b/Tests/TestingServices.Tests.Unit/Machines/Transitions/GotoTransitions/GotoStateFailTest.cs
@@ -41,7 +41,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
                 r.CreateMachine(typeof(Program));
             });
 
-            base.AssertFailed(test, 1);
+            base.AssertFailed(test, 1, true);
         }
     }
 }

--- a/Tests/TestingServices.Tests.Unit/Machines/Transitions/GotoTransitions/GotoStateMultipleInActionFailTest.cs
+++ b/Tests/TestingServices.Tests.Unit/Machines/Transitions/GotoTransitions/GotoStateMultipleInActionFailTest.cs
@@ -89,7 +89,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
 
             var bugReport = "Machine 'Microsoft.PSharp.TestingServices.Tests.Unit.GotoStateTopLevelActionFailTest+Program()' " +
                 "has called multiple raise/goto/pop in the same action.";
-            base.AssertFailed(test, bugReport);
+            base.AssertFailed(test, bugReport, true);
         }
 
         [Fact]
@@ -101,7 +101,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
 
             var bugReport = "Machine 'Microsoft.PSharp.TestingServices.Tests.Unit.GotoStateTopLevelActionFailTest+Program()' " +
                 "has called multiple raise/goto/pop in the same action.";
-            base.AssertFailed(test, bugReport);
+            base.AssertFailed(test, bugReport, true);
         }
 
         [Fact]
@@ -113,7 +113,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
 
             var bugReport = "Machine 'Microsoft.PSharp.TestingServices.Tests.Unit.GotoStateTopLevelActionFailTest+Program()' " +
                 "cannot call API 'Send' after calling raise/goto/pop in the same action.";
-            base.AssertFailed(test, bugReport);
+            base.AssertFailed(test, bugReport, true);
         }
 
         [Fact]
@@ -125,7 +125,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
 
             var bugReport = "Machine 'Microsoft.PSharp.TestingServices.Tests.Unit.GotoStateTopLevelActionFailTest+Program()' " +
                 "has called raise/goto/pop inside an OnExit method.";
-            base.AssertFailed(test, bugReport);
+            base.AssertFailed(test, bugReport, true);
         }
 
     }

--- a/Tests/TestingServices.Tests.Unit/RuntimeInterface/CreateAndExecuteTest.cs
+++ b/Tests/TestingServices.Tests.Unit/RuntimeInterface/CreateAndExecuteTest.cs
@@ -86,7 +86,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
                 r.CreateMachine(typeof(M), new Configure(true));
             });
 
-            base.AssertFailed(test, "Machine 'N()' called receive while executing synchronously.");
+            base.AssertFailed(test, "Machine 'N()' called receive while executing synchronously.", true);
         }
 
     }

--- a/Tests/TestingServices.Tests.Unit/RuntimeInterface/SendAndExecuteTest1.cs
+++ b/Tests/TestingServices.Tests.Unit/RuntimeInterface/SendAndExecuteTest1.cs
@@ -118,7 +118,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
                 r.CreateMachine(typeof(A), new Configure(true));
             });
 
-            base.AssertFailed(config, test, "Machine 'B()' called receive while executing synchronously.");
+            base.AssertFailed(config, test, "Machine 'B()' called receive while executing synchronously.", true);
         }
     }
 }


### PR DESCRIPTION
This is related to #216.

- Machine states can inherit event handlers from base states.
- If a machine state installs an event handler for an event that is already handled by a base state, then it overrides the base state handler. This currently works only for event handlers of same type (e.g. goto/push/do), else an error is shown.
- Added assertions related to duplicate event handlers (not allowed to declare multiple handlers for same event in the same state).
- Added tons of unit tests.