### PR TITLE
Asynchronous Logger

### DIFF
--- a/Source/Core/Core.csproj
+++ b/Source/Core/Core.csproj
@@ -13,4 +13,7 @@
   <PropertyGroup>
     <OutputPath>..\..\bin\</OutputPath>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Tpl.Dataflow" Version="4.5.24" />
+  </ItemGroup>
 </Project>

--- a/Source/Core/IO/Logging/AsyncLogger.cs
+++ b/Source/Core/IO/Logging/AsyncLogger.cs
@@ -1,0 +1,128 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="AsyncLogger.cs">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// 
+//      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
+
+namespace Microsoft.PSharp.IO
+{
+    /// <summary>
+    /// The logger maintains a queue of log items,
+    /// and dequeues and writes them to a text writer
+    /// in a background thread
+    /// </summary>
+    internal sealed class AsyncLogger : StateMachineLogger
+    {
+
+        /// <summary>
+        /// Messages are tagged with this enum. The tag says how to log them
+        /// Write(Line) => Use the Write(Line) method of the underlying Writer
+        /// Wake => This is an internal message generated when the logger is being
+        /// disposed - it wakes up the dequeuing thread if it is suspended at an await
+        /// and causes it to flush all remaining messages
+        /// </summary>
+        enum ProcessingOption { Write, WriteLine, Wake };
+
+        /// <summary>
+        /// An item in the queue is the string to be logged,
+        /// and a ProcessingOption that tells what to do with the message         
+        /// </summary>
+        BufferBlock<Tuple<string, ProcessingOption>> queue;
+
+        TaskCompletionSource<bool> finished;
+        public volatile bool IsRunning;        
+        TextWriter writer;
+
+        
+        public AsyncLogger(TextWriter t)
+        {
+            queue = new BufferBlock<Tuple<string, ProcessingOption>>();
+            this.IsRunning = true;
+            writer = t ?? TextWriter.Null;
+            finished = new TaskCompletionSource<bool>();
+
+            Task.Run(async () => {
+                while (this.IsRunning)
+                {
+                    var current = await queue.ReceiveAsync().ConfigureAwait(false);
+                    ProcessItem(current);
+                }
+
+                // flush the queue
+                Tuple<string, ProcessingOption> message;
+                while (queue.TryReceive(out message))
+                {                    
+                    ProcessItem(message);
+                }
+                
+                finished.SetResult(true);
+            });            
+        }
+
+        private void ProcessItem(Tuple<string, ProcessingOption> current)
+        {
+            var message = current.Item1;
+            switch (current.Item2)
+            {
+                case ProcessingOption.Write:     this.writer.Write(message);
+                                                 break;
+                case ProcessingOption.WriteLine: this.writer.WriteLine(message);
+                                                 break;
+                case ProcessingOption.Wake:      break;    
+            }            
+        }
+
+        public override void Dispose()
+        {
+            
+            this.IsRunning = false;
+
+            // The dequeueing task might be suspended at the await.
+            // this message will wake it up and cause it to flush
+            queue.Post(new Tuple<string, ProcessingOption>("", ProcessingOption.Wake));
+            
+            finished.Task.Wait();
+
+            // mark the queue as complete
+            queue.Complete();            
+        }
+
+        public override void Write(string value)
+        {
+            queue.Post(new Tuple<string,ProcessingOption>(value, ProcessingOption.Write));
+        }
+
+        public override void Write(string format, params object[] args)
+        {
+            var value = IO.Utilities.Format(format, args);
+            queue.Post(new Tuple<string, ProcessingOption>(value, ProcessingOption.Write));
+        }
+
+        public override void WriteLine(string value)
+        {
+            queue.Post(new Tuple<string, ProcessingOption>(value, ProcessingOption.WriteLine));
+        }
+
+        public override void WriteLine(string format, params object[] args)
+        {
+            var value = IO.Utilities.Format(format, args);
+            queue.Post(new Tuple<string, ProcessingOption>(value, ProcessingOption.WriteLine));
+        }
+    }
+}

--- a/Source/Core/IO/Logging/SyncWriterLogger.cs
+++ b/Source/Core/IO/Logging/SyncWriterLogger.cs
@@ -1,0 +1,74 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="SyncWriterLogger.cs">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// 
+//      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.IO;
+
+namespace Microsoft.PSharp.IO
+{
+    /// <summary>
+    /// Logger that wraps the TextWriter passed in a thread-safe wrapper
+    /// </summary>
+    internal sealed class SyncWriterLogger : StateMachineLogger
+    {
+
+        TextWriter writer;
+
+        
+        public SyncWriterLogger(TextWriter t)
+        {            
+            writer = t?? TextWriter.Null;
+        }
+        
+        public override void Write(string value)
+        {
+            lock (writer)
+            {
+                writer.Write(value);
+            }
+        }
+
+        
+        public override void Write(string format, params object[] args)
+        {
+            lock (writer)
+            {
+                writer.Write(format, args);
+            }
+        }
+
+        
+        public override void WriteLine(string value)
+        {
+            lock (writer)
+            {
+                writer.WriteLine(value);
+            }
+        }
+
+        
+        public override void WriteLine(string format, params object[] args)
+        {
+            lock (writer)
+            {
+                writer.WriteLine(format, args);
+            }
+        }
+
+        public override void Dispose()
+        {
+            
+        }
+    }
+}

--- a/Tests/Core.Tests.Performance/Configuration.cs
+++ b/Tests/Core.Tests.Performance/Configuration.cs
@@ -15,6 +15,8 @@
 using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Exporters;
+using BenchmarkDotNet.Exporters.Csv;
 
 namespace Microsoft.PSharp.Core.Tests.Performance
 {
@@ -24,6 +26,9 @@ namespace Microsoft.PSharp.Core.Tests.Performance
         {
             Add(MemoryDiagnoser.Default);
             //Add(StatisticColumn.OperationsPerSecond);
+            Add(StatisticColumn.Mean, StatisticColumn.Median, StatisticColumn.P95);
+            Add(RPlotExporter.Default);
+            Add(CsvMeasurementsExporter.Default);
         }
     }
 }

--- a/Tests/Core.Tests.Performance/Core.Tests.Performance.csproj
+++ b/Tests/Core.Tests.Performance/Core.Tests.Performance.csproj
@@ -15,6 +15,6 @@
     <ProjectReference Include="..\..\Source\Core\Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.10.3" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.10.9" />
   </ItemGroup>
 </Project>

--- a/Tests/Core.Tests.Performance/Tests/LoggerTest.cs
+++ b/Tests/Core.Tests.Performance/Tests/LoggerTest.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="MailboxTest.cs">
+// <copyright file="Logger.cs">
 //      Copyright (c) Microsoft Corporation. All rights reserved.
 // 
 //      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
@@ -17,19 +17,35 @@ using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using System.Collections.Concurrent;
 using Microsoft.PSharp.IO;
+using BenchmarkDotNet.Attributes.Jobs;
+using BenchmarkDotNet.Engines;
+using System.IO;
+using System;
+using System.Reflection;
+using System.Linq;
 
 namespace Microsoft.PSharp.Core.Tests.Performance
 {
+    /// <summary>
+    /// Warning: this test requires ~1.5 GB of free disk space to run
+    /// It generates a log file in the bin directory
+    /// In the interest of diagnostics, it chooses not to delete the generated log file
+    /// </summary>
     [Config(typeof(Configuration))]
+    [SimpleJob(RunStrategy.Monitoring)]
     public class LoggerTest
     {
         public partial class SimpleMachine
         {
             private PSharpRuntime instance;
-            
+            private TaskCompletionSource<bool> tcs;
+            //private string dictName = "SomeDictionary";
+
             public SimpleMachine()
-            {                
+            {
+                //this.Name = "SimpleMachine";
                 this.Counter = 0;
+                this.targetRounds = 0;
             }
 
             public void SendMessageToPSharp()
@@ -37,7 +53,7 @@ namespace Microsoft.PSharp.Core.Tests.Performance
 
                 Task.Factory.StartNew(async () =>
                 {
-                    await Task.Delay(0);
+                    await Task.Delay(0/*TimeSpan.FromSeconds(10)*/);
                     this.instance.SendEvent(this.Id, new Timeout());
                 });
             }
@@ -52,11 +68,15 @@ namespace Microsoft.PSharp.Core.Tests.Performance
         public class SetContextMessage : Event
         {
             public PSharpRuntime runtime;
+            public int rounds;
+            public TaskCompletionSource<bool> tcs;
 
-            public SetContextMessage(PSharpRuntime runtime)
+            public SetContextMessage(PSharpRuntime runtime, int rounds, TaskCompletionSource<bool> tcs)
                 : base()
             {
                 this.runtime = runtime;
+                this.rounds = rounds;
+                this.tcs = tcs;
             }
         }
 
@@ -73,6 +93,8 @@ namespace Microsoft.PSharp.Core.Tests.Performance
             //ISimpleMachineContext context;
             //string Name;
             int Counter;
+            private int targetRounds;
+            private int rounds;
 
             [Microsoft.PSharp.Start]
             [OnEntry(nameof(InitOnEntry))]
@@ -95,7 +117,10 @@ namespace Microsoft.PSharp.Core.Tests.Performance
             void InitOnEntry()
             {
                 this.Counter = 0;
-                this.instance = (this.ReceivedEvent as SetContextMessage).runtime;
+                var e = this.ReceivedEvent as SetContextMessage;
+                this.instance = e.runtime;
+                this.targetRounds = e.rounds;
+                this.tcs = e.tcs;
                 this.SendMessageToPSharp();
                 this.Goto<SimpleThinking>();
             }
@@ -103,7 +128,7 @@ namespace Microsoft.PSharp.Core.Tests.Performance
             void IncrementCounter()
             {
                 this.Counter++;
-
+                
                 this.SendMessageToPSharp();
 
                 if (this.Counter == 10)
@@ -124,6 +149,13 @@ namespace Microsoft.PSharp.Core.Tests.Performance
                 {
                     for (int i = 0; i < 500; i++) ;
                 }
+                this.rounds++;
+
+                if(this.rounds == this.targetRounds)
+                {
+                    this.Raise(new Halt());
+                    this.tcs.SetResult(true);                                        
+                }
 
                 this.SendMessageToPSharp();
             }
@@ -132,6 +164,10 @@ namespace Microsoft.PSharp.Core.Tests.Performance
             {
                 if (this.Counter == 10)
                 {
+                    // Print to screen
+                    //context.EventSource.Message("{0}: Inside Advance Thinking", this.Name);
+
+                    // Persist
                     this.PersistInline();
                 }
 
@@ -139,24 +175,103 @@ namespace Microsoft.PSharp.Core.Tests.Performance
             }
         }
 
-        [Params(1, 5, 10)]
+        [Params(100, 1000, 10000)]
         public int Clients { get; set; }
 
-        [Benchmark]
-        public void RunWithLogger()
+        [Params(8)]
+        public int TargetRounds { get; set; }
+
+        
+        private string path;
+        private string basePath;
+
+
+        [GlobalSetup]
+        public void GlobalSetup()
         {
-            var configuration = PSharp.Configuration.Create().WithVerbosityEnabled(0);
-            var runtime = new StateMachineRuntime(configuration);            
-            ConcurrentQueue<MachineId> machines = new ConcurrentQueue<MachineId>();
+            basePath = System.IO.Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            path = basePath + String.Format(@"\\LoggerTestlog.txt");
+        }
+              
+        [Benchmark(Baseline = true)]
+        public void RunSyncNull()
+        {
+            using (var logger = new SyncWriterLogger(null))
+            {
+                var configuration = PSharp.Configuration.Create().WithVerbosityEnabled(2);
+                var runtime = new StateMachineRuntime(configuration);
+                runtime.SetLogger(logger);
+                ConcurrentQueue<MachineId> machines = new ConcurrentQueue<MachineId>();
+                RunMachine(runtime, machines);
+            }
+        }
+
+        [Benchmark]
+        public void RunAsyncNull()
+        {
+            using (var logger = new AsyncLogger(null))
+            {
+                var configuration = PSharp.Configuration.Create().WithVerbosityEnabled(2);
+                var runtime = new StateMachineRuntime(configuration);
+                runtime.SetLogger(logger);
+                ConcurrentQueue<MachineId> machines = new ConcurrentQueue<MachineId>();
+                RunMachine(runtime, machines);
+            }
+        }
+
+        [Benchmark]
+        public void RunSync()
+        {
+            using (var writer = new StreamWriter(path, false))
+            {
+                using (var logger = new SyncWriterLogger(writer))
+                {
+                    var configuration = PSharp.Configuration.Create().WithVerbosityEnabled(2);
+                    var runtime = new StateMachineRuntime(configuration);
+                    runtime.SetLogger(logger);
+                    ConcurrentQueue<MachineId> machines = new ConcurrentQueue<MachineId>();
+                    RunMachine(runtime, machines);
+                }
+            }
+        }
+
+        [Benchmark]
+        public void RunAsync()
+        {
+            using (var writer = new StreamWriter(path, false))
+            {
+                using (var logger = new AsyncLogger(writer))
+                {
+                    var configuration = PSharp.Configuration.Create().WithVerbosityEnabled(2);
+                    var runtime = new StateMachineRuntime(configuration);
+                    runtime.SetLogger(logger);
+                    ConcurrentQueue<MachineId> machines = new ConcurrentQueue<MachineId>();
+                    RunMachine(runtime, machines);
+                }
+            }
+        }
+
+        private void RunMachine(StateMachineRuntime runtime, ConcurrentQueue<MachineId> machines)
+        {
+            var tcsArray = InitializeArray<TaskCompletionSource<bool>>(Clients);
             Parallel.For(0, Clients, index =>
             {
-                machines.Enqueue(runtime.CreateMachine(typeof(SimpleMachine), new SetContextMessage(runtime)));
+                machines.Enqueue(runtime.CreateMachine(typeof(SimpleMachine), new SetContextMessage(runtime, TargetRounds, tcsArray[index])));
             });
 
-            foreach (var machine in machines)
+            var tasks = from x in tcsArray select x.Task;
+            Task.WhenAll(tasks).Wait();
+        }
+
+        T[] InitializeArray<T>(int length) where T : new()
+        {
+            T[] array = new T[length];
+            for (int i = 0; i < length; ++i)
             {
-                runtime.SendEvent(machine, new Halt());
+                array[i] = new T();
             }
-        }        
+
+            return array;
+        }
     }
 }


### PR DESCRIPTION
This PR adds a logger that clients of PSharp can use, called AsyncLogger. The logger places the messages it receives in a queue, and asynchronously dequeues and writes these messages to the underlying TextWriter.
For comparison, the PR also includes a synchronous logger (SyncWriterLogger) that uses locks and immediately writes to the underlying TextWriter once a lock has been acquired.

A performance test shows that AsyncLogger is twice as fast as SyncWriterLogger writing to a file at verbosity level 2.

![loggertest-barplot](https://user-images.githubusercontent.com/12654369/30733130-450d2f8a-9f93-11e7-917f-b43bdc98fb6b.png)
The figure shows the performance of the loggers on a system with machines that don't communicate with each other. Default Clients indicates the number of machines created. "Null" suffixed to the benchmark name indicates that the logger writes to TextWriter.Null.

AsyncLogger switches to synchronous mode to flush pending messages in the queue on disposing it.
I would greatly appreciate feedback on better ways to do this without dropping any message.

