### PR TITLE
LinkedList for Machine.Inbox to get O(1) dequeue

### DIFF
--- a/Source/Core/Library/Machine.cs
+++ b/Source/Core/Library/Machine.cs
@@ -91,7 +91,7 @@ namespace Microsoft.PSharp
         /// Inbox of the state-machine. Incoming events are
         /// queued here. Events are dequeued to be processed.
         /// </summary>
-        private List<EventInfo> Inbox;
+        private LinkedList<EventInfo> Inbox;
 
         /// <summary>
         /// Gets the raised event. If no event has been raised
@@ -232,7 +232,7 @@ namespace Microsoft.PSharp
         /// </summary>
         protected Machine()
         {
-            this.Inbox = new List<EventInfo>();
+            this.Inbox = new LinkedList<EventInfo>();
             this.StateStack = new Stack<MachineState>();
             this.ActionHandlerStack = new Stack<Dictionary<Type, EventActionHandler>>();
             this.ActionMap = new Dictionary<string, CachedAction>();
@@ -579,7 +579,7 @@ namespace Microsoft.PSharp
 
                 base.Runtime.Logger.OnEnqueue(this.Id, this.CurrentStateName, eventInfo.EventName);
 
-                this.Inbox.Add(eventInfo);
+                this.Inbox.AddLast(eventInfo);
 
                 if (eventInfo.Event.Assert >= 0)
                 {
@@ -613,15 +613,17 @@ namespace Microsoft.PSharp
         /// <returns>EventInfo</returns>
         internal EventInfo TryDequeueEvent(bool checkOnly = false)
         {
-            EventInfo nextEventInfo = null;
+            EventInfo nextAvailableEventInfo = null;
 
             // Iterates through the events in the inbox.
-            for (int idx = 0; idx < this.Inbox.Count; idx++)
+            var node = Inbox.First;
+            while (node != null)
             {
-                // Removes an ignored event.
-                if (this.Inbox[idx].EventType.IsGenericType)
+                var nextNode = node.Next;
+                var currentEventInfo = node.Value;
+                if (currentEventInfo.EventType.IsGenericType)
                 {
-                    var genericTypeDefinition = this.Inbox[idx].EventType.GetGenericTypeDefinition();
+                    var genericTypeDefinition = currentEventInfo.EventType.GetGenericTypeDefinition();
                     var ignored = false;
                     foreach (var tup in this.CurrentActionHandlerMap)
                     {
@@ -638,39 +640,43 @@ namespace Microsoft.PSharp
                     {
                         if (!checkOnly)
                         {
-                            this.Inbox.RemoveAt(idx);
-                            idx--;
+                            // Removes an ignored event.
+                            Inbox.Remove(node);
                         }
 
+                        node = nextNode;
                         continue;
                     }
                 }
 
-                if (this.IsIgnored(this.Inbox[idx].EventType))
+                if (this.IsIgnored(currentEventInfo.EventType))
                 {
                     if (!checkOnly)
                     {
-                        this.Inbox.RemoveAt(idx);
-                        idx--;
+                        // Removes an ignored event.
+                        Inbox.Remove(node);
                     }
 
+                    node = nextNode;
                     continue;
                 }
 
-                // Dequeues the first event that is not deferred.
-                if (!this.IsDeferred(this.Inbox[idx].EventType))
+                // Skips a deferred event.
+                if (!this.IsDeferred(currentEventInfo.EventType))
                 {
-                    nextEventInfo = this.Inbox[idx];
+                    nextAvailableEventInfo = currentEventInfo;
                     if (!checkOnly)
                     {
-                        this.Inbox.RemoveAt(idx);
+                        Inbox.Remove(node);
                     }
 
                     break;
                 }
+
+                node = nextNode;
             }
 
-            return nextEventInfo;
+            return nextAvailableEventInfo;
         }
 
         /// <summary>
@@ -1209,27 +1215,33 @@ namespace Microsoft.PSharp
         /// <returns>Event received</returns>
         private Task<Event> WaitOnEvent()
         {
+            // Dequeues the first event that the machine waits
+            // to receive, if there is one in the inbox.
             EventInfo eventInfoInInbox = null;
             lock (this.Inbox)
             {
-                // Iterates through the events in the inbox.
-                for (int idx = 0; idx < this.Inbox.Count; idx++)
+                var node = this.Inbox.First;
+                while (node != null)
                 {
-                    // Dequeues the first event that the machine waits
-                    // to receive, if there is one in the inbox.
+                    var nextNode = node.Next;
+                    var currentEventInfo = node.Value;
+
                     EventWaitHandler eventWaitHandler = this.EventWaitHandlers.FirstOrDefault(
-                        val => val.EventType == this.Inbox[idx].EventType &&
-                               val.Predicate(this.Inbox[idx].Event));
+                        val => val.EventType == currentEventInfo.EventType &&
+                               val.Predicate(currentEventInfo.Event));
+
                     if (eventWaitHandler != null)
                     {
-                        base.Runtime.Logger.OnReceive(this.Id, this.CurrentStateName, this.Inbox[idx].EventName, wasBlocked:false);
+                        base.Runtime.Logger.OnReceive(this.Id, this.CurrentStateName, currentEventInfo.EventName, wasBlocked: false);
 
                         this.EventWaitHandlers.Clear();
-                        this.ReceiveCompletionSource.SetResult(this.Inbox[idx].Event);
-                        eventInfoInInbox = this.Inbox[idx];
-                        this.Inbox.RemoveAt(idx);
+                        this.ReceiveCompletionSource.SetResult(currentEventInfo.Event);
+                        eventInfoInInbox = currentEventInfo;
+                        this.Inbox.Remove(node);
                         break;
                     }
+
+                    node = nextNode;
                 }
             }
 


### PR DESCRIPTION
Machine.Inbox is a List<EventInfo> at present. This pull request proposes using a LinkedList<EventInfo> to implement it. 

Using a linked list gets us O(1) on dequeue operations instead of the O(n) incurred currently owing to the calls to List::RemoveAt in Machine::TryDequeueEvent. O(n) dequeue causes a P# machine to perform badly in situations where its inbox can contain tens of thousands of messages. The performance can degrade completely if the inbox ends up queueing millions/tens of millions of messages (For example, run the Mailbox benchmark in the performance branch - the results are in the attached excel file).
The add operation in Enqueue remains O(1). 

[PerfResults.xlsx](https://github.com/p-org/PSharp/files/1301853/PerfResults.xlsx)