### PR TITLE
Revised sync execution semantics to match RunToCompletion

### DIFF
--- a/Source/Core/Library/Machine.cs
+++ b/Source/Core/Library/Machine.cs
@@ -120,10 +120,10 @@ namespace Microsoft.PSharp
         private bool IsRunning;
 
         /// <summary>
-        /// Is the machine executing under a synchronous call. This includes
-        /// the methods CreateMachineAndExecute and SendEventAndExecute.
+        /// If the machine is executing under a synchronous call, this is the 
+        /// machine waiting for quiescence
         /// </summary>
-        internal bool IsInsideSynchronousCall;
+        internal MachineId SyncCallerMachineId;
 
         /// <summary>
         /// Is pop invoked in the current action.
@@ -239,7 +239,7 @@ namespace Microsoft.PSharp
             this.EventWaitHandlers = new List<EventWaitHandler>();
 
             this.IsRunning = true;
-            this.IsInsideSynchronousCall = false;
+            this.SyncCallerMachineId = null;
             this.IsPopInvoked = false;
         }
 

--- a/Source/Core/Library/Machine.cs
+++ b/Source/Core/Library/Machine.cs
@@ -120,12 +120,6 @@ namespace Microsoft.PSharp
         private bool IsRunning;
 
         /// <summary>
-        /// If the machine is executing under a synchronous call, this is the 
-        /// machine waiting for quiescence
-        /// </summary>
-        internal MachineId SyncCallerMachineId;
-
-        /// <summary>
         /// Is pop invoked in the current action.
         /// </summary>
         private bool IsPopInvoked;
@@ -239,7 +233,6 @@ namespace Microsoft.PSharp
             this.EventWaitHandlers = new List<EventWaitHandler>();
 
             this.IsRunning = true;
-            this.SyncCallerMachineId = null;
             this.IsPopInvoked = false;
         }
 
@@ -767,8 +760,7 @@ namespace Microsoft.PSharp
         /// Runs the event handler. The handler terminates if there
         /// is no next event to process or if the machine is halted.
         /// </summary>
-        /// <param name="returnEarly">Returns after handling just one event</param>
-        internal async Task<bool> RunEventHandler(bool returnEarly = false)
+        internal async Task<bool> RunEventHandler()
         {
             if (this.Info.IsHalted)
             {
@@ -839,13 +831,6 @@ namespace Microsoft.PSharp
 
                 // Handles next event.
                 await this.HandleEvent(nextEventInfo.Event);
-
-
-                // Return after handling the first event?
-                if (returnEarly)
-                {
-                    return false;
-                }
             }
 
             return completed;

--- a/Source/Core/Runtime/PSharpRuntime.cs
+++ b/Source/Core/Runtime/PSharpRuntime.cs
@@ -258,13 +258,15 @@ namespace Microsoft.PSharp
         public abstract void SendEvent(MachineId target, Event e, SendOptions options = null);
 
         /// <summary>
-        /// Synchronously delivers an <see cref="Event"/> to a machine and
-        /// executes the event handler if the machine is available.
+        /// Sends an <see cref="Event"/> to a machine. Returns immediately
+        /// if the target machine was already running. Otherwise blocks until the machine handles
+        /// the event and reaches quiescense again.
         /// </summary>
         /// <param name="target">Target machine id</param>
         /// <param name="e">Event</param>
         /// <param name="options">Optional parameters of a send operation.</param>
-        public abstract Task SendEventAndExecute(MachineId target, Event e, SendOptions options = null);
+        /// <returns>True if event was handled, false if the event was only enqueued</returns>
+        public abstract Task<bool> SendEventAndExecute(MachineId target, Event e, SendOptions options = null);
 
         /// <summary>
         /// Sends an asynchronous <see cref="Event"/> to a remote machine.
@@ -422,14 +424,16 @@ namespace Microsoft.PSharp
         internal abstract void SendEvent(MachineId mid, Event e, AbstractMachine sender, SendOptions options);
 
         /// <summary>
-        /// Sends an asynchronous <see cref="Event"/> to a machine and
-        /// executes the event handler if the machine is available.
+        /// Sends an asynchronous <see cref="Event"/> to a machine. Returns immediately
+        /// if the target machine was already running. Otherwise blocks until the machine handles
+        /// the event and reaches quiescense again.
         /// </summary>
         /// <param name="mid">MachineId</param>
         /// <param name="e">Event</param>
         /// <param name="sender">Sender machine</param>
         /// <param name="options">Optional parameters of a send operation.</param>
-        internal abstract Task SendEventAndExecute(MachineId mid, Event e, AbstractMachine sender, SendOptions options);
+        /// <returns>True if event was handled, false if the event was only enqueued</returns>
+        internal abstract Task<bool> SendEventAndExecute(MachineId mid, Event e, AbstractMachine sender, SendOptions options);
 
         /// <summary>
         /// Sends an asynchronous <see cref="Event"/> to a remote machine.

--- a/Source/TestingServices/Events/QuiescentEvent.cs
+++ b/Source/TestingServices/Events/QuiescentEvent.cs
@@ -1,0 +1,39 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="QuiescentEvent.cs">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// 
+//      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Runtime.Serialization;
+
+namespace Microsoft.PSharp
+{
+    /// <summary>
+    /// Signals that a machine has reached Quiescence
+    /// </summary>
+    [DataContract]
+    internal sealed class QuiescentEvent : Event
+    {
+        /// <summary>
+        /// MachineId
+        /// </summary>
+        public MachineId mid;
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        public QuiescentEvent(MachineId mid)
+            : base()
+        {
+            this.mid = mid;
+        }
+    }
+}

--- a/Source/TestingServices/Runtime/BugFindingRuntime.cs
+++ b/Source/TestingServices/Runtime/BugFindingRuntime.cs
@@ -91,6 +91,11 @@ namespace Microsoft.PSharp.TestingServices
         /// </summary>
         internal int? RootTaskId;
 
+        /// <summary>
+        /// Records if a machine was triggered by an enqueue
+        /// </summary>
+        internal bool machineTriggered;
+
         #endregion
 
         #region initialization
@@ -358,19 +363,21 @@ namespace Microsoft.PSharp.TestingServices
         }
 
         /// <summary>
-        /// Synchronously delivers an <see cref="Event"/> to a machine
-        /// and executes it if the machine is available.
+        /// Sends an <see cref="Event"/> to a machine. Returns immediately
+        /// if the target machine was already running. Otherwise blocks until the machine handles
+        /// the event and reaches quiescense again.
         /// </summary>
         /// <param name="target">Target machine id</param>
         /// <param name="e">Event</param>
         /// <param name="options">Optional parameters of a send operation.</param>
-        public override async Task SendEventAndExecute(MachineId target, Event e, SendOptions options = null)
+        /// <returns>True if event was handled, false if the event was only enqueued</returns>
+        public override Task<bool> SendEventAndExecute(MachineId target, Event e, SendOptions options = null)
         {
             // If the target machine is null then report an error and exit.
             this.Assert(target != null, "Cannot send to a null machine.");
             // If the event is null then report an error and exit.
             this.Assert(e != null, "Cannot send a null event.");
-            await this.SendEventAndExecute(target, e, this.GetCurrentMachine(), options);
+            return this.SendEventAndExecute(target, e, this.GetCurrentMachine(), options);
         }
 
         /// <summary>
@@ -523,7 +530,7 @@ namespace Microsoft.PSharp.TestingServices
             this.SetOperationGroupIdForMachine(machine, creator, operationGroupId);
 
             this.BugTrace.AddCreateMachineStep(creator, machine.Id, e == null ? null : new EventInfo(e));
-            this.RunMachineEventHandler(machine, e, true, false, null);
+            this.RunMachineEventHandler(machine, e, true, null, null);
 
             return machine.Id;
         }
@@ -544,10 +551,10 @@ namespace Microsoft.PSharp.TestingServices
             Machine creator, Guid? operationGroupId)
         {
             this.AssertCorrectCallerMachine(creator, "CreateMachineAndExecute");
-            if (creator != null)
-            {
-                this.AssertNoPendingTransitionStatement(creator, "CreateMachine");
-            }
+            this.Assert(creator != null, "Only a machine can execute CreateMachineAndExecute. " +
+                "Avoid calling directly from the PSharp Test method. " + 
+                "Instead call through a 'harness' machine.");
+            this.AssertNoPendingTransitionStatement(creator, "CreateMachine");
 
             // Using ulong.MaxValue because a 'Create' operation cannot specify
             // the id of its target, because the id does not exist yet.
@@ -557,7 +564,10 @@ namespace Microsoft.PSharp.TestingServices
             this.SetOperationGroupIdForMachine(machine, creator, operationGroupId);
 
             this.BugTrace.AddCreateMachineStep(creator, machine.Id, e == null ? null : new EventInfo(e));
-            this.RunMachineEventHandler(machine, e, true, true, null);
+            this.RunMachineEventHandler(machine, e, true, creator.Id, null);
+
+            // wait until the machine reaches quiescence
+            await creator.Receive(typeof(QuiescentEvent), rev => (rev as QuiescentEvent).mid == machine.Id);
 
             return await Task.FromResult(machine.Id);
         }
@@ -660,23 +670,28 @@ namespace Microsoft.PSharp.TestingServices
             EventInfo eventInfo = this.EnqueueEvent(machine, e, sender, operationGroupId, options?.MustHandle ?? false, ref runNewHandler);
             if (runNewHandler)
             {
-                this.RunMachineEventHandler(machine, null, false, false, eventInfo);
+                this.RunMachineEventHandler(machine, null, false, null, eventInfo);
             }
         }
 
         /// <summary>
-        /// Sends an asynchronous <see cref="Event"/> to a machine and
-        /// executes the event handler if the machine is available.
+        /// Sends an <see cref="Event"/> to a machine. Returns immediately
+        /// if the target machine was already running. Otherwise blocks until the machine handles
+        /// the event and reaches quiescense again.
         /// </summary>
         /// <param name="mid">MachineId</param>
         /// <param name="e">Event</param>
         /// <param name="sender">Sender machine</param>
         /// <param name="options">Optional parameters of a send operation.</param>
-        internal override async Task SendEventAndExecute(MachineId mid, Event e, AbstractMachine sender, SendOptions options)
+        /// <returns>True if event was handled, false if the event was only enqueued</returns>
+        internal override async Task<bool> SendEventAndExecute(MachineId mid, Event e, AbstractMachine sender, SendOptions options)
         {
             this.AssertCorrectCallerMachine(sender as Machine, "SendEventAndExecute");
             this.Assert(AllCreatedMachineIds.Contains(mid), "Cannot Send event {0} to a MachineId ({0},{1}) that was never " +
                 "previously bound to a machine of type {2}", e.GetType().FullName, mid.Value, mid.Generation, mid);
+            this.Assert(sender != null && (sender is Machine), "Only a machine can execute CreateMachineAndExecute. " +
+                "Avoid calling directly from the PSharp Test method. " +
+                "Instead call through a 'harness' machine.");
 
             this.Scheduler.Schedule(OperationType.Send, OperationTargetType.Inbox, mid.Value);
             var operationGroupId = base.GetNewOperationGroupId(sender, options?.OperationGroupId);
@@ -685,17 +700,26 @@ namespace Microsoft.PSharp.TestingServices
             {
                 this.Assert(options == null || !options.MustHandle,
                     $"A must-handle event '{e.GetType().FullName}' was sent to the halted machine '{mid}'.\n");
-                return;
+                return true;
             }
 
             bool runNewHandler = false;
+
+            // indicates if the machine implicitly handled the event
+            // (because it doesn't trigger an action)
+            machineTriggered = false; // set by CheckStartEventHandler
+
             EventInfo eventInfo = this.EnqueueEvent(machine, e, sender, operationGroupId, options?.MustHandle ?? false, ref runNewHandler);
             if (runNewHandler)
             {
-                this.RunMachineEventHandler(machine, null, false, true, eventInfo);
-            }
+                this.RunMachineEventHandler(machine, null, false, sender.Id, eventInfo);
 
-            await Task.CompletedTask;
+                // wait until the machine reaches quiescence
+                await (sender as Machine).Receive(typeof(QuiescentEvent),
+                    rev => (rev as QuiescentEvent).mid == mid);
+                return true;
+            }
+            return machineTriggered;  
         }
 
         /// <summary>
@@ -771,10 +795,10 @@ namespace Microsoft.PSharp.TestingServices
         /// <param name="machine">Machine that executes this event handler.</param>
         /// <param name="initialEvent">Event for initializing the machine.</param>
         /// <param name="isFresh">If true, then this is a new machine.</param>
-        /// <param name="executeSynchronously">If true, this operation executes synchronously.</param>
+        /// <param name="syncCaller">Caller machine that is blocked for quiscence.</param>
         /// <param name="enablingEvent">If non-null, the event info of the sent event that caused the event handler to be restarted.</param>
         private void RunMachineEventHandler(Machine machine, Event initialEvent, bool isFresh,
-            bool executeSynchronously, EventInfo enablingEvent)
+            MachineId syncCaller, EventInfo enablingEvent)
         {
             Task task = new Task(async () =>
             {
@@ -782,20 +806,21 @@ namespace Microsoft.PSharp.TestingServices
                 {
                     this.Scheduler.NotifyEventHandlerStarted(machine.Info as SchedulableInfo);
 
-                    machine.IsInsideSynchronousCall = executeSynchronously;
+                    machine.SyncCallerMachineId = syncCaller;
 
                     if (isFresh)
                     {
                         await machine.GotoStartState(initialEvent);
                     }
 
-                    await machine.RunEventHandler(executeSynchronously);
-                    machine.IsInsideSynchronousCall = false;
+                    await machine.RunEventHandler();
 
-                    if (executeSynchronously)
+                    if(syncCaller != null)
                     {
-                        await machine.RunEventHandler();
+                        this.SendEvent(syncCaller, new QuiescentEvent(machine.Id));
                     }
+
+                    machine.SyncCallerMachineId = null;
 
                     IO.Debug.WriteLine($"<ScheduleDebug> Completed event handler of '{machine.Id}'.");
                     (machine.Info as SchedulableInfo).NotifyEventHandlerCompleted();
@@ -840,6 +865,7 @@ namespace Microsoft.PSharp.TestingServices
         /// <returns>Boolean</returns>
         internal override bool CheckStartEventHandler(Machine machine)
         {
+            machineTriggered = true;
             return machine.TryDequeueEvent(true) != null;
         }
 
@@ -1286,8 +1312,6 @@ namespace Microsoft.PSharp.TestingServices
         /// <param name="machine">Machine</param>
         internal override void NotifyReceiveCalled(Machine machine)
         {
-            this.Assert(!machine.IsInsideSynchronousCall, $"Machine '{machine.Id}' called " +
-                "receive while executing synchronously.");
             this.AssertCorrectCallerMachine(machine, "Receive");
             this.AssertNoPendingTransitionStatement(machine, "Receive");
         }

--- a/Source/TestingServices/Runtime/BugFindingRuntime.cs
+++ b/Source/TestingServices/Runtime/BugFindingRuntime.cs
@@ -94,7 +94,7 @@ namespace Microsoft.PSharp.TestingServices
         /// <summary>
         /// Records if a machine was triggered by an enqueue
         /// </summary>
-        internal bool machineTriggered;
+        internal bool startEventHandlerCalled;
 
         #endregion
 
@@ -705,9 +705,11 @@ namespace Microsoft.PSharp.TestingServices
 
             bool runNewHandler = false;
 
-            // indicates if the machine implicitly handled the event
-            // (because it doesn't trigger an action)
-            machineTriggered = false; // set by CheckStartEventHandler
+            // This is set true by CheckStartEventHandler, called by EnqueueEvent. runNewHandler is not
+            // set to true by EnqueueEvent (even when the machine was previously Idle) when the event
+            // e requires no action by the machine (i.e., it implicitly handles the event). In such a case, 
+            // CheckStartEventHandler must have been called.
+            startEventHandlerCalled = false; 
 
             EventInfo eventInfo = this.EnqueueEvent(machine, e, sender, operationGroupId, options?.MustHandle ?? false, ref runNewHandler);
             if (runNewHandler)
@@ -719,7 +721,7 @@ namespace Microsoft.PSharp.TestingServices
                     rev => (rev as QuiescentEvent).mid == mid);
                 return true;
             }
-            return machineTriggered;  
+            return startEventHandlerCalled;  
         }
 
         /// <summary>
@@ -806,8 +808,6 @@ namespace Microsoft.PSharp.TestingServices
                 {
                     this.Scheduler.NotifyEventHandlerStarted(machine.Info as SchedulableInfo);
 
-                    machine.SyncCallerMachineId = syncCaller;
-
                     if (isFresh)
                     {
                         await machine.GotoStartState(initialEvent);
@@ -819,8 +819,6 @@ namespace Microsoft.PSharp.TestingServices
                     {
                         this.SendEvent(syncCaller, new QuiescentEvent(machine.Id));
                     }
-
-                    machine.SyncCallerMachineId = null;
 
                     IO.Debug.WriteLine($"<ScheduleDebug> Completed event handler of '{machine.Id}'.");
                     (machine.Info as SchedulableInfo).NotifyEventHandlerCompleted();
@@ -865,7 +863,7 @@ namespace Microsoft.PSharp.TestingServices
         /// <returns>Boolean</returns>
         internal override bool CheckStartEventHandler(Machine machine)
         {
-            machineTriggered = true;
+            startEventHandlerCalled = true;
             return machine.TryDequeueEvent(true) != null;
         }
 

--- a/Tests/Core.Tests.Unit/RuntimeInterface/SendAndExecuteTest3.cs
+++ b/Tests/Core.Tests.Unit/RuntimeInterface/SendAndExecuteTest3.cs
@@ -1,0 +1,110 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="SendAndExecuteTest3.cs">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// 
+//      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace Microsoft.PSharp.Core.Tests.Unit
+{
+    public class SendAndExecuteTest3 
+    {
+        class Conf : Event
+        {
+            public TaskCompletionSource<bool> tcs;
+
+            public Conf(TaskCompletionSource<bool> tcs)
+            {
+                this.tcs = tcs;
+            }
+        }
+
+        class E : Event
+        {
+            public int x;
+
+            public E()
+            {
+                this.x = 0;
+            }
+        }
+
+        class LE : Event { }
+
+        class Harness : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            class Init : MachineState { }
+
+            async Task InitOnEntry()
+            {
+                var tcs = (this.ReceivedEvent as Conf).tcs;
+                var e = new E();
+                var m = await this.Runtime.CreateMachineAndExecute(typeof(M));
+                await this.Runtime.SendEventAndExecute(m, e);
+                this.Assert(e.x == 1);
+                tcs.SetResult(true);
+            }
+        }
+
+        class M : Machine
+        {
+            bool LE_Handled = false;
+
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            [OnEventDoAction(typeof(E), nameof(HandleEventE))]
+            [OnEventDoAction(typeof(LE), nameof(HandleEventLE))]
+            class Init : MachineState { }
+
+            void InitOnEntry()
+            {
+                this.Send(this.Id, new LE());
+            }
+
+            void HandleEventLE()
+            {
+                LE_Handled = true;
+            }
+
+            void HandleEventE()
+            {
+                this.Assert(LE_Handled);
+                var e = (this.ReceivedEvent as E);
+                e.x = 1;
+            }
+        }
+
+
+        [Fact]
+        public void TestSyncSendBlocks()
+        {
+            var runtime = PSharpRuntime.Create();
+            var failed = false;
+            var tcs = new TaskCompletionSource<bool>();
+            runtime.OnFailure += delegate
+            {
+                failed = true;
+                tcs.SetResult(true);
+            };
+
+            runtime.CreateMachine(typeof(Harness), new Conf(tcs));
+            tcs.Task.Wait(1000);
+
+            Assert.False(failed);
+        }
+    }
+}

--- a/Tests/Core.Tests.Unit/RuntimeInterface/SendAndExecuteTest4.cs
+++ b/Tests/Core.Tests.Unit/RuntimeInterface/SendAndExecuteTest4.cs
@@ -1,0 +1,99 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="SendAndExecuteTest4.cs">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// 
+//      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace Microsoft.PSharp.Core.Tests.Unit
+{
+    public class SendAndExecuteTest4 
+    {
+        class Conf : Event
+        {
+            public TaskCompletionSource<bool> tcs;
+
+            public Conf(TaskCompletionSource<bool> tcs)
+            {
+                this.tcs = tcs;
+            }
+        }
+
+        class LE : Event { }
+
+        class E : Event
+        {
+            public MachineId mid;
+
+            public E(MachineId mid)
+            {
+                this.mid = mid;
+            }
+        }
+
+        class Harness : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            [IgnoreEvents(typeof(LE))]
+            class Init : MachineState { }
+
+            async Task InitOnEntry()
+            {
+                var tcs = (this.ReceivedEvent as Conf).tcs;
+                var m = await this.Runtime.CreateMachineAndExecute(typeof(M), new E(this.Id));
+                var handled = await this.Runtime.SendEventAndExecute(m, new LE());
+                this.Assert(handled);
+                tcs.SetResult(true);
+            }
+        }
+
+        class M : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            [IgnoreEvents(typeof(LE))]
+            class Init : MachineState { }
+
+            async Task InitOnEntry()
+            {
+                var creator = (this.ReceivedEvent as E).mid;
+                var handled = await this.Id.Runtime.SendEventAndExecute(creator, new LE());
+                this.Assert(!handled);
+            }
+
+        }
+
+
+        [Fact]
+        public void TestSendCycleDoesNotDeadlock()
+        {
+            var runtime = PSharpRuntime.Create();
+            var failed = false;
+            var tcs = new TaskCompletionSource<bool>();
+            runtime.OnFailure += delegate
+            {
+                failed = true;
+                tcs.SetResult(false);
+            };
+
+            runtime.CreateMachine(typeof(Harness), new Conf(tcs));
+            tcs.Task.Wait();
+
+            Assert.False(failed);
+        }
+
+    }
+}


### PR DESCRIPTION
The methods `CreateMachineAndExecute` and `SendEventAndExecute` when executed, if the target machine was idle, then these methods block until it becomes idle again. If the target machine wasn't idle at the time of the call, then the methods return immediately. This matches with a _RunToCompletion_ semantics for scheduling. 

Unlike previous implementation of these methods (which was only for optimization), the user can now rely on the semantics to control scheduling.