### PR TITLE
OperationGroupId in production

### DIFF
--- a/Source/Core/Library/Machine.cs
+++ b/Source/Core/Library/Machine.cs
@@ -247,7 +247,7 @@ namespace Microsoft.PSharp
         /// <returns>MachineId</returns>
         protected MachineId CreateMachine(Type type, Event e = null)
         {
-            return base.Runtime.CreateMachine(type, null, e, this);
+            return base.Runtime.CreateMachine(type, null, e, this, null);
         }
 
         /// <summary>
@@ -261,7 +261,7 @@ namespace Microsoft.PSharp
         /// <returns>MachineId</returns>
         protected MachineId CreateMachine(Type type, string friendlyName, Event e = null)
         {
-            return base.Runtime.CreateMachine(type, friendlyName, e, this);
+            return base.Runtime.CreateMachine(type, friendlyName, e, this, null);
         }
 
         /// <summary>
@@ -275,7 +275,7 @@ namespace Microsoft.PSharp
         /// <returns>MachineId</returns>
         protected MachineId CreateRemoteMachine(Type type, string endpoint, Event e = null)
         {
-            return base.Runtime.CreateRemoteMachine(type, null, endpoint, e, this);
+            return base.Runtime.CreateRemoteMachine(type, null, endpoint, e, this, null);
         }
 
         /// <summary>
@@ -291,7 +291,7 @@ namespace Microsoft.PSharp
         protected MachineId CreateRemoteMachine(Type type, string friendlyName,
             string endpoint, Event e = null)
         {
-            return base.Runtime.CreateRemoteMachine(type, friendlyName, endpoint, e, this);
+            return base.Runtime.CreateRemoteMachine(type, friendlyName, endpoint, e, this, null);
         }
 
         /// <summary>

--- a/Source/Core/Runtime/PSharpRuntime.cs
+++ b/Source/Core/Runtime/PSharpRuntime.cs
@@ -141,8 +141,9 @@ namespace Microsoft.PSharp
         /// </summary>
         /// <param name="type">Type of the machine</param>
         /// <param name="e">Event</param>
+        /// <param name="operationGroupId">Optional operation group id</param>
         /// <returns>MachineId</returns>
-        public abstract MachineId CreateMachine(Type type, Event e = null);
+        public abstract MachineId CreateMachine(Type type, Event e = null, Guid? operationGroupId = null);
 
         /// <summary>
         /// Creates a new machine of the specified <see cref="Type"/> and name, and
@@ -151,9 +152,10 @@ namespace Microsoft.PSharp
         /// </summary>
         /// <param name="type">Type of the machine</param>
         /// <param name="friendlyName">Friendly machine name used for logging</param>
+        /// <param name="operationGroupId">Optional operation group id</param>
         /// <param name="e">Event</param>
         /// <returns>MachineId</returns>
-        public abstract MachineId CreateMachine(Type type, string friendlyName, Event e = null);
+        public abstract MachineId CreateMachine(Type type, string friendlyName, Event e = null, Guid? operationGroupId = null);
 
         /// <summary>
         /// Creates a new machine of the specified <see cref="Type"/> and with the
@@ -163,8 +165,9 @@ namespace Microsoft.PSharp
         /// </summary>
         /// <param name="type">Type of the machine</param>
         /// <param name="e">Event</param>
+        /// <param name="operationGroupId">Optional operation group id</param>
         /// <returns>MachineId</returns>
-        public abstract Task<MachineId> CreateMachineAndExecute(Type type, Event e = null);
+        public abstract Task<MachineId> CreateMachineAndExecute(Type type, Event e = null, Guid? operationGroupId = null);
 
         /// <summary>
         /// Creates a new machine of the specified <see cref="Type"/> and name, and with
@@ -174,9 +177,10 @@ namespace Microsoft.PSharp
         /// </summary>
         /// <param name="type">Type of the machine</param>
         /// <param name="friendlyName">Friendly machine name used for logging</param>
+        /// <param name="operationGroupId">Optional operation group id</param>
         /// <param name="e">Event</param>
         /// <returns>MachineId</returns>
-        public abstract Task<MachineId> CreateMachineAndExecute(Type type, string friendlyName, Event e = null);
+        public abstract Task<MachineId> CreateMachineAndExecute(Type type, string friendlyName, Event e = null, Guid? operationGroupId = null);
 
         /// <summary>
         /// Creates a new remote machine of the specified <see cref="Type"/> and with
@@ -185,9 +189,10 @@ namespace Microsoft.PSharp
         /// </summary>
         /// <param name="type">Type of the machine</param>
         /// <param name="endpoint">Endpoint</param>
+        /// <param name="operationGroupId">Optional operation group id</param>
         /// <param name="e">Event</param>
         /// <returns>MachineId</returns>
-        public abstract MachineId RemoteCreateMachine(Type type, string endpoint, Event e = null);
+        public abstract MachineId RemoteCreateMachine(Type type, string endpoint, Event e = null, Guid? operationGroupId = null);
 
         /// <summary>
         /// Creates a new remote machine of the specified <see cref="Type"/> and name, and
@@ -197,10 +202,11 @@ namespace Microsoft.PSharp
         /// <param name="type">Type of the machine</param>
         /// <param name="friendlyName">Friendly machine name used for logging</param>
         /// <param name="endpoint">Endpoint</param>
+        /// <param name="operationGroupId">Optional operation group id</param>
         /// <param name="e">Event</param>
         /// <returns>MachineId</returns>
         public abstract MachineId RemoteCreateMachine(Type type, string friendlyName,
-            string endpoint, Event e = null);
+            string endpoint, Event e = null, Guid? operationGroupId = null);
 
         /// <summary>
         /// Sends an asynchronous <see cref="Event"/> to a machine.
@@ -305,10 +311,11 @@ namespace Microsoft.PSharp
         /// </summary>
         /// <param name="type">Type of the machine</param>
         /// <param name="friendlyName">Friendly machine name used for logging</param>
+        /// <param name="operationGroupId">Operation group id</param>
         /// <param name="e">Event passed during machine construction</param>
         /// <param name="creator">Creator machine</param>
         /// <returns>MachineId</returns>
-        internal abstract MachineId CreateMachine(Type type, string friendlyName, Event e, Machine creator);
+        internal abstract MachineId CreateMachine(Type type, string friendlyName, Event e, Machine creator, Guid? operationGroupId);
 
         /// <summary>
         /// Creates a new <see cref="Machine"/> of the specified <see cref="Type"/>. The
@@ -318,9 +325,10 @@ namespace Microsoft.PSharp
         /// <param name="type">Type of the machine</param>
         /// <param name="friendlyName">Friendly machine name used for logging</param>
         /// <param name="e">Event passed during machine construction</param>
+        /// <param name="operationGroupId">Operation group id</param>
         /// <param name="creator">Creator machine</param>
         /// <returns>MachineId</returns>
-        internal abstract Task<MachineId> CreateMachineAndExecute(Type type, string friendlyName, Event e, Machine creator);
+        internal abstract Task<MachineId> CreateMachineAndExecute(Type type, string friendlyName, Event e, Machine creator, Guid? operationGroupId);
 
         /// <summary>
         /// Creates a new remote <see cref="Machine"/> of the specified <see cref="System.Type"/>.
@@ -328,11 +336,12 @@ namespace Microsoft.PSharp
         /// <param name="type">Type of the machine</param>
         /// <param name="friendlyName">Friendly machine name used for logging</param>
         /// <param name="endpoint">Endpoint</param>
+        /// <param name="operationGroupId">Operation group id</param>
         /// <param name="e">Event passed during machine construction</param>
         /// <param name="creator">Creator machine</param>
         /// <returns>MachineId</returns>
         internal abstract MachineId CreateRemoteMachine(Type type, string friendlyName, string endpoint,
-            Event e, Machine creator);
+            Event e, Machine creator, Guid? operationGroupId);
 
         /// <summary>
         /// Sends an asynchronous <see cref="Event"/> to a machine.
@@ -677,6 +686,53 @@ namespace Microsoft.PSharp
         public void RemoveLogger()
         {
             this.Logger = new ConsoleLogger();
+        }
+
+        #endregion
+
+        #region Operation Group Id
+        /// <summary>
+        /// Sets the operation group id for the specified event.
+        /// </summary>
+        /// <param name="eventInfo">EventInfo</param>
+        /// <param name="sender">Sender machine</param>
+        /// <param name="operationGroupId">Operation group id</param>
+        internal void SetOperationGroupIdForEvent(EventInfo eventInfo, AbstractMachine sender, Guid? operationGroupId)
+        {
+            if (operationGroupId.HasValue)
+            {
+                eventInfo.SetOperationGroupId(operationGroupId.Value);
+            }
+            else if (sender != null)
+            {
+                eventInfo.SetOperationGroupId(sender.Info.OperationGroupId);
+            }
+            else
+            {
+                eventInfo.SetOperationGroupId(Guid.Empty);
+            }
+        }
+
+        /// <summary>
+        /// Sets the operation group id for the specified machine.
+        /// </summary>
+        /// <param name="created">Machine created</param>
+        /// <param name="sender">Sender machine</param>
+        /// <param name="operationGroupId">Operation group id</param>
+        internal void SetOperationGroupIdForMachine(Machine created, AbstractMachine sender, Guid? operationGroupId)
+        {
+            if (operationGroupId.HasValue)
+            {
+                created.Info.OperationGroupId = operationGroupId.Value;
+            }
+            else if (sender != null)
+            {
+                created.Info.OperationGroupId = sender.Info.OperationGroupId;
+            }
+            else
+            {
+                created.Info.OperationGroupId = Guid.Empty;
+            }
         }
 
         #endregion

--- a/Source/Core/Runtime/StateMachineRuntime.cs
+++ b/Source/Core/Runtime/StateMachineRuntime.cs
@@ -79,11 +79,12 @@ namespace Microsoft.PSharp
         /// used to access its payload, and cannot be handled.
         /// </summary>
         /// <param name="type">Type of the machine</param>
+        /// <param name="operationGroupId">Operation group id</param>
         /// <param name="e">Event</param>
         /// <returns>MachineId</returns>
-        public override MachineId CreateMachine(Type type, Event e = null)
+        public override MachineId CreateMachine(Type type, Event e = null, Guid? operationGroupId = null)
         {
-            return this.CreateMachine(type, null, e, null);
+            return this.CreateMachine(type, null, e, null, operationGroupId);
         }
 
         /// <summary>
@@ -93,11 +94,12 @@ namespace Microsoft.PSharp
         /// </summary>
         /// <param name="type">Type of the machine</param>
         /// <param name="friendlyName">Friendly machine name used for logging</param>
+        /// <param name="operationGroupId">Operation group id</param>
         /// <param name="e">Event</param>
         /// <returns>MachineId</returns>
-        public override MachineId CreateMachine(Type type, string friendlyName, Event e = null)
+        public override MachineId CreateMachine(Type type, string friendlyName, Event e = null, Guid? operationGroupId = null)
         {
-            return this.CreateMachine(type, friendlyName, e, null);
+            return this.CreateMachine(type, friendlyName, e, null, operationGroupId);
         }
 
         /// <summary>
@@ -107,11 +109,12 @@ namespace Microsoft.PSharp
         /// the machine is initialized and the <see cref="Event"/> (if any) is handled.
         /// </summary>
         /// <param name="type">Type of the machine</param>
+        /// <param name="operationGroupId">Operation group id</param>
         /// <param name="e">Event</param>
         /// <returns>MachineId</returns>
-        public override Task<MachineId> CreateMachineAndExecute(Type type, Event e = null)
+        public override Task<MachineId> CreateMachineAndExecute(Type type, Event e = null, Guid? operationGroupId = null)
         {
-            return this.CreateMachineAndExecute(type, null, e, null);
+            return this.CreateMachineAndExecute(type, null, e, null, operationGroupId);
         }
 
         /// <summary>
@@ -122,11 +125,12 @@ namespace Microsoft.PSharp
         /// </summary>
         /// <param name="type">Type of the machine</param>
         /// <param name="friendlyName">Friendly machine name used for logging</param>
+        /// <param name="operationGroupId">Operation group id</param>
         /// <param name="e">Event</param>
         /// <returns>MachineId</returns>
-        public override Task<MachineId> CreateMachineAndExecute(Type type, string friendlyName, Event e = null)
+        public override Task<MachineId> CreateMachineAndExecute(Type type, string friendlyName, Event e = null, Guid? operationGroupId = null)
         {
-            return this.CreateMachineAndExecute(type, friendlyName, e, null);
+            return this.CreateMachineAndExecute(type, friendlyName, e, null, operationGroupId);
         }
 
         /// <summary>
@@ -136,11 +140,12 @@ namespace Microsoft.PSharp
         /// </summary>
         /// <param name="type">Type of the machine</param>
         /// <param name="endpoint">Endpoint</param>
+        /// <param name="operationGroupId">Operation group id</param>
         /// <param name="e">Event</param>
         /// <returns>MachineId</returns>
-        public override MachineId RemoteCreateMachine(Type type, string endpoint, Event e = null)
+        public override MachineId RemoteCreateMachine(Type type, string endpoint, Event e = null, Guid? operationGroupId = null)
         {
-            return this.CreateRemoteMachine(type, null, endpoint, e, null);
+            return this.CreateRemoteMachine(type, null, endpoint, e, null, operationGroupId);
         }
 
         /// <summary>
@@ -151,12 +156,13 @@ namespace Microsoft.PSharp
         /// <param name="type">Type of the machine</param>
         /// <param name="friendlyName">Friendly machine name used for logging</param>
         /// <param name="endpoint">Endpoint</param>
+        /// <param name="operationGroupId">Operation group id</param>
         /// <param name="e">Event</param>
         /// <returns>MachineId</returns>
         public override MachineId RemoteCreateMachine(Type type, string friendlyName,
-            string endpoint, Event e = null)
+            string endpoint, Event e = null, Guid? operationGroupId = null)
         {
-            return this.CreateRemoteMachine(type, friendlyName, endpoint, e, null);
+            return this.CreateRemoteMachine(type, friendlyName, endpoint, e, null, operationGroupId);
         }
 
         /// <summary>
@@ -274,11 +280,14 @@ namespace Microsoft.PSharp
         /// <param name="type">Type of the machine</param>
         /// <param name="friendlyName">Friendly machine name used for logging</param>
         /// <param name="e">Event passed during machine construction</param>
+        /// <param name="operationGroupId">Operation group id</param>
         /// <param name="creator">Creator machine</param>
         /// <returns>MachineId</returns>
-        internal override MachineId CreateMachine(Type type, string friendlyName, Event e, Machine creator)
+        internal override MachineId CreateMachine(Type type, string friendlyName, Event e, Machine creator, Guid? operationGroupId)
         {
             Machine machine = this.CreateMachine(type, friendlyName);
+            this.SetOperationGroupIdForMachine(machine, creator, operationGroupId);
+
             this.RunMachineEventHandler(machine, e, true);
             return machine.Id;
         }
@@ -291,11 +300,13 @@ namespace Microsoft.PSharp
         /// <param name="type">Type of the machine</param>
         /// <param name="friendlyName">Friendly machine name used for logging</param>
         /// <param name="e">Event passed during machine construction</param>
+        /// <param name="operationGroupId">Operation group id</param>
         /// <param name="creator">Creator machine</param>
         /// <returns>MachineId</returns>
-        internal override async Task<MachineId> CreateMachineAndExecute(Type type, string friendlyName, Event e, Machine creator)
+        internal override async Task<MachineId> CreateMachineAndExecute(Type type, string friendlyName, Event e, Machine creator, Guid? operationGroupId)
         {
             Machine machine = this.CreateMachine(type, friendlyName);
+            this.SetOperationGroupIdForMachine(machine, creator, operationGroupId);
             await this.RunMachineEventHandlerAsync(machine, e, true);
             return machine.Id;
         }
@@ -307,10 +318,11 @@ namespace Microsoft.PSharp
         /// <param name="friendlyName">Friendly machine name used for logging</param>
         /// <param name="endpoint">Endpoint</param>
         /// <param name="e">Event passed during machine construction</param>
+        /// <param name="operationGroupId">Operation group id</param>
         /// <param name="creator">Creator machine</param>
         /// <returns>MachineId</returns>
         internal override MachineId CreateRemoteMachine(Type type, string friendlyName, string endpoint,
-            Event e, Machine creator)
+            Event e, Machine creator, Guid? operationGroupId)
         {
             base.Assert(type.IsSubclassOf(typeof(Machine)),
                 $"Type '{type.Name}' is not a machine.");
@@ -366,7 +378,7 @@ namespace Microsoft.PSharp
             }
 
             bool runNewHandler = false;
-            this.EnqueueEvent(machine, e, sender, ref runNewHandler);
+            this.EnqueueEvent(machine, e, sender, operationGroupId, ref runNewHandler);
             if (runNewHandler)
             {
                 this.RunMachineEventHandler(machine, null, false);
@@ -399,7 +411,7 @@ namespace Microsoft.PSharp
             }
 
             bool runNewHandler = false;
-            this.EnqueueEvent(machine, e, sender, ref runNewHandler);
+            this.EnqueueEvent(machine, e, sender, operationGroupId, ref runNewHandler);
             if (runNewHandler)
             {
                 await this.RunMachineEventHandlerAsync(machine, null, false);
@@ -424,10 +436,12 @@ namespace Microsoft.PSharp
         /// <param name="machine">Machine</param>
         /// <param name="e">Event</param>
         /// <param name="sender">Sender machine</param>
+        /// <param name="operationGroupId">Operation group id</param>
         /// <param name="runNewHandler">Run a new handler</param>
-        private void EnqueueEvent(Machine machine, Event e, AbstractMachine sender, ref bool runNewHandler)
+        private void EnqueueEvent(Machine machine, Event e, AbstractMachine sender, Guid? operationGroupId, ref bool runNewHandler)
         {
             EventInfo eventInfo = new EventInfo(e, null);
+            this.SetOperationGroupIdForEvent(eventInfo, sender, operationGroupId);
 
             if (sender != null)
             {
@@ -778,6 +792,8 @@ namespace Microsoft.PSharp
         /// <param name="operationGroupId">Operation group id</param>
         internal override void NotifyRaisedEvent(Machine machine, EventInfo eventInfo, Guid? operationGroupId)
         {
+            this.SetOperationGroupIdForEvent(eventInfo, machine, operationGroupId);
+
             if (base.Configuration.Verbose <= 1)
             {
                 return;
@@ -809,6 +825,9 @@ namespace Microsoft.PSharp
         /// <param name="eventInfo">EventInfo</param>
         internal override void NotifyDequeuedEvent(Machine machine, EventInfo eventInfo)
         {
+            // The machine inherits the operation group id of the dequeued event.
+            machine.Info.OperationGroupId = eventInfo.OperationGroupId;
+
             base.Log($"<DequeueLog> Machine '{machine.Id}' dequeued " +
                 $"event '{eventInfo.EventName}'.");
         }

--- a/Source/TestingServices/Runtime/BugFindingRuntime.cs
+++ b/Source/TestingServices/Runtime/BugFindingRuntime.cs
@@ -167,9 +167,10 @@ namespace Microsoft.PSharp.TestingServices
         /// used to access its payload, and cannot be handled.
         /// </summary>
         /// <param name="type">Type of the machine</param>
+        /// <param name="operationGroupId">Optional operation group id</param>
         /// <param name="e">Event</param>
         /// <returns>MachineId</returns>
-        public override MachineId CreateMachine(Type type, Event e = null)
+        public override MachineId CreateMachine(Type type, Event e = null, Guid? operationGroupId = null)
         {
             Machine creator = null;
             if (this.TaskMap.ContainsKey((int)Task.CurrentId))
@@ -177,7 +178,7 @@ namespace Microsoft.PSharp.TestingServices
                 creator = this.TaskMap[(int)Task.CurrentId];
             }
 
-            return this.CreateMachine(type, null, e, creator);
+            return this.CreateMachine(type, null, e, creator, operationGroupId);
         }
 
         /// <summary>
@@ -187,9 +188,10 @@ namespace Microsoft.PSharp.TestingServices
         /// </summary>
         /// <param name="type">Type of the machine</param>
         /// <param name="friendlyName">Friendly machine name used for logging</param>
+        /// <param name="operationGroupId">Optional operation group id</param>
         /// <param name="e">Event</param>
         /// <returns>MachineId</returns>
-        public override MachineId CreateMachine(Type type, string friendlyName, Event e = null)
+        public override MachineId CreateMachine(Type type, string friendlyName, Event e = null, Guid? operationGroupId = null)
         {
             Machine creator = null;
             if (this.TaskMap.ContainsKey((int)Task.CurrentId))
@@ -197,7 +199,7 @@ namespace Microsoft.PSharp.TestingServices
                 creator = this.TaskMap[(int)Task.CurrentId];
             }
 
-            return this.CreateMachine(type, friendlyName, e, creator);
+            return this.CreateMachine(type, friendlyName, e, creator, operationGroupId);
         }
 
         /// <summary>
@@ -207,9 +209,10 @@ namespace Microsoft.PSharp.TestingServices
         /// when the machine is initialized and the <see cref="Event"/> (if any) is handled.
         /// </summary>
         /// <param name="type">Type of the machine</param>
+        /// <param name="operationGroupId">Optional operation group id</param>
         /// <param name="e">Event</param>
         /// <returns>MachineId</returns>
-        public override Task<MachineId> CreateMachineAndExecute(Type type, Event e = null)
+        public override Task<MachineId> CreateMachineAndExecute(Type type, Event e = null, Guid? operationGroupId = null)
         {
             Machine creator = null;
             if (this.TaskMap.ContainsKey((int)Task.CurrentId))
@@ -217,7 +220,7 @@ namespace Microsoft.PSharp.TestingServices
                 creator = this.TaskMap[(int)Task.CurrentId];
             }
 
-            return this.CreateMachineAndExecute(type, null, e, creator);
+            return this.CreateMachineAndExecute(type, null, e, creator, operationGroupId);
         }
 
         /// <summary>
@@ -228,9 +231,10 @@ namespace Microsoft.PSharp.TestingServices
         /// </summary>
         /// <param name="type">Type of the machine</param>
         /// <param name="friendlyName">Friendly machine name used for logging</param>
+        /// <param name="operationGroupId">Optional operation group id</param>
         /// <param name="e">Event</param>
         /// <returns>MachineId</returns>
-        public override Task<MachineId> CreateMachineAndExecute(Type type, string friendlyName, Event e = null)
+        public override Task<MachineId> CreateMachineAndExecute(Type type, string friendlyName, Event e = null, Guid? operationGroupId = null)
         {
             Machine creator = null;
             if (this.TaskMap.ContainsKey((int)Task.CurrentId))
@@ -238,7 +242,7 @@ namespace Microsoft.PSharp.TestingServices
                 creator = this.TaskMap[(int)Task.CurrentId];
             }
 
-            return this.CreateMachineAndExecute(type, friendlyName, e, creator);
+            return this.CreateMachineAndExecute(type, friendlyName, e, creator, operationGroupId);
         }
 
         /// <summary>
@@ -248,9 +252,10 @@ namespace Microsoft.PSharp.TestingServices
         /// </summary>
         /// <param name="type">Type of the machine</param>
         /// <param name="endpoint">Endpoint</param>
+        /// <param name="operationGroupId">Optional operation group id</param>
         /// <param name="e">Event</param>
         /// <returns>MachineId</returns>
-        public override MachineId RemoteCreateMachine(Type type, string endpoint, Event e = null)
+        public override MachineId RemoteCreateMachine(Type type, string endpoint, Event e = null, Guid? operationGroupId = null)
         {
             Machine creator = null;
             if (this.TaskMap.ContainsKey((int)Task.CurrentId))
@@ -258,7 +263,7 @@ namespace Microsoft.PSharp.TestingServices
                 creator = this.TaskMap[(int)Task.CurrentId];
             }
 
-            return this.CreateRemoteMachine(type, null, endpoint, e, creator);
+            return this.CreateRemoteMachine(type, null, endpoint, e, creator, operationGroupId);
         }
 
         /// <summary>
@@ -269,10 +274,11 @@ namespace Microsoft.PSharp.TestingServices
         /// <param name="type">Type of the machine</param>
         /// <param name="friendlyName">Friendly machine name used for logging</param>
         /// <param name="endpoint">Endpoint</param>
+        /// <param name="operationGroupId">Optional operation group id</param>
         /// <param name="e">Event</param>
         /// <returns>MachineId</returns>
         public override MachineId RemoteCreateMachine(Type type, string friendlyName,
-            string endpoint, Event e = null)
+            string endpoint, Event e = null, Guid? operationGroupId = null)
         {
             Machine creator = null;
             if (this.TaskMap.ContainsKey((int)Task.CurrentId))
@@ -280,7 +286,7 @@ namespace Microsoft.PSharp.TestingServices
                 creator = this.TaskMap[(int)Task.CurrentId];
             }
 
-            return this.CreateRemoteMachine(type, friendlyName, endpoint, e, creator);
+            return this.CreateRemoteMachine(type, friendlyName, endpoint, e, creator, operationGroupId);
         }
 
         /// <summary>
@@ -444,10 +450,11 @@ namespace Microsoft.PSharp.TestingServices
         /// </summary>
         /// <param name="type">Type of the machine</param>
         /// <param name="friendlyName">Friendly machine name used for logging</param>
+        /// <param name="operationGroupId">Operation group id</param>
         /// <param name="e">Event passed during machine construction</param>
         /// <param name="creator">Creator machine</param>
         /// <returns>MachineId</returns>
-        internal override MachineId CreateMachine(Type type, string friendlyName, Event e, Machine creator)
+        internal override MachineId CreateMachine(Type type, string friendlyName, Event e, Machine creator, Guid? operationGroupId)
         {
             if (creator != null)
             {
@@ -459,6 +466,7 @@ namespace Microsoft.PSharp.TestingServices
             this.Scheduler.Schedule(OperationType.Create, OperationTargetType.Schedulable, ulong.MaxValue);
 
             Machine machine = this.CreateMachine(type, friendlyName);
+            this.SetOperationGroupIdForMachine(machine, creator, operationGroupId);
 
             this.BugTrace.AddCreateMachineStep(creator, machine.Id, e == null ? null : new EventInfo(e));
             if (base.Configuration.EnableDataRaceDetection)
@@ -483,10 +491,11 @@ namespace Microsoft.PSharp.TestingServices
         /// </summary>
         /// <param name="type">Type of the machine</param>
         /// <param name="friendlyName">Friendly machine name used for logging</param>
+        /// <param name="operationGroupId">Operation group id</param>
         /// <param name="e">Event passed during machine construction</param>
         /// <param name="creator">Creator machine</param>
         /// <returns>MachineId</returns>
-        internal override async Task<MachineId> CreateMachineAndExecute(Type type, string friendlyName, Event e, Machine creator)
+        internal override async Task<MachineId> CreateMachineAndExecute(Type type, string friendlyName, Event e, Machine creator, Guid? operationGroupId)
         {
             if (creator != null)
             {
@@ -498,6 +507,7 @@ namespace Microsoft.PSharp.TestingServices
             this.Scheduler.Schedule(OperationType.Create, OperationTargetType.Schedulable, ulong.MaxValue);
 
             Machine machine = this.CreateMachine(type, friendlyName);
+            this.SetOperationGroupIdForMachine(machine, creator, operationGroupId);
 
             this.BugTrace.AddCreateMachineStep(creator, machine.Id, e == null ? null : new EventInfo(e));
             if (base.Configuration.EnableDataRaceDetection)
@@ -523,13 +533,14 @@ namespace Microsoft.PSharp.TestingServices
         /// <param name="type">Type of the machine</param>
         /// <param name="friendlyName">Friendly machine name used for logging</param>
         /// <param name="endpoint">Endpoint</param>
+        /// <param name="operationGroupId">Operation group id</param>
         /// <param name="e">Event passed during machine construction</param>
         /// <param name="creator">Creator machine</param>
         /// <returns>MachineId</returns>
         internal override MachineId CreateRemoteMachine(Type type, string friendlyName, string endpoint,
-            Event e, Machine creator)
+            Event e, Machine creator, Guid? operationGroupId)
         {
-            return this.CreateMachine(type, friendlyName, e, creator);
+            return this.CreateMachine(type, friendlyName, e, creator, operationGroupId);
         }
 
         /// <summary>
@@ -548,9 +559,6 @@ namespace Microsoft.PSharp.TestingServices
 
             machine.Initialize(this, mid, new SchedulableInfo(mid));
             machine.InitializeStateInformation();
-
-            // The new machine inherits the operation group id of the creator.
-            machine.Info.OperationGroupId = this.Scheduler.ScheduledMachine.NextOperationGroupId;
 
             if (base.Configuration.ReportCodeCoverage && !isMachineTypeCached)
             {
@@ -1556,28 +1564,6 @@ namespace Microsoft.PSharp.TestingServices
             }
 
             return fingerprint;
-        }
-
-        /// <summary>
-        /// Sets the operation group id for the specified event.
-        /// </summary>
-        /// <param name="eventInfo">EventInfo</param>
-        /// <param name="sender">Sender machine</param>
-        /// <param name="operationGroupId">Operation group id</param>
-        private void SetOperationGroupIdForEvent(EventInfo eventInfo, AbstractMachine sender, Guid? operationGroupId)
-        {
-            if (operationGroupId.HasValue)
-            {
-                eventInfo.SetOperationGroupId(operationGroupId.Value);
-            }
-            else if (sender != null)
-            {
-                eventInfo.SetOperationGroupId((sender.Info as SchedulableInfo).NextOperationGroupId);
-            }
-            else
-            {
-                eventInfo.SetOperationGroupId(Guid.Empty);
-            }
         }
 
         #endregion

--- a/Tests/Core.Tests.Unit/Core.Tests.Unit.csproj
+++ b/Tests/Core.Tests.Unit/Core.Tests.Unit.csproj
@@ -18,4 +18,7 @@
     <PackageReference Include="xunit.runner.console" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
 </Project>

--- a/Tests/Core.Tests.Unit/Features/GetOperationGroupIdTest.cs
+++ b/Tests/Core.Tests.Unit/Features/GetOperationGroupIdTest.cs
@@ -66,25 +66,6 @@ namespace Microsoft.PSharp.Core.Tests.Unit
             }
         }
 
-        class M3 : Machine
-        {
-            [Start]
-            [OnEntry(nameof(InitOnEntry))]
-            class Init : MachineState { }
-
-            void InitOnEntry()
-            {
-                var target = CreateMachine(typeof(M4));
-                Runtime.GetCurrentOperationGroupId(target);
-            }
-        }
-
-        class M4 : Machine
-        {
-            [Start]
-            class Init : MachineState { }
-        }
-
         public void AssertSucceeded(Type machine)
         {
             var runtime = PSharpRuntime.Create();
@@ -102,26 +83,6 @@ namespace Microsoft.PSharp.Core.Tests.Unit
             Assert.False(failed);
         }
 
-        public string AssertFailed(Type machine)
-        {
-            var runtime = PSharpRuntime.Create();
-            var failed = false;
-            var msg = "";
-            var tcs = new TaskCompletionSource<bool>();
-            runtime.OnFailure += delegate (Exception e)
-            {
-                failed = true;
-                msg = e.Message;
-                tcs.SetResult(true);
-            };
-
-            runtime.CreateMachine(machine);
-
-            tcs.Task.Wait(100);
-            Assert.True(failed);
-            return msg;
-        }
-
         [Fact]
         public void TestGetOperationGroupIdNotSet()
         {
@@ -132,13 +93,6 @@ namespace Microsoft.PSharp.Core.Tests.Unit
         public void TestGetOperationGroupIdSet()
         {
             AssertSucceeded(typeof(M2));
-        }
-
-        [Fact]
-        public void TestGetOperationGroupIdOfNotCurrentMachine()
-        {
-            var msg = AssertFailed(typeof(M3));
-            Assert.True(msg.Equals("Trying to access the operation group id of 'Microsoft.PSharp.TestingServices.Tests.Unit.GetOperationGroupIdTest+M4()', which is not the currently executing machine."));
         }
     }
 }

--- a/Tests/Core.Tests.Unit/Features/GetOperationGroupIdTest.cs
+++ b/Tests/Core.Tests.Unit/Features/GetOperationGroupIdTest.cs
@@ -1,0 +1,144 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="GetOperationGroupIdTest.cs">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// 
+//      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.PSharp.Core.Tests.Unit
+{
+    public class GetOperationGroupIdTest 
+    {
+        static Guid OperationGroup = Guid.NewGuid();
+
+        class E : Event
+        {
+            public MachineId Id;
+
+            public E() { }
+
+            public E(MachineId id)
+            {
+                Id = id;
+            }
+        }
+
+        class M1 : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            class Init : MachineState { }
+
+            void InitOnEntry()
+            {
+                var id = Runtime.GetCurrentOperationGroupId(Id);
+                Assert(id == Guid.Empty, $"OperationGroupId is not '{Guid.Empty}', but {id}.");
+            }
+        }
+
+        class M2 : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            [OnEventDoAction(typeof(E), nameof(CheckEvent))]
+            class Init : MachineState { }
+
+            void InitOnEntry()
+            {
+                Runtime.SendEvent(Id, new E(Id), OperationGroup);
+            }
+
+            void CheckEvent()
+            {
+                var id = Runtime.GetCurrentOperationGroupId(Id);
+                Assert(id == OperationGroup, $"OperationGroupId is not '{OperationGroup}', but {id}.");
+            }
+        }
+
+        class M3 : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            class Init : MachineState { }
+
+            void InitOnEntry()
+            {
+                var target = CreateMachine(typeof(M4));
+                Runtime.GetCurrentOperationGroupId(target);
+            }
+        }
+
+        class M4 : Machine
+        {
+            [Start]
+            class Init : MachineState { }
+        }
+
+        public void AssertSucceeded(Type machine)
+        {
+            var runtime = PSharpRuntime.Create();
+            var failed = false;
+            var tcs = new TaskCompletionSource<bool>();
+            runtime.OnFailure += delegate
+            {
+                failed = true;
+                tcs.SetResult(true);
+            };
+
+            runtime.CreateMachine(machine);
+
+            tcs.Task.Wait(100);
+            Assert.False(failed);
+        }
+
+        public string AssertFailed(Type machine)
+        {
+            var runtime = PSharpRuntime.Create();
+            var failed = false;
+            var msg = "";
+            var tcs = new TaskCompletionSource<bool>();
+            runtime.OnFailure += delegate (Exception e)
+            {
+                failed = true;
+                msg = e.Message;
+                tcs.SetResult(true);
+            };
+
+            runtime.CreateMachine(machine);
+
+            tcs.Task.Wait(100);
+            Assert.True(failed);
+            return msg;
+        }
+
+        [Fact]
+        public void TestGetOperationGroupIdNotSet()
+        {
+            AssertSucceeded(typeof(M1));
+        }
+
+        [Fact]
+        public void TestGetOperationGroupIdSet()
+        {
+            AssertSucceeded(typeof(M2));
+        }
+
+        [Fact]
+        public void TestGetOperationGroupIdOfNotCurrentMachine()
+        {
+            var msg = AssertFailed(typeof(M3));
+            Assert.True(msg.Equals("Trying to access the operation group id of 'Microsoft.PSharp.TestingServices.Tests.Unit.GetOperationGroupIdTest+M4()', which is not the currently executing machine."));
+        }
+    }
+}

--- a/Tests/Core.Tests.Unit/Features/OperationGroupingTest.cs
+++ b/Tests/Core.Tests.Unit/Features/OperationGroupingTest.cs
@@ -1,0 +1,354 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="OperationGroupingTest.cs">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// 
+//      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+
+namespace Microsoft.PSharp.Core.Tests.Unit
+{
+    public class OperationGroupingTest
+    {
+        static Guid OperationGroup1 = Guid.NewGuid();
+        static Guid OperationGroup2 = Guid.NewGuid();
+
+        class E : Event
+        {
+            public MachineId Id;
+
+            public E() { }
+
+            public E(MachineId id)
+            {
+                Id = id;
+            }
+        }
+
+        class M1 : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            class Init : MachineState { }
+
+            void InitOnEntry()
+            {
+                var id = this.OperationGroupId;
+                Assert(id == Guid.Empty, $"OperationGroupId is not '{Guid.Empty}', but {id}.");
+            }
+        }
+
+        class M2 : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            [OnEventDoAction(typeof(E), nameof(CheckEvent))]
+            class Init : MachineState { }
+
+            void InitOnEntry()
+            {
+                Send(Id, new E());
+            }
+
+            void CheckEvent()
+            {
+                var id = this.OperationGroupId;
+                Assert(id == Guid.Empty, $"OperationGroupId is not '{Guid.Empty}', but {id}.");
+            }
+        }
+
+        class M2S : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            [OnEventDoAction(typeof(E), nameof(CheckEvent))]
+            class Init : MachineState { }
+
+            void InitOnEntry()
+            {
+                Runtime.SendEvent(Id, new E(), OperationGroup1);
+            }
+
+            void CheckEvent()
+            {
+                var id = this.OperationGroupId;
+                Assert(id == OperationGroup1, $"OperationGroupId is not '{OperationGroup1}', but {id}.");
+            }
+        }
+
+        class M3 : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            class Init : MachineState { }
+
+            void InitOnEntry()
+            {
+                var target = CreateMachine(typeof(M4));
+            }
+        }
+
+        class M4 : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            class Init : MachineState { }
+
+            void InitOnEntry()
+            {
+                var id = this.OperationGroupId;
+                Assert(id == Guid.Empty, $"OperationGroupId is not '{Guid.Empty}', but {id}.");
+            }
+        }
+
+        class M5 : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            class Init : MachineState { }
+
+            void InitOnEntry()
+            {
+                var target = CreateMachine(typeof(M6));
+                Send(target, new E());
+            }
+        }
+
+        class M6 : Machine
+        {
+            [Start]
+            [OnEventDoAction(typeof(E), nameof(CheckEvent))]
+            class Init : MachineState { }
+
+            void CheckEvent()
+            {
+                var id = this.OperationGroupId;
+                Assert(id == Guid.Empty, $"OperationGroupId is not '{Guid.Empty}', but {id}.");
+            }
+        }
+
+        class M5S : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            class Init : MachineState { }
+
+            void InitOnEntry()
+            {
+                var target = CreateMachine(typeof(M6S));
+                Runtime.SendEvent(target, new E(), OperationGroup1);
+            }
+        }
+
+        class M6S : Machine
+        {
+            [Start]
+            [OnEventDoAction(typeof(E), nameof(CheckEvent))]
+            class Init : MachineState { }
+
+            void CheckEvent()
+            {
+                var id = this.OperationGroupId;
+                Assert(id == OperationGroup1, $"OperationGroupId is not '{OperationGroup1}', but {id}.");
+            }
+        }
+
+        class M7 : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            [OnEventDoAction(typeof(E), nameof(CheckEvent))]
+            class Init : MachineState { }
+
+            void InitOnEntry()
+            {
+                var target = CreateMachine(typeof(M8));
+                Runtime.SendEvent(target, new E(Id), OperationGroup1);
+            }
+
+            void CheckEvent()
+            {
+                var id = this.OperationGroupId;
+                Assert(id == OperationGroup1, $"OperationGroupId is not '{OperationGroup1}', but {id}.");
+            }
+        }
+
+        class M8 : Machine
+        {
+            [Start]
+            [OnEventDoAction(typeof(E), nameof(CheckEvent))]
+            class Init : MachineState { }
+
+            void CheckEvent()
+            {
+                var id = this.OperationGroupId;
+                Assert(id == OperationGroup1, $"OperationGroupId is not '{OperationGroup1}', but {id}.");
+                Send((ReceivedEvent as E).Id, new E());
+            }
+        }
+
+        class M7S : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            [OnEventDoAction(typeof(E), nameof(CheckEvent))]
+            class Init : MachineState { }
+
+            void InitOnEntry()
+            {
+                var target = CreateMachine(typeof(M8S));
+                Runtime.SendEvent(target, new E(Id), OperationGroup1);
+            }
+
+            void CheckEvent()
+            {
+                var id = this.OperationGroupId;
+                Assert(id == OperationGroup2, $"OperationGroupId is not '{OperationGroup2}', but {id}.");
+            }
+        }
+
+        class M8S : Machine
+        {
+            [Start]
+            [OnEventDoAction(typeof(E), nameof(CheckEvent))]
+            class Init : MachineState { }
+
+            void CheckEvent()
+            {
+                var id = this.OperationGroupId;
+                Assert(id == OperationGroup1, $"OperationGroupId is not '{OperationGroup1}', but {id}.");
+                Runtime.SendEvent((ReceivedEvent as E).Id, new E(), OperationGroup2);
+            }
+        }
+
+        class M9S : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            [OnEventDoAction(typeof(E), nameof(CheckEvent))]
+            class Init : MachineState { }
+
+            void InitOnEntry()
+            {
+                var target = CreateMachine(typeof(M10S));
+                Runtime.SendEvent(target, new E(Id), OperationGroup1);
+            }
+
+            void CheckEvent()
+            {
+                var id = this.OperationGroupId;
+                Assert(id == OperationGroup2, $"OperationGroupId is not '{OperationGroup2}', but {id}.");
+            }
+        }
+
+        class M10S : Machine
+        {
+            [Start]
+            [OnEventDoAction(typeof(E), nameof(CheckEvent))]
+            class Init : MachineState { }
+
+            void CheckEvent()
+            {
+                var target = CreateMachine(typeof(M11S));
+                var id = this.OperationGroupId;
+                Assert(id == OperationGroup1, $"OperationGroupId is not '{OperationGroup1}', but {id}.");
+                Runtime.SendEvent((ReceivedEvent as E).Id, new E(), OperationGroup2);
+            }
+        }
+
+        class M11S : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            class Init : MachineState { }
+
+            void InitOnEntry()
+            {
+                var id = this.OperationGroupId;
+                Assert(id == OperationGroup1, $"OperationGroupId is not '{OperationGroup1}', but {id}.");
+            }
+        }
+
+        public void AssertSucceeded(Type machine)
+        {
+            var runtime = PSharpRuntime.Create();
+            var failed = false;
+            var tcs = new TaskCompletionSource<bool>();
+            runtime.OnFailure += delegate
+            {
+                failed = true;
+                tcs.SetResult(true);
+            };
+
+            runtime.CreateMachine(machine);
+
+            tcs.Task.Wait(100);
+            Assert.False(failed);
+        }
+
+        [Fact]
+        public void TestOperationGroupingSingleMachineNoSend()
+        {
+            AssertSucceeded(typeof(M1));
+        }
+
+        [Fact]
+        public void TestOperationGroupingSingleMachineSend()
+        {
+            AssertSucceeded(typeof(M2));
+        }
+
+        [Fact]
+        public void TestOperationGroupingSingleMachineSendStarter()
+        {
+            AssertSucceeded(typeof(M2S));
+        }
+
+        [Fact]
+        public void TestOperationGroupingTwoMachinesCreate()
+        {
+            AssertSucceeded(typeof(M3));
+        }
+
+        [Fact]
+        public void TestOperationGroupingTwoMachinesSend()
+        {
+            AssertSucceeded(typeof(M5));
+        }
+
+        [Fact]
+        public void TestOperationGroupingTwoMachinesSendStarter()
+        {
+            AssertSucceeded(typeof(M5S));
+        }
+
+        [Fact]
+        public void TestOperationGroupingTwoMachinesSendBack()
+        {
+            AssertSucceeded(typeof(M7));
+        }
+
+        [Fact]
+        public void TestOperationGroupingTwoMachinesSendBackStarter()
+        {
+            AssertSucceeded(typeof(M7S));
+        }
+
+        [Fact]
+        public void TestOperationGroupingThreeMachinesSendStarter()
+        {
+            AssertSucceeded(typeof(M9S));
+        }
+    }
+}

--- a/Tests/LanguageServices.Tests.Unit/LanguageServices.Tests.Unit.csproj
+++ b/Tests/LanguageServices.Tests.Unit/LanguageServices.Tests.Unit.csproj
@@ -18,4 +18,7 @@
     <PackageReference Include="xunit.runner.console" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
 </Project>

--- a/Tests/SharedObjects.Tests.Unit/SharedObjects.Tests.Unit.csproj
+++ b/Tests/SharedObjects.Tests.Unit/SharedObjects.Tests.Unit.csproj
@@ -18,4 +18,7 @@
     <PackageReference Include="xunit.runner.console" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
 </Project>

--- a/Tests/StaticAnalysis.Tests.Unit/StaticAnalysis.Tests.Unit.csproj
+++ b/Tests/StaticAnalysis.Tests.Unit/StaticAnalysis.Tests.Unit.csproj
@@ -18,4 +18,7 @@
     <PackageReference Include="xunit.runner.console" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
 </Project>

--- a/Tests/TestingServices.Tests.Integration/TestingServices.Tests.Integration.csproj
+++ b/Tests/TestingServices.Tests.Integration/TestingServices.Tests.Integration.csproj
@@ -18,4 +18,7 @@
     <PackageReference Include="xunit.runner.console" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
 </Project>

--- a/Tests/TestingServices.Tests.Unit/TestingServices.Tests.Unit.csproj
+++ b/Tests/TestingServices.Tests.Unit/TestingServices.Tests.Unit.csproj
@@ -18,4 +18,7 @@
     <PackageReference Include="xunit.runner.console" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
I changed the `CreateMachine` API to mirror `Send`.  `Runtime.CreateMachine` can now take an optional `OperationGroupId` parameter. 

The `OperationGroupId` are also propagated by the production runtime.

Added unit tests. 