### PR TITLE
Additional OnGoto logging

### DIFF
--- a/Source/Core/IO/Logging/DisposingLogger.cs
+++ b/Source/Core/IO/Logging/DisposingLogger.cs
@@ -83,6 +83,14 @@ namespace Microsoft.PSharp.IO
         public void OnDefault(MachineId machineId, string currentStateName) { }
 
         /// <summary>
+        /// Called when a machine transitions states via a 'goto'.
+        /// </summary>
+        /// <param name="machineId">Id of the machine.</param>
+        /// <param name="currentStateName">The name of the current state of <paramref name="machineId"/>, if any.</param>
+        /// <param name="newStateName">The target state of goto.</param>
+        public void OnGoto(MachineId machineId, string currentStateName, string newStateName) { }
+
+        /// <summary>
         /// Called when a machine is being pushed to a state.
         /// </summary>
         /// <param name="machineId">Id of the machine being pushed to the state.</param>

--- a/Source/Core/IO/Logging/ILogger.cs
+++ b/Source/Core/IO/Logging/ILogger.cs
@@ -83,6 +83,14 @@ namespace Microsoft.PSharp.IO
         void OnDefault(MachineId machineId, string currentStateName);
 
         /// <summary>
+        /// Called when a machine transitions states via a 'goto'.
+        /// </summary>
+        /// <param name="machineId">Id of the machine.</param>
+        /// <param name="currentStateName">The name of the current state of <paramref name="machineId"/>, if any.</param>
+        /// <param name="newStateName">The target state of goto.</param>
+        void OnGoto(MachineId machineId, string currentStateName, string newStateName);
+
+        /// <summary>
         /// Called when a machine is being pushed to a state.
         /// </summary>
         /// <param name="machineId">Id of the machine being pushed to the state.</param>

--- a/Source/Core/IO/Logging/StateMachineLogger.cs
+++ b/Source/Core/IO/Logging/StateMachineLogger.cs
@@ -120,6 +120,21 @@ namespace Microsoft.PSharp.IO
         }
 
         /// <summary>
+        /// Called when a machine transitions states via a 'goto'.
+        /// </summary>
+        /// <param name="machineId">Id of the machine.</param>
+        /// <param name="currentStateName">The name of the current state of <paramref name="machineId"/>, if any.</param>
+        /// <param name="newStateName">The target state of goto.</param>
+        public void OnGoto(MachineId machineId, string currentStateName, string newStateName)
+        {
+            if(this.IsVerbose)
+            {
+                this.WriteLine($"<GotoLog> Machine '{machineId}' is transitioning from state '{currentStateName}' to state '{newStateName}'.");
+            }
+        }
+
+
+        /// <summary>
         /// Called when a machine is being pushed to a state.
         /// </summary>
         /// <param name="machineId">Id of the machine being pushed to the state</param>

--- a/Source/Core/Library/Machine.cs
+++ b/Source/Core/Library/Machine.cs
@@ -1066,6 +1066,9 @@ namespace Microsoft.PSharp
         /// <param name="onExitActionName">Action name</param>
         private async Task GotoState(Type s, string onExitActionName)
         {
+            this.Logger.OnGoto(this.Id, this.CurrentStateName, 
+                $"{s.DeclaringType}.{StateGroup.GetQualifiedStateName(s)}");
+
             // The machine performs the on exit action of the current state.
             await this.ExecuteCurrentStateOnExit(onExitActionName);
             if (this.Info.IsHalted)


### PR DESCRIPTION
Added a `OnGoto` method to the `ILogger` interface. It is called when a machine invokes `this.Goto` or if a `GotoTransition` fires. The `StateMachineLogger` prints the following:

```
<GotoLog> Machine 'TestLogging.M(0)' is transitioning from state 'TestLogging.M.S1' to state 'TestLogging.M.S2'.
```
