### PR TITLE
Resolve #254: Make code coverage always run out of process

### DIFF
--- a/Tools/Testing/Tester/Monitoring/CodeCoverageMonitor.cs
+++ b/Tools/Testing/Tester/Monitoring/CodeCoverageMonitor.cs
@@ -14,11 +14,9 @@
 
 using Microsoft.PSharp.IO;
 using System;
-using System.Configuration;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
-using System.Text.RegularExpressions;
+using System.Threading;
 
 namespace Microsoft.PSharp.TestingServices
 {
@@ -74,17 +72,57 @@ namespace Microsoft.PSharp.TestingServices
 
         private static void RunMonitorProcess(bool isStarting)
         {
+            var error = string.Empty;
+            var exitCode = 0;
+            var outputFile = GetOutputName();
+            var arguments = isStarting ? $"/start:coverage /output:{outputFile}" : "/shutdown";
+            var timedOut = false;
             using (var monitorProc = new Process())
             {
                 monitorProc.StartInfo.FileName = CodeCoverageInstrumentation.GetToolPath("VSPerfCmdToolPath", "VSPerfCmd");
-                monitorProc.StartInfo.Arguments = isStarting ? $"/start:coverage /output:{GetOutputName()}" : "/shutdown";
+                monitorProc.StartInfo.Arguments = arguments;
                 monitorProc.StartInfo.UseShellExecute = false;
                 monitorProc.StartInfo.RedirectStandardOutput = true;
                 monitorProc.StartInfo.RedirectStandardError = true;
                 monitorProc.Start();
-                if (isStarting)
+
+                Output.WriteLine($"... Shutting down code coverage monitor");
+
+                // timedOut can only become true on shutdown (non-infinite timeout value)
+                timedOut = !monitorProc.WaitForExit(isStarting ? Timeout.Infinite : 5000);
+                if (!timedOut)
                 {
-                    monitorProc.WaitForExit();
+                    exitCode = monitorProc.ExitCode;
+                    if (exitCode != 0)
+                    {
+                        error = monitorProc.StandardError.ReadToEnd();
+                    }
+                }
+            }
+
+            if (exitCode != 0 || error.Length > 0)
+            {
+                if (error.Length == 0)
+                {
+                    error = "<no error message returned>";
+                }
+                Output.WriteLine($"Warning: 'VSPerfCmd {arguments}' exit code {exitCode}: {error}");
+            }
+            if (!isStarting)
+            {
+                if (timedOut)
+                {
+                    Output.WriteLine($"Warning: VsPerfCmd timed out on shutdown");
+                }
+
+                if (File.Exists(outputFile))
+                {
+                    var fileInfo = new FileInfo(outputFile);
+                    Output.WriteLine($"..... Created {outputFile}");
+                }
+                else
+                {
+                    Output.WriteLine($"Warning: Code coverage output file {outputFile} was not created");
                 }
             }
         }


### PR DESCRIPTION
When `PSharpTester` is run without /parallel, the instrumented binary is pulled into the `PSharpTester` process; therefore calling `VSPerfCmd /shutdown` from `PSharpTester` can't wait for all instrumented processes to stop, but not waiting means there is some time after `PSharpTester` exits that `VSPerfCmd /shutdown` is still active, and this interferes with a subsequent `PSharpTester` run with no delay. Changed to execute the parallel code path (out of process) if `Configuration.ReportCodeCoverage` is set.