### PR TITLE
Resolve #236 and #241

### DIFF
--- a/Source/Core/Configuration/Configuration.cs
+++ b/Source/Core/Configuration/Configuration.cs
@@ -597,7 +597,7 @@ namespace Microsoft.PSharp
         {
             // Return true if not set
             return this.RewriteCSharpVersion.Major == 0
-                || this.RewriteCSharpVersion > new Version(major, minor);
+                || this.RewriteCSharpVersion >= new Version(major, minor);
         }
 
         #endregion

--- a/Tools/Compilation/SyntaxRewriter/PSharp.targets
+++ b/Tools/Compilation/SyntaxRewriter/PSharp.targets
@@ -9,6 +9,7 @@
   <Target Name="GenerateToolOutput">
     <Rewriter
         InputFiles="@(PSharp)"
+        CSharpVersion="$(LangVersion)"
         OutputFiles="@(PSharp->'$(IntermediateOutputPath)%(FileName)%(Extension).cs')">
       <Output TaskParameter="OutputFiles" ItemName="Compile" />
     </Rewriter>

--- a/Tools/Compilation/SyntaxRewriter/PSharp.vs2017.targets
+++ b/Tools/Compilation/SyntaxRewriter/PSharp.vs2017.targets
@@ -3,6 +3,7 @@
   <Target Name="GenerateToolOutput" BeforeTargets="CoreCompile">
     <Rewriter
         InputFiles="@(PSharp)"
+        CSharpVersion="$(LangVersion)"
         OutputFiles="@(PSharp->'$(IntermediateOutputPath)%(FileName)%(Extension).cs')">
       <Output TaskParameter="OutputFiles" ItemName="Compile" />
     </Rewriter>

--- a/Tools/Testing/Tester/Instrumentation/CodeCoverageInstrumentation.cs
+++ b/Tools/Testing/Tester/Instrumentation/CodeCoverageInstrumentation.cs
@@ -30,7 +30,6 @@ namespace Microsoft.PSharp.TestingServices
     {
         internal static string OutputDirectory = string.Empty;
         internal static List<string> InstrumentedAssemblyNames = new List<string>();
-        private static string VSInstrToolPath = GetToolPath("VSInstrToolPath", "VSInstr");
 
         internal static void Instrument(Configuration configuration)
         {
@@ -118,7 +117,7 @@ namespace Microsoft.PSharp.TestingServices
 
             using (var instrProc = new Process())
             {
-                instrProc.StartInfo.FileName = VSInstrToolPath;
+                instrProc.StartInfo.FileName = GetToolPath("VSInstrToolPath", "VSInstr");
                 instrProc.StartInfo.Arguments = $"/coverage {assemblyName}";
                 instrProc.StartInfo.UseShellExecute = false;
                 instrProc.StartInfo.RedirectStandardOutput = true;

--- a/Tools/Testing/Tester/Instrumentation/CodeCoverageInstrumentation.cs
+++ b/Tools/Testing/Tester/Instrumentation/CodeCoverageInstrumentation.cs
@@ -201,13 +201,23 @@ namespace Microsoft.PSharp.TestingServices
         /// <summary>
         /// Returns the tool path to the code coverage instrumentor.
         /// </summary>
+        /// <param name="settingName">The name of the setting; also used to query the environment variables</param>
+        /// <param name="toolName">The name of the tool; used in messages only</param>
         /// <returns>Tool path</returns>
         internal static string GetToolPath(string settingName, string toolName)
         {
             string toolPath = "";
             try
             {
-                toolPath = ConfigurationManager.AppSettings[settingName];
+                toolPath = Environment.GetEnvironmentVariable(settingName);
+                if (string.IsNullOrEmpty(toolPath))
+                {
+                    toolPath = ConfigurationManager.AppSettings[settingName];
+                }
+                else
+                {
+                    Output.WriteLine($"{toolName} overriding app settings path with environment variable");
+                }
             }
             catch (ConfigurationErrorsException)
             {


### PR DESCRIPTION
- #236: make MSBuild Rewriter task CSharpVersion use LangVersion
- #241: allow env vars to override app settings for VS coverage tools path