### PR TITLE
SendOptions and MustHandle

### DIFF
--- a/Source/Core/IO/Logging/StateMachineLogger.cs
+++ b/Source/Core/IO/Logging/StateMachineLogger.cs
@@ -237,7 +237,8 @@ namespace Microsoft.PSharp.IO
         {
             if (this.IsVerbose)
             {
-                var guid = operationGroupId.HasValue ? operationGroupId.Value.ToString() : "<none>";
+                var guid = (operationGroupId.HasValue && operationGroupId.Value != Guid.Empty) ? 
+                    operationGroupId.Value.ToString() : "<none>";
                 var target = isTargetHalted
                             ? $"a halted machine '{targetMachineId}'"
                             : $"machine '{targetMachineId}'";

--- a/Source/Core/Library/Events/EventInfo.cs
+++ b/Source/Core/Library/Events/EventInfo.cs
@@ -57,6 +57,11 @@ namespace Microsoft.PSharp
         internal Guid OperationGroupId { get; private set; }
 
         /// <summary>
+        /// Is this a must-handle event?
+        /// </summary>
+        internal bool MustHandle { get; private set; }
+
+        /// <summary>
         /// Creates a new <see cref="EventInfo"/>.
         /// </summary>
         /// <param name="e">Event</param>
@@ -65,6 +70,7 @@ namespace Microsoft.PSharp
             Event = e;
             EventType = e.GetType();
             EventName = EventType.FullName;
+            MustHandle = false;
         }
 
         /// <summary>
@@ -84,6 +90,15 @@ namespace Microsoft.PSharp
         internal void SetOperationGroupId(Guid operationGroupId)
         {
             this.OperationGroupId = operationGroupId;
+        }
+
+        /// <summary>
+        /// Sets the MustHandle flag of the event
+        /// </summary>
+        /// <param name="mustHandle">MustHandle flag</param>
+        internal void SetMustHandle(bool mustHandle)
+        {
+            this.MustHandle = mustHandle;
         }
 
         /// <summary>

--- a/Source/Core/Library/Machine.cs
+++ b/Source/Core/Library/Machine.cs
@@ -309,13 +309,14 @@ namespace Microsoft.PSharp
         /// </summary>
         /// <param name="mid">MachineId</param>
         /// <param name="e">Event</param>
-        protected void Send(MachineId mid, Event e)
+        /// <param name="options">Optional parameters</param>
+        protected void Send(MachineId mid, Event e, SendOptions options = null)
         {
             // If the target machine is null, then report an error and exit.
             this.Assert(mid != null, $"Machine '{base.Id}' is sending to a null machine.");
             // If the event is null, then report an error and exit.
             this.Assert(e != null, $"Machine '{base.Id}' is sending a null event.");
-            base.Runtime.SendEvent(mid, e, this, null);
+            base.Runtime.SendEvent(mid, e, this, options);
         }
 
         /// <summary>
@@ -323,13 +324,14 @@ namespace Microsoft.PSharp
         /// </summary>
         /// <param name="mid">MachineId</param>
         /// <param name="e">Event</param>
-        protected void RemoteSend(MachineId mid, Event e)
+        /// <param name="options">Optional parameters</param>
+        protected void RemoteSend(MachineId mid, Event e, SendOptions options = null)
         {
             // If the target machine is null, then report an error and exit.
             this.Assert(mid != null, $"Machine '{base.Id}' is sending to a null machine.");
             // If the event is null, then report an error and exit.
             this.Assert(e != null, $"Machine '{base.Id}' is sending a null event.");
-            base.Runtime.SendEventRemotely(mid, e, this, null);
+            base.Runtime.SendEventRemotely(mid, e, this, options);
         }
 
         /// <summary>
@@ -824,7 +826,7 @@ namespace Microsoft.PSharp
                         lock (this.Inbox)
                         {
                             this.Info.IsHalted = true;
-                            base.Runtime.NotifyHalted(this, this.Inbox.Count);
+                            base.Runtime.NotifyHalted(this, this.Inbox);
                             this.CleanUpResources();
                         }
 

--- a/Source/Core/Library/SendOptions.cs
+++ b/Source/Core/Library/SendOptions.cs
@@ -1,0 +1,59 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="SendOptions.cs">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+//
+//      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+
+namespace Microsoft.PSharp
+{
+    /// <summary>
+    /// Optional parameters for a send operation.
+    /// </summary>
+    public class SendOptions
+    {
+        /// <summary>
+        /// Operation group id.
+        /// </summary>
+        public Guid? OperationGroupId;
+
+        /// <summary>
+        /// Is this a MustHandle event?
+        /// </summary>
+        public bool MustHandle;
+
+        /// <summary>
+        /// Default options.
+        /// </summary>
+        public SendOptions()
+        {
+            OperationGroupId = null;
+            MustHandle = false;
+        }
+
+        /// <summary>
+        /// A string that represents the current options.
+        /// </summary>
+        public override string ToString()
+        {
+            return $"SendOptions[Guid='{OperationGroupId}', MustHandle='{MustHandle}']";
+        }
+
+        /// <summary>
+        /// Implicit conversion from a Guid.
+        /// </summary>
+        public static implicit operator SendOptions(Guid operationGroupId)
+        {
+            return new SendOptions { OperationGroupId = operationGroupId };
+        }
+    }
+}

--- a/Tests/Core.Tests.Unit/Logging/CustomLoggerTest.cs
+++ b/Tests/Core.Tests.Unit/Logging/CustomLoggerTest.cs
@@ -143,11 +143,11 @@ namespace Microsoft.PSharp.Core.Tests.Unit
 <ActionLog> Machine 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+M()' in state 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+M.Init' invoked action 'InitOnEntry'.
 <CreateLog> Machine 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+N()' is created.
 <StateLog> Machine 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+N()' enters state 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+N.Init'.
-<SendLog> Operation Group ----: Machine 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+M()' in state 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+M.Init' sent event 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+E' to machine 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+N()'.
+<SendLog> Operation Group <none>: Machine 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+M()' in state 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+M.Init' sent event 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+E' to machine 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+N()'.
 <EnqueueLog> Machine 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+N()' enqueued event 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+E'.
 <DequeueLog> Machine 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+N()' in state 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+N.Init' dequeued event 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+E'.
 <ActionLog> Machine 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+N()' in state 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+N.Init' invoked action 'Act'.
-<SendLog> Operation Group ----: Machine 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+N()' in state 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+N.Init' sent event 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+E' to machine 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+M()'.
+<SendLog> Operation Group <none>: Machine 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+N()' in state 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+N.Init' sent event 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+E' to machine 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+M()'.
 <EnqueueLog> Machine 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+M()' enqueued event 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+E'.
 <DequeueLog> Machine 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+M()' in state 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+M.Init' dequeued event 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+E'.
 <ActionLog> Machine 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+M()' in state 'Microsoft.PSharp.Core.Tests.Unit.CustomLoggerTest+M.Init' invoked action 'Act'.


### PR DESCRIPTION
Changed `Send` to take an optional `options` parameter. Added support for `MustHandle` events, which must be dequeued before the target machine halts.