### PR TITLE
Fixing build failure when psharp targets are included without .psharp files

### DIFF
--- a/Tools/Compilation/SyntaxRewriter/Program.cs
+++ b/Tools/Compilation/SyntaxRewriter/Program.cs
@@ -183,6 +183,13 @@ namespace Microsoft.PSharp
 
         public bool Execute()
         {
+            if (InputFiles == null)
+            {
+                // Target was included but no .psharp files are present in the project. Skip
+                // execution.
+                return true;
+            }
+
             for (int i = 0; i < InputFiles.Length; i++)
             {
                 var inp = File.ReadAllText(InputFiles[i].ItemSpec);


### PR DESCRIPTION
Modifying SyntaxRewriter to allow psharp targets to be included for projects without any .psharp files - the rewriter will simply ignore such projects.