### PR TITLE
Generalize OnHalt to record events dropped on halt

### DIFF
--- a/Source/Core/IO/Logging/DisposingLogger.cs
+++ b/Source/Core/IO/Logging/DisposingLogger.cs
@@ -156,7 +156,8 @@ namespace Microsoft.PSharp.IO
         /// Called when a machine has been halted.
         /// </summary>
         /// <param name="machineId">The id of the machine that has been halted.</param>
-        public void OnHalt(MachineId machineId) { }
+        /// <param name="inboxSize">Approximate size of the machine inbox.</param>
+        public void OnHalt(MachineId machineId, int inboxSize) { }
 
         /// <summary>
         /// Called when a random result has been obtained.

--- a/Source/Core/IO/Logging/ILogger.cs
+++ b/Source/Core/IO/Logging/ILogger.cs
@@ -158,7 +158,8 @@ namespace Microsoft.PSharp.IO
         /// Called when a machine has been halted.
         /// </summary>
         /// <param name="machineId">The id of the machine that has been halted.</param>
-        void OnHalt(MachineId machineId);
+        /// <param name="inboxSize">Approximate size of the machine inbox.</param>
+        void OnHalt(MachineId machineId, int inboxSize);
 
         /// <summary>
         /// Called when a random result has been obtained.

--- a/Source/Core/IO/Logging/StateMachineLogger.cs
+++ b/Source/Core/IO/Logging/StateMachineLogger.cs
@@ -265,11 +265,12 @@ namespace Microsoft.PSharp.IO
         /// Called when a machine has been halted.
         /// </summary>
         /// <param name="machineId">The id of the machine that has been halted.</param>
-        public virtual void OnHalt(MachineId machineId)
+        /// <param name="inboxSize">Approximate size of the machine inbox.</param>
+        public virtual void OnHalt(MachineId machineId, int inboxSize)
         {
             if (this.IsVerbose)
             {
-                this.WriteLine($"<HaltLog> Machine '{machineId}' halted.");
+                this.WriteLine($"<HaltLog> Machine '{machineId}' halted with '{inboxSize}' events in its inbox.");
             }
         }
 

--- a/Source/Core/Library/Machine.cs
+++ b/Source/Core/Library/Machine.cs
@@ -813,8 +813,8 @@ namespace Microsoft.PSharp
                         lock (this.Inbox)
                         {
                             this.Info.IsHalted = true;
+                            base.Runtime.NotifyHalted(this, this.Inbox.Count);
                             this.CleanUpResources();
-                            base.Runtime.NotifyHalted(this);
                         }
 
                         return;

--- a/Source/Core/Runtime/PSharpRuntime.cs
+++ b/Source/Core/Runtime/PSharpRuntime.cs
@@ -653,8 +653,9 @@ namespace Microsoft.PSharp
         /// Notifies that a machine has halted.
         /// </summary>
         /// <param name="machine">Machine</param>
+        /// <param name="inboxSize">Current size of the machine inbox.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal virtual void NotifyHalted(Machine machine)
+        internal virtual void NotifyHalted(Machine machine, int inboxSize)
         {
             // Override to implement the notification.
         }

--- a/Source/Core/Runtime/StateMachineRuntime.cs
+++ b/Source/Core/Runtime/StateMachineRuntime.cs
@@ -795,9 +795,10 @@ namespace Microsoft.PSharp
         /// Notifies that a machine has halted.
         /// </summary>
         /// <param name="machine">Machine</param>
-        internal override void NotifyHalted(Machine machine)
+        /// <param name="inboxSize">Current size of the machine inbox.</param>
+        internal override void NotifyHalted(Machine machine, int inboxSize)
         {
-            base.Logger.OnHalt(machine.Id);
+            base.Logger.OnHalt(machine.Id, inboxSize);
             this.MachineMap.TryRemove(machine.Id.Value, out machine);
         }
 

--- a/Source/TestingServices/Runtime/BugFindingRuntime.cs
+++ b/Source/TestingServices/Runtime/BugFindingRuntime.cs
@@ -1212,10 +1212,11 @@ namespace Microsoft.PSharp.TestingServices
         /// Notifies that a machine has halted.
         /// </summary>
         /// <param name="machine">Machine</param>
-        internal override void NotifyHalted(Machine machine)
+        /// <param name="inboxSize">Current size of the machine inbox.</param>
+        internal override void NotifyHalted(Machine machine, int inboxSize)
         {
             this.BugTrace.AddHaltStep(machine.Id, null);
-            this.Logger.OnHalt(machine.Id);
+            this.Logger.OnHalt(machine.Id, inboxSize);
             this.MachineMap.TryRemove(machine.Id.Value, out machine);
         }
 


### PR DESCRIPTION
@pdeligia @TedHartMS What do you guys think of this generalization?
```
        /// <param name="inboxSize">Approximate size of the machine's inbox</param>
        public virtual void OnHalt(MachineId machineId, int inboxSize)
```
I think it'll be useful to know if a machine's inbox was non-empty when the machine halted. But note that the `inboxSize` is only approximate for production runs because an enqueue can happen after the call to `OnHalt`.