### PR TITLE
Exception capture for Machine.ExecuteAction sync path

### DIFF
--- a/Samples/PingPong/PingPong.PSharpLanguage.AsyncAwait/Server.psharp
+++ b/Samples/PingPong/PingPong.PSharpLanguage.AsyncAwait/Server.psharp
@@ -1,4 +1,7 @@
-﻿namespace PingPong.PSharpLanguage.AsyncAwait
+﻿using System;
+using System.Threading.Tasks;
+
+namespace PingPong.PSharpLanguage.AsyncAwait
 {
     /// <summary>
     /// A P# machine that models a simple server.
@@ -15,17 +18,20 @@
         start state Active
         {
             /// <summary>
-            /// The 'on ... do ...' action declaration will execute (asynchrously)
-            /// the 'SendPong' method, whenever a 'Ping' event is dequeued while the
-            /// server machine is in the 'Active' state. See client.psharp for an 
-            /// example of an async anonymous action, which requires an explicit async
-            /// declaration.
+			/// Whenever a 'Ping' event is dequeued while the server machine is in the
+			/// 'Active' state, the 'on ... do ...' action declaration will execute the
+			/// 'SendPong' method; the method invocation will automatically be asynchronous
+			/// due to the Task return type of SendPong, and no 'await' is required here.
+			/// See client.psharp for an example of an async anonymous action, which does
+			/// require an explicit async declaration.
             /// </summary>
             on Client.Ping do SendPong;
         }
 
-        void SendPong()
+        async Task SendPong()
         {
+            await Task.Delay(42); // Simple await operation (compiler will warn if no awaits are present).
+
             // Receives a reference to a client machine (as a payload of
             // the 'Ping' event).
             var client = (trigger as Client.Ping).client;

--- a/Source/Core/Library/CachedAction.cs
+++ b/Source/Core/Library/CachedAction.cs
@@ -1,0 +1,56 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="CachedAction.cs">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// 
+//      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace Microsoft.PSharp
+{
+    internal class CachedAction
+    {
+        internal readonly MethodInfo MethodInfo;
+        private Action Action;
+        private Func<Task> TaskFunc;
+
+        internal bool IsAsync => this.TaskFunc != null;
+
+        internal CachedAction(MethodInfo methodInfo, Machine machine)
+        {
+            this.MethodInfo = methodInfo;
+
+            // MethodInfo.Invoke catches the exception to wrap it in a TargetInvocationException.
+            // This unwinds the stack before Machine.ExecuteAction's exception filter is invoked,
+            // so call through the delegate instead (which is also much faster than Invoke).
+            if (methodInfo.ReturnType == typeof(void))
+            {
+                this.Action = (Action)Delegate.CreateDelegate(typeof(Action), machine, methodInfo);
+            }
+            else
+            {
+                this.TaskFunc = (Func<Task>)Delegate.CreateDelegate(typeof(Func<Task>), machine, methodInfo);
+            }
+        }
+
+        internal void Execute()
+        {
+            this.Action();
+        }
+
+        internal async Task ExecuteAsync()
+        {
+            await this.TaskFunc();
+        }
+    }
+}

--- a/Source/Core/Runtime/Exceptions/MachineActionExceptionFilterException.cs
+++ b/Source/Core/Runtime/Exceptions/MachineActionExceptionFilterException.cs
@@ -1,0 +1,41 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="MachineActionExceptionFilterException.cs">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// 
+//      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+
+namespace Microsoft.PSharp
+{
+    /// <summary>
+    /// The exception that is thrown by the P# runtime upon a machine action failure.
+    /// </summary>
+    internal sealed class MachineActionExceptionFilterException : RuntimeException
+    {
+        /// <summary>
+        /// Initializes a new instance of the exception.
+        /// </summary>
+        /// <param name="message">Message</param>
+        internal MachineActionExceptionFilterException(string message)
+            : base(message)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the exception.
+        /// </summary>
+        /// <param name="message">Message</param>
+        /// <param name="innerException">Inner exception</param>
+        internal MachineActionExceptionFilterException(string message, Exception innerException)
+            : base(message, innerException)
+        { }
+    }
+}

--- a/Source/Core/Runtime/PSharpRuntime.cs
+++ b/Source/Core/Runtime/PSharpRuntime.cs
@@ -772,7 +772,7 @@ namespace Microsoft.PSharp
         /// Raises the <see cref="OnFailure"/> event with the specified <see cref="Exception"/>.
         /// </summary>
         /// <param name="exception">Exception</param>
-        protected void RaiseOnFailureEvent(Exception exception)
+        protected internal void RaiseOnFailureEvent(Exception exception)
         {
             this.OnFailure?.Invoke(exception);
         }


### PR DESCRIPTION
Convert MethodInfo to delegates and add 'when' exception filter for synchronous machine actions