### PR TITLE
Update to Xunit2.3.1 (necessary for VS 2017 Update 4.x)

### DIFF
--- a/Tests/Core.Tests.Unit/Core.Tests.Unit.csproj
+++ b/Tests/Core.Tests.Unit/Core.Tests.Unit.csproj
@@ -14,9 +14,9 @@
     <ProjectReference Include="..\..\Source\Core\Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.console" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.console" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/Tests/Core.Tests.Unit/Features/GetOperationGroupIdTest.cs
+++ b/Tests/Core.Tests.Unit/Features/GetOperationGroupIdTest.cs
@@ -66,7 +66,7 @@ namespace Microsoft.PSharp.Core.Tests.Unit
             }
         }
 
-        public void AssertSucceeded(Type machine)
+        private void AssertSucceeded(Type machine)
         {
             var runtime = PSharpRuntime.Create();
             var failed = false;

--- a/Tests/Core.Tests.Unit/Features/OnHaltTest.cs
+++ b/Tests/Core.Tests.Unit/Features/OnHaltTest.cs
@@ -143,7 +143,7 @@ namespace Microsoft.PSharp.Core.Tests.Unit
             }
         }
 
-        public void AssertSucceeded(Type machine)
+        private void AssertSucceeded(Type machine)
         {
             var runtime = PSharpRuntime.Create();
             var failed = false;
@@ -160,7 +160,7 @@ namespace Microsoft.PSharp.Core.Tests.Unit
             Assert.False(failed);
         }
 
-        public void AssertFailed(Type machine)
+        private void AssertFailed(Type machine)
         {
             var runtime = PSharpRuntime.Create();
             var failed = false;

--- a/Tests/Core.Tests.Unit/Features/OperationGroupingTest.cs
+++ b/Tests/Core.Tests.Unit/Features/OperationGroupingTest.cs
@@ -280,7 +280,7 @@ namespace Microsoft.PSharp.Core.Tests.Unit
             }
         }
 
-        public void AssertSucceeded(Type machine)
+        private void AssertSucceeded(Type machine)
         {
             var runtime = PSharpRuntime.Create();
             var failed = false;

--- a/Tests/LanguageServices.Tests.Unit/LanguageServices.Tests.Unit.csproj
+++ b/Tests/LanguageServices.Tests.Unit/LanguageServices.Tests.Unit.csproj
@@ -14,9 +14,9 @@
     <ProjectReference Include="..\..\Source\LanguageServices\LanguageServices.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.console" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.console" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/Tests/SharedObjects.Tests.Unit/SharedObjects.Tests.Unit.csproj
+++ b/Tests/SharedObjects.Tests.Unit/SharedObjects.Tests.Unit.csproj
@@ -14,9 +14,9 @@
     <ProjectReference Include="..\..\Source\SharedObjects\SharedObjects.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.console" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.console" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/Tests/StaticAnalysis.Tests.Unit/StaticAnalysis.Tests.Unit.csproj
+++ b/Tests/StaticAnalysis.Tests.Unit/StaticAnalysis.Tests.Unit.csproj
@@ -14,9 +14,9 @@
     <ProjectReference Include="..\..\Source\StaticAnalysis\StaticAnalysis.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.console" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.console" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/Tests/TestingServices.Tests.Integration/TestingServices.Tests.Integration.csproj
+++ b/Tests/TestingServices.Tests.Integration/TestingServices.Tests.Integration.csproj
@@ -14,9 +14,9 @@
     <ProjectReference Include="..\..\Source\TestingServices\TestingServices.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.console" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.console" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/Tests/TestingServices.Tests.Unit/Machines/Declarations/NameofTest.cs
+++ b/Tests/TestingServices.Tests.Unit/Machines/Declarations/NameofTest.cs
@@ -110,7 +110,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
             });
 
             base.AssertSucceeded(test);
-            Assert.Equal(WithNameofValue, 11111);
+            Assert.Equal(11111, WithNameofValue);
         }
 
         [Fact]
@@ -121,7 +121,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
             });
 
             base.AssertSucceeded(test);
-            Assert.Equal(WithoutNameofValue, 11111);
+            Assert.Equal(11111, WithoutNameofValue);
         }
     }
 }

--- a/Tests/TestingServices.Tests.Unit/Machines/Transitions/GotoTransitions/GotoStateTest.cs
+++ b/Tests/TestingServices.Tests.Unit/Machines/Transitions/GotoTransitions/GotoStateTest.cs
@@ -113,7 +113,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
             });
 
             base.AssertSucceeded(test);
-            Assert.Equal(MonitorValue, 101);
+            Assert.Equal(101, MonitorValue);
         }
 
         [Fact]
@@ -124,7 +124,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
             });
 
             base.AssertSucceeded(test);
-            Assert.Equal(MonitorValue, 202);
+            Assert.Equal(202, MonitorValue);
         }
     }
 }

--- a/Tests/TestingServices.Tests.Unit/TestingServices.Tests.Unit.csproj
+++ b/Tests/TestingServices.Tests.Unit/TestingServices.Tests.Unit.csproj
@@ -14,9 +14,9 @@
     <ProjectReference Include="..\..\Source\TestingServices\TestingServices.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.console" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.console" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/Tests/run-integration-tests.ps1
+++ b/Tests/run-integration-tests.ps1
@@ -5,7 +5,7 @@ param(
     [string]$test="all"
 )
 
-if (-not (Test-Path $PSScriptRoot\..\packages\xunit.runner.console\2.2.0\tools\xunit.console.exe))
+if (-not (Test-Path $PSScriptRoot\..\packages\xunit.runner.console\2.3.1\tools\net452\xunit.console.exe))
 {
     Write-Host "Error: the xUnit console runner was not found. Please build P# to install the NuGet package." -ForegroundColor "red"
     exit
@@ -26,7 +26,7 @@ if (($test -eq "all") -or ($test -eq "testing-services"))
         exit
     }
 
-    Invoke-Expression "$PSScriptRoot\..\packages\xunit.runner.console\2.2.0\tools\xunit.console.exe $PSScriptRoot\TestingServices.Tests.Integration\bin\$framework\Microsoft.PSharp.TestingServices.Tests.Integration.dll -verbose"
+    Invoke-Expression "$PSScriptRoot\..\packages\xunit.runner.console\2.3.1\tools\net452\xunit.console.exe $PSScriptRoot\TestingServices.Tests.Integration\bin\$framework\Microsoft.PSharp.TestingServices.Tests.Integration.dll -verbose"
 }
 
 Write-Host "Done." -ForegroundColor "green" 

--- a/Tests/run-unit-tests.ps1
+++ b/Tests/run-unit-tests.ps1
@@ -5,7 +5,7 @@ param(
     [string]$test="all"
 )
 
-if (-not (Test-Path $PSScriptRoot\..\packages\xunit.runner.console\2.2.0\tools\xunit.console.exe))
+if (-not (Test-Path $PSScriptRoot\..\packages\xunit.runner.console\2.3.1\tools\net452\xunit.console.exe))
 {
     Write-Host "Error: the xUnit console runner was not found. Please build P# to install the NuGet package." -ForegroundColor "red"
     exit
@@ -26,7 +26,7 @@ if (($test -eq "all") -or ($test -eq "core"))
         exit
     }
 
-    Invoke-Expression "$PSScriptRoot\..\packages\xunit.runner.console\2.2.0\tools\xunit.console.exe $PSScriptRoot\Core.Tests.Unit\bin\$framework\Microsoft.PSharp.Core.Tests.Unit.dll -verbose"
+    Invoke-Expression "$PSScriptRoot\..\packages\xunit.runner.console\2.3.1\tools\net452\xunit.console.exe $PSScriptRoot\Core.Tests.Unit\bin\$framework\Microsoft.PSharp.Core.Tests.Unit.dll -verbose"
 }
 
 if (($test -eq "all") -or ($test -eq "testing-services"))
@@ -40,7 +40,7 @@ if (($test -eq "all") -or ($test -eq "testing-services"))
         exit
     }
 
-    Invoke-Expression "$PSScriptRoot\..\packages\xunit.runner.console\2.2.0\tools\xunit.console.exe $PSScriptRoot\TestingServices.Tests.Unit\bin\$framework\Microsoft.PSharp.TestingServices.Tests.Unit.dll -verbose"
+    Invoke-Expression "$PSScriptRoot\..\packages\xunit.runner.console\2.3.1\tools\net452\xunit.console.exe $PSScriptRoot\TestingServices.Tests.Unit\bin\$framework\Microsoft.PSharp.TestingServices.Tests.Unit.dll -verbose"
 }
 
 if (($test -eq "all") -or ($test -eq "shared-objects"))
@@ -54,7 +54,7 @@ if (($test -eq "all") -or ($test -eq "shared-objects"))
         exit
     }
 
-    Invoke-Expression "$PSScriptRoot\..\packages\xunit.runner.console\2.2.0\tools\xunit.console.exe $PSScriptRoot\SharedObjects.Tests.Unit\bin\$framework\Microsoft.PSharp.SharedObjects.Tests.Unit.dll -verbose"
+    Invoke-Expression "$PSScriptRoot\..\packages\xunit.runner.console\2.3.1\tools\net452\xunit.console.exe $PSScriptRoot\SharedObjects.Tests.Unit\bin\$framework\Microsoft.PSharp.SharedObjects.Tests.Unit.dll -verbose"
 }
 
 if (($test -eq "all") -or ($test -eq "language-services"))
@@ -68,7 +68,7 @@ if (($test -eq "all") -or ($test -eq "language-services"))
         exit
     }
 
-    Invoke-Expression "$PSScriptRoot\..\packages\xunit.runner.console\2.2.0\tools\xunit.console.exe $PSScriptRoot\LanguageServices.Tests.Unit\bin\$framework\Microsoft.PSharp.LanguageServices.Tests.Unit.dll -verbose"   
+    Invoke-Expression "$PSScriptRoot\..\packages\xunit.runner.console\2.3.1\tools\net452\xunit.console.exe $PSScriptRoot\LanguageServices.Tests.Unit\bin\$framework\Microsoft.PSharp.LanguageServices.Tests.Unit.dll -verbose"   
 }
 
 if (($test -eq "all") -or ($test -eq "static-analysis"))
@@ -82,7 +82,7 @@ if (($test -eq "all") -or ($test -eq "static-analysis"))
         exit
     }
 
-    Invoke-Expression "$PSScriptRoot\..\packages\xunit.runner.console\2.2.0\tools\xunit.console.exe $PSScriptRoot\StaticAnalysis.Tests.Unit\bin\$framework\Microsoft.PSharp.StaticAnalysis.Tests.Unit.dll -verbose"  
+    Invoke-Expression "$PSScriptRoot\..\packages\xunit.runner.console\2.3.1\tools\net452\xunit.console.exe $PSScriptRoot\StaticAnalysis.Tests.Unit\bin\$framework\Microsoft.PSharp.StaticAnalysis.Tests.Unit.dll -verbose"  
 }
 
 Write-Host "Done." -ForegroundColor "green" 


### PR DESCRIPTION
Unit tests may no longer be discovered after this. If you encounter that, remove folder %TEMP%\VisualStudioTestExplorerExtensions and restart VS. This still didn't work for me until I created and ran a simple Xunit UT project following https://xunit.github.io/docs/getting-started-desktop.html (which re-creates this directory) and restarted VS. Also, CodeLens sometimes wasn't showing the status/run icon for UTs; that seems to work now.