### PR TITLE
Break on failure, for PSharpReplayer

### DIFF
--- a/Source/Core/Runtime/PSharpRuntime.cs
+++ b/Source/Core/Runtime/PSharpRuntime.cs
@@ -801,6 +801,13 @@ namespace Microsoft.PSharp
         /// <param name="exception">Exception</param>
         protected internal void RaiseOnFailureEvent(Exception exception)
         {
+            if (this.Configuration.AttachDebugger && exception is MachineActionExceptionFilterException &&
+                !((exception as MachineActionExceptionFilterException).InnerException is RuntimeException))
+            {
+                System.Diagnostics.Debugger.Break();
+                this.Configuration.AttachDebugger = false;
+            }
+
             this.OnFailure?.Invoke(exception);
         }
 


### PR DESCRIPTION
I made this change so that the Replayer breaks at the site of the exception. This does not matter so much to users that use the P# nuget because they will get an "exception unhandled in user code" break at the right point. But when taking a dependence on P# sources, the Replayer breaks at a point when the stack has unwound already. This change follows the same OnFailure logic that we followed for creating dumps at the site of the exception.