### PR TITLE
Changes required for PTester

### DIFF
--- a/Source/Core/Library/Machine.cs
+++ b/Source/Core/Library/Machine.cs
@@ -329,9 +329,19 @@ namespace Microsoft.PSharp
         /// <param name="e">Event</param>
         protected void Monitor<T>(Event e)
         {
+            this.Monitor(typeof(T), e);
+        }
+
+        /// <summary>
+        /// Invokes the specified monitor with the specified event.
+        /// </summary>
+        /// <param name="type">Type of the monitor</param>
+        /// <param name="e">Event</param>
+        protected void Monitor(Type type, Event e)
+        {
             // If the event is null, then report an error and exit.
             this.Assert(e != null, $"Machine '{base.Id}' is sending a null event.");
-            base.Runtime.Monitor<T>(this, e);
+            base.Runtime.Monitor(type, this, e);
         }
 
         /// <summary>

--- a/Source/Core/Runtime/PSharpRuntime.cs
+++ b/Source/Core/Runtime/PSharpRuntime.cs
@@ -241,6 +241,13 @@ namespace Microsoft.PSharp
         public abstract void InvokeMonitor<T>(Event e);
 
         /// <summary>
+        /// Invokes the specified monitor with the specified <see cref="Event"/>.
+        /// </summary>
+        /// <param name="type">Type of the monitor</param>
+        /// <param name="e">Event</param>
+        public abstract void InvokeMonitor(Type type, Event e);
+
+        /// <summary>
         /// Returns a nondeterministic boolean choice, that can be controlled
         /// during analysis or testing.
         /// </summary>
@@ -381,9 +388,9 @@ namespace Microsoft.PSharp
         /// Invokes the specified <see cref="PSharp.Monitor"/> with the specified <see cref="Event"/>.
         /// </summary>
         /// <param name="sender">Sender machine</param>
-        /// <typeparam name="T">Type of the monitor</typeparam>
+        /// <param name="type">Type of the monitor</param>
         /// <param name="e">Event</param>
-        internal abstract void Monitor<T>(AbstractMachine sender, Event e);
+        internal abstract void Monitor(Type type, AbstractMachine sender, Event e);
 
         /// <summary>
         /// Checks if the assertion holds, and if not it throws an

--- a/Source/Core/Runtime/StateMachineRuntime.cs
+++ b/Source/Core/Runtime/StateMachineRuntime.cs
@@ -221,9 +221,19 @@ namespace Microsoft.PSharp
         /// <param name="e">Event</param>
         public override void InvokeMonitor<T>(Event e)
         {
+            this.InvokeMonitor(typeof(T), e);
+        }
+
+        /// <summary>
+        /// Invokes the specified monitor with the specified <see cref="Event"/>.
+        /// </summary>
+        /// <param name="type">Type of the monitor</param>
+        /// <param name="e">Event</param>
+        public override void InvokeMonitor(Type type, Event e)
+        {
             // If the event is null then report an error and exit.
             base.Assert(e != null, "Cannot monitor a null event.");
-            this.Monitor<T>(null, e);
+            this.Monitor(type, null, e);
         }
 
         /// <summary>
@@ -534,9 +544,9 @@ namespace Microsoft.PSharp
         /// Invokes the specified <see cref="PSharp.Monitor"/> with the specified <see cref="Event"/>.
         /// </summary>
         /// <param name="sender">Sender machine</param>
-        /// <typeparam name="T">Type of the monitor</typeparam>
+        /// <param name="type">Type of the monitor</param>
         /// <param name="e">Event</param>
-        internal override void Monitor<T>(AbstractMachine sender, Event e)
+        internal override void Monitor(Type type, AbstractMachine sender, Event e)
         {
             if (!base.Configuration.EnableMonitorsInProduction)
             {
@@ -550,7 +560,7 @@ namespace Microsoft.PSharp
             {
                 foreach (var m in this.Monitors)
                 {
-                    if (m.GetType() == typeof(T))
+                    if (m.GetType() == type)
                     {
                         monitor = m;
                         break;

--- a/Source/TestingServices/Runtime/BugFindingRuntime.cs
+++ b/Source/TestingServices/Runtime/BugFindingRuntime.cs
@@ -336,15 +336,25 @@ namespace Microsoft.PSharp.TestingServices
         }
 
         /// <summary>
-        /// Invokes the specified monitor with the given event.
+        /// Invokes the specified monitor with the specified <see cref="Event"/>.
         /// </summary>
         /// <typeparam name="T">Type of the monitor</typeparam>
         /// <param name="e">Event</param>
         public override void InvokeMonitor<T>(Event e)
         {
+            this.InvokeMonitor(typeof(T), e);
+        }
+
+        /// <summary>
+        /// Invokes the specified monitor with the specified <see cref="Event"/>.
+        /// </summary>
+        /// <param name="type">Type of the monitor</param>
+        /// <param name="e">Event</param>
+        public override void InvokeMonitor(Type type, Event e)
+        {
             // If the event is null then report an error and exit.
-            this.Assert(e != null, "Cannot monitor a null event.");
-            this.Monitor<T>(null, e);
+            base.Assert(e != null, "Cannot monitor a null event.");
+            this.Monitor(type, null, e);
         }
 
         /// <summary>
@@ -820,9 +830,9 @@ namespace Microsoft.PSharp.TestingServices
         /// Invokes the specified monitor with the given event.
         /// </summary>
         /// <param name="sender">Sender machine</param>
-        /// <typeparam name="T">Type of the monitor</typeparam>
+        /// <param name="type">Type of the monitor</param>
         /// <param name="e">Event</param>
-        internal override void Monitor<T>(AbstractMachine sender, Event e)
+        internal override void Monitor(Type type, AbstractMachine sender, Event e)
         {
             if (sender != null && sender is Machine)
             {
@@ -831,7 +841,7 @@ namespace Microsoft.PSharp.TestingServices
 
             foreach (var m in this.Monitors)
             {
-                if (m.GetType() == typeof(T))
+                if (m.GetType() == type)
                 {
                     if (base.Configuration.ReportCodeCoverage)
                     {

--- a/Source/TestingServices/Statistics/Coverage/CodeCoverageReporter.cs
+++ b/Source/TestingServices/Statistics/Coverage/CodeCoverageReporter.cs
@@ -23,7 +23,7 @@ namespace Microsoft.PSharp.TestingServices.Coverage
     /// <summary>
     /// The P# code coverage reporter.
     /// </summary>
-    internal class CodeCoverageReporter
+    public class CodeCoverageReporter
     {
         #region fields
 


### PR DESCRIPTION
Introduces API `Monitor(Type T, ...)` in addition to `Monitor<T>(...)`.
Make `CodeCoverageReporter` public.