### PR TITLE
Fix race conditions in logging

### DIFF
--- a/Source/Core/IO/Logging/DisposingLogger.cs
+++ b/Source/Core/IO/Logging/DisposingLogger.cs
@@ -128,15 +128,14 @@ namespace Microsoft.PSharp.IO
         /// <summary>
         /// Called when an event is sent to a target machine.
         /// </summary>
-        /// <param name="targetMachineId">Id of the target machine.</param>
-        /// <param name="targetStateName">The name of the current state of the target machine.</param>
+        /// <param name="targetMachineId">Id of the target machine.</param>        
         /// <param name="senderId">The machine that sent the event, if any.</param>
         /// <param name="senderStateName">The name of the current state of the sender machine, if applicable
         ///     (if it is a non-Machine specialization of an AbstractMachine, it is not applicable).</param>
         /// <param name="eventName">The event being sent.</param>
         /// <param name="operationGroupId">The operation group id, if any.</param>
         /// <param name="isTargetHalted">Is the target machine halted.</param>
-        public void OnSend(MachineId targetMachineId, string targetStateName, MachineId senderId, string senderStateName,
+        public void OnSend(MachineId targetMachineId, MachineId senderId, string senderStateName,
             string eventName, Guid? operationGroupId, bool isTargetHalted) { }
 
         /// <summary>

--- a/Source/Core/IO/Logging/DisposingLogger.cs
+++ b/Source/Core/IO/Logging/DisposingLogger.cs
@@ -63,10 +63,9 @@ namespace Microsoft.PSharp.IO
         /// <summary>
         /// Called when an event is about to be enqueued to a machine.
         /// </summary>
-        /// <param name="machineId">Id of the machine that the event is being enqueued to.</param>
-        /// <param name="currentStateName">The name of the current state of <paramref name="machineId"/>, if any.</param>
+        /// <param name="machineId">Id of the machine that the event is being enqueued to.</param>        
         /// <param name="eventName">Name of the event.</param>
-        public void OnEnqueue(MachineId machineId, string currentStateName, string eventName) { }
+        public void OnEnqueue(MachineId machineId, string eventName) { }
 
         /// <summary>
         /// Called when an event is dequeued by a machine.

--- a/Source/Core/IO/Logging/ILogger.cs
+++ b/Source/Core/IO/Logging/ILogger.cs
@@ -130,15 +130,14 @@ namespace Microsoft.PSharp.IO
         /// <summary>
         /// Called when an event is sent to a target machine.
         /// </summary>
-        /// <param name="targetMachineId">Id of the target machine.</param>
-        /// <param name="targetStateName">The name of the current state of the target machine.</param>
+        /// <param name="targetMachineId">Id of the target machine.</param>        
         /// <param name="senderId">The id of the machine that sent the event, if any.</param>
         /// <param name="senderStateName">The name of the current state of the sender machine, if applicable
         ///     (if it is a non-Machine specialization of an AbstractMachine, it is not applicable).</param>
         /// <param name="eventName">The event being sent.</param>
         /// <param name="operationGroupId">The operation group id, if any.</param>
         /// <param name="isTargetHalted">Is the target machine halted.</param>
-        void OnSend(MachineId targetMachineId, string targetStateName, MachineId senderId, string senderStateName,
+        void OnSend(MachineId targetMachineId, MachineId senderId, string senderStateName,
             string eventName, Guid? operationGroupId, bool isTargetHalted);
 
         /// <summary>

--- a/Source/Core/IO/Logging/ILogger.cs
+++ b/Source/Core/IO/Logging/ILogger.cs
@@ -63,10 +63,9 @@ namespace Microsoft.PSharp.IO
         /// <summary>
         /// Called when an event is about to be enqueued to a machine.
         /// </summary>
-        /// <param name="machineId">Id of the machine that the event is being enqueued to.</param>
-        /// <param name="currentStateName">The name of the current state of <paramref name="machineId"/>, if any.</param>
+        /// <param name="machineId">Id of the machine that the event is being enqueued to.</param>        
         /// <param name="eventName">Name of the event.</param>
-        void OnEnqueue(MachineId machineId, string currentStateName, string eventName);
+        void OnEnqueue(MachineId machineId, string eventName);
 
         /// <summary>
         /// Called when an event is dequeued by a machine.

--- a/Source/Core/IO/Logging/StateMachineLogger.cs
+++ b/Source/Core/IO/Logging/StateMachineLogger.cs
@@ -82,14 +82,13 @@ namespace Microsoft.PSharp.IO
         /// <summary>
         /// Called when an event is about to be enqueued to a machine.
         /// </summary>
-        /// <param name="machineId">Id of the machine that the event is being enqueued to.</param>
-        /// <param name="currentStateName">The name of the current state of <paramref name="machineId"/>, if any.</param>
+        /// <param name="machineId">Id of the machine that the event is being enqueued to.</param>        
         /// <param name="eventName">Name of the event.</param>
-        public virtual void OnEnqueue(MachineId machineId, string currentStateName, string eventName)
+        public virtual void OnEnqueue(MachineId machineId, string eventName)
         {
             if (this.IsVerbose)
             {
-                this.WriteLine($"<EnqueueLog> Machine '{machineId}' in state '{currentStateName}' enqueued event '{eventName}'.");
+                this.WriteLine($"<EnqueueLog> Machine '{machineId}' enqueued event '{eventName}'.");
             }
         }
 

--- a/Source/Core/IO/Logging/StateMachineLogger.cs
+++ b/Source/Core/IO/Logging/StateMachineLogger.cs
@@ -211,15 +211,14 @@ namespace Microsoft.PSharp.IO
         /// <summary>
         /// Called when an event is sent to a target machine.
         /// </summary>
-        /// <param name="targetMachineId">Id of the target machine.</param>
-        /// <param name="targetStateName">The name of the current state of the target machine.</param>
+        /// <param name="targetMachineId">Id of the target machine.</param>        
         /// <param name="senderId">The id of the machine that sent the event, if any.</param>
         /// <param name="senderStateName">The name of the current state of the sender machine, if applicable
         ///     (if it is a non-Machine specialization of an AbstractMachine, it is not applicable).</param>
         /// <param name="eventName">The event being sent.</param>
         /// <param name="operationGroupId">The operation group id, if any.</param>
         /// <param name="isTargetHalted">Is the target machine halted.</param>
-        public virtual void OnSend(MachineId targetMachineId, string targetStateName, MachineId senderId, string senderStateName,
+        public virtual void OnSend(MachineId targetMachineId, MachineId senderId, string senderStateName,
             string eventName, Guid? operationGroupId, bool isTargetHalted)
         {
             if (this.IsVerbose)
@@ -227,7 +226,7 @@ namespace Microsoft.PSharp.IO
                 var guid = operationGroupId.HasValue ? operationGroupId.Value.ToString() : "<none>";
                 var target = isTargetHalted
                             ? $"a halted machine '{targetMachineId}'"
-                            : $"machine '{targetMachineId}' in state '{targetStateName}'";
+                            : $"machine '{targetMachineId}'";
                 var message = senderId != null
                     ? $"<SendLog> Operation Group {guid}: Machine '{senderId}' in state '{senderStateName}'" +
                             $" sent event '{eventName}' to {target}."

--- a/Source/Core/Library/Machine.cs
+++ b/Source/Core/Library/Machine.cs
@@ -577,7 +577,7 @@ namespace Microsoft.PSharp
                     return;
                 }
 
-                base.Runtime.Logger.OnEnqueue(this.Id, this.CurrentStateName, eventInfo.EventName);
+                base.Runtime.Logger.OnEnqueue(this.Id, eventInfo.EventName);
 
                 this.Inbox.AddLast(eventInfo);
 

--- a/Source/Core/Runtime/PSharpRuntime.cs
+++ b/Source/Core/Runtime/PSharpRuntime.cs
@@ -325,7 +325,7 @@ namespace Microsoft.PSharp
             if (!this.MachineMap.TryGetValue(targetMachineId.Value, out targetMachine))
             {
                 var senderState = (sender as Machine)?.CurrentStateName ?? string.Empty;
-                this.Logger.OnSend(targetMachineId, string.Empty, sender?.Id, senderState,
+                this.Logger.OnSend(targetMachineId, sender?.Id, senderState,
                     e.GetType().FullName, operationGroupId, isTargetHalted: true);
                 return false;
             }

--- a/Source/Core/Runtime/StateMachineRuntime.cs
+++ b/Source/Core/Runtime/StateMachineRuntime.cs
@@ -418,7 +418,7 @@ namespace Microsoft.PSharp
             this.SetOperationGroupIdForEvent(eventInfo, sender, ref operationGroupId);
 
             var senderState = (sender as Machine)?.CurrentStateName ?? string.Empty;
-            base.Logger.OnSend(machine.Id, machine.CurrentStateName, sender?.Id, senderState,
+            base.Logger.OnSend(machine.Id, sender?.Id, senderState,
                 e.GetType().FullName, operationGroupId, isTargetHalted: false);
 
             machine.Enqueue(eventInfo, ref runNewHandler);

--- a/Source/TestingServices/Runtime/BugFindingRuntime.cs
+++ b/Source/TestingServices/Runtime/BugFindingRuntime.cs
@@ -663,7 +663,7 @@ namespace Microsoft.PSharp.TestingServices
             this.SetOperationGroupIdForEvent(eventInfo, sender, ref operationGroupId);
 
             var senderState = (sender as Machine)?.CurrentStateName ?? string.Empty;
-            this.Logger.OnSend(machine.Id, machine.CurrentStateName, sender?.Id, senderState,
+            this.Logger.OnSend(machine.Id, sender?.Id, senderState,
                 e.GetType().FullName, operationGroupId, isTargetHalted:false);
 
             if (sender != null)

--- a/Tests/Core.Tests.Performance/Tests/LoggerTest.cs
+++ b/Tests/Core.Tests.Performance/Tests/LoggerTest.cs
@@ -1,0 +1,162 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="MailboxTest.cs">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// 
+//      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Threading.Tasks;
+
+using BenchmarkDotNet.Attributes;
+using System.Collections.Concurrent;
+using Microsoft.PSharp.IO;
+
+namespace Microsoft.PSharp.Core.Tests.Performance
+{
+    [Config(typeof(Configuration))]
+    public class LoggerTest
+    {
+        public partial class SimpleMachine
+        {
+            private PSharpRuntime instance;
+            
+            public SimpleMachine()
+            {                
+                this.Counter = 0;
+            }
+
+            public void SendMessageToPSharp()
+            {
+
+                Task.Factory.StartNew(async () =>
+                {
+                    await Task.Delay(0);
+                    this.instance.SendEvent(this.Id, new Timeout());
+                });
+            }
+
+            public void PersistInline()
+            {
+
+            }
+        }
+
+
+        public class SetContextMessage : Event
+        {
+            public PSharpRuntime runtime;
+
+            public SetContextMessage(PSharpRuntime runtime)
+                : base()
+            {
+                this.runtime = runtime;
+            }
+        }
+
+        public partial class SimpleMachine : Machine
+        {
+            internal class Timeout : Event
+            {
+                public Timeout()
+                    : base()
+                {
+                }
+            }
+
+            //ISimpleMachineContext context;
+            //string Name;
+            int Counter;
+
+            [Microsoft.PSharp.Start]
+            [OnEntry(nameof(InitOnEntry))]
+            class Unknown : MachineState
+            {
+            }
+
+            [OnEntry("psharp_SimpleThinking_on_entry_action")]
+            [OnEventDoAction(typeof(SimpleMachine.Timeout), "IncrementCounter")]
+            class SimpleThinking : MachineState
+            {
+            }
+
+            [OnEntry("psharp_AdvancedThinking_on_entry_action")]
+            [OnEventDoAction(typeof(SimpleMachine.Timeout), "IncrementCounter")]
+            class AdvancedThinking : MachineState
+            {
+            }
+
+            void InitOnEntry()
+            {
+                this.Counter = 0;
+                this.instance = (this.ReceivedEvent as SetContextMessage).runtime;
+                this.SendMessageToPSharp();
+                this.Goto<SimpleThinking>();
+            }
+
+            void IncrementCounter()
+            {
+                this.Counter++;
+
+                this.SendMessageToPSharp();
+
+                if (this.Counter == 10)
+                {
+                    this.Goto<AdvancedThinking>();
+                }
+
+                if (this.Counter == 20)
+                {
+                    this.Counter = 0;
+                    this.Goto<SimpleThinking>();
+                }
+            }
+
+            protected void psharp_SimpleThinking_on_entry_action()
+            {
+                if (this.Counter == 0)
+                {
+                    for (int i = 0; i < 500; i++) ;
+                }
+
+                this.SendMessageToPSharp();
+            }
+
+            protected void psharp_AdvancedThinking_on_entry_action()
+            {
+                if (this.Counter == 10)
+                {
+                    this.PersistInline();
+                }
+
+                this.SendMessageToPSharp();
+            }
+        }
+
+        [Params(1, 5, 10)]
+        public int Clients { get; set; }
+
+        [Benchmark]
+        public void RunWithLogger()
+        {
+            var configuration = PSharp.Configuration.Create().WithVerbosityEnabled(0);
+            var runtime = new StateMachineRuntime(configuration);            
+            ConcurrentQueue<MachineId> machines = new ConcurrentQueue<MachineId>();
+            Parallel.For(0, Clients, index =>
+            {
+                machines.Enqueue(runtime.CreateMachine(typeof(SimpleMachine), new SetContextMessage(runtime)));
+            });
+
+            foreach (var machine in machines)
+            {
+                runtime.SendEvent(machine, new Halt());
+            }
+        }        
+    }
+}


### PR DESCRIPTION
ILogger::OnSend and ILogger::OnEnqueue should not track the current state of the machine that is receiving the message, since access to Machine.CurrentState of the receiver by the sender and the receiver can race.
The current implementations of ILogger are race-y, and can cause null pointer access exceptions.

The pull request includes a (performance) test that manifested these issues. I had originally written it for some other stuff I'm working on - it will be made more complete later.