### PR TITLE
Fix V3008

### DIFF
--- a/Source/SchedulingStrategies/Strategies/Probabilistic/PCTStrategy.cs
+++ b/Source/SchedulingStrategies/Strategies/Probabilistic/PCTStrategy.cs
@@ -90,9 +90,7 @@ namespace Microsoft.PSharp.TestingServices.SchedulingStrategies
             RandomNumberGenerator = random;
             MaxScheduledSteps = maxSteps;
             ScheduledSteps = 0;
-
             ScheduleLength = 0;
-            ScheduledSteps = 0;
             MaxPrioritySwitchPoints = maxPrioritySwitchPoints;
             PrioritizedSchedulableChoices = new List<ISchedulable>();
             PriorityChangePoints = new SortedSet<int>();


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio:

- The 'ScheduledSteps' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 95, 92. SchedulingStrategies PCTStrategy.cs 95