### PR TITLE
StackTrace in race report during replay.

### DIFF
--- a/Source/AddOns/DynamicRaceDetection/ThreadMonitor/Monitoring/Threads/ThreadExecutionMonitorDispatcher.cs
+++ b/Source/AddOns/DynamicRaceDetection/ThreadMonitor/Monitoring/Threads/ThreadExecutionMonitorDispatcher.cs
@@ -215,9 +215,7 @@ namespace Microsoft.PSharp.Monitoring.AllCallbacks
                     var info = GetSourceInformation(frame);
                     if (Regex.Match(info,@"\bMachine.cs\b").Success) { break; }
                     debugInfo.Add(info);
-                    if (i > 15) { break; }
                 }
-                StackFrame callStack = new StackFrame(4, true);
                 var caller = new StackFrame(5, true);
                 string sep = $"{Environment.NewLine}\t\t\t";
                 string className = TryGetClassName(location, objH);

--- a/Source/AddOns/DynamicRaceDetection/ThreadMonitor/Utilities/ThreadMonitorCommandLineOptions.cs
+++ b/Source/AddOns/DynamicRaceDetection/ThreadMonitor/Utilities/ThreadMonitorCommandLineOptions.cs
@@ -161,6 +161,9 @@ namespace Microsoft.PSharp.Utilities
                 }
 
                 base.Configuration.ScheduleFile = option.Substring(8);
+
+                // For replay Read Write tracing is automatically enabled to give call stack information for races.
+                base.Configuration.EnableReadWriteTracing = true;
             }
             else if (option.ToLower().StartsWith("/reduction:"))
             {

--- a/Source/TestingServices/RaceDetection/RaceDetectionEngine.cs
+++ b/Source/TestingServices/RaceDetection/RaceDetectionEngine.cs
@@ -393,7 +393,8 @@ namespace Microsoft.PSharp.TestingServices.RaceDetection
             var nL = Environment.NewLine;
             var firstId = DescriptiveName[(ulong)fId];
             var secondId = DescriptiveName[(ulong)sId];
-            string report = $"****RACE:****{nL}\t{diagnostic}{nL}\t\t {first}:{firstId}{nL}\t\t {second}:{secondId}";
+            //Removing diagnostic from the report string
+            string report = $"****RACE:****{nL}\t\t {first}:{firstId}{nL}\t\t {second}:{secondId}";
             Log.WriteLine(report);
             this.TestReport.BugReports.Add(report);
         }


### PR DESCRIPTION
Modifications:
1. /replay:file_name> will now set EnableReadWriteTracing falg as true, to include tracing during replay.
2. GetDebugInformation goes through the call stack till it reaches Machine.cs code file. (Maximum upto 15).
3. Removed unwanted diagnostic string.