### PR TITLE
Added instructions to flush outputs

### DIFF
--- a/Source/Core/IO/Logging/ConsoleLogger.cs
+++ b/Source/Core/IO/Logging/ConsoleLogger.cs
@@ -27,8 +27,7 @@ namespace Microsoft.PSharp.IO
         /// <param name="value">Text</param>
         public override void Write(string value)
         {
-            Console.Write(value);
-			Console.Out.Flush();
+			Console.Write(value);
         }
 
         /// <summary>
@@ -39,7 +38,6 @@ namespace Microsoft.PSharp.IO
         public override void Write(string format, params object[] args)
         {
             Console.Write(format, args);
-			Console.Out.Flush();
         }
 
         /// <summary>
@@ -50,7 +48,6 @@ namespace Microsoft.PSharp.IO
         public override void WriteLine(string value)
         {
             Console.WriteLine(value);
-			Console.Out.Flush();
 		}
 
         /// <summary>
@@ -62,7 +59,6 @@ namespace Microsoft.PSharp.IO
         public override void WriteLine(string format, params object[] args)
         {
             Console.WriteLine(format, args);
-			Console.Out.Flush();
 		}
 
         /// <summary>

--- a/Source/Core/IO/Logging/ConsoleLogger.cs
+++ b/Source/Core/IO/Logging/ConsoleLogger.cs
@@ -28,6 +28,7 @@ namespace Microsoft.PSharp.IO
         public override void Write(string value)
         {
             Console.Write(value);
+			Console.Out.Flush();
         }
 
         /// <summary>
@@ -38,6 +39,7 @@ namespace Microsoft.PSharp.IO
         public override void Write(string format, params object[] args)
         {
             Console.Write(format, args);
+			Console.Out.Flush();
         }
 
         /// <summary>
@@ -48,7 +50,8 @@ namespace Microsoft.PSharp.IO
         public override void WriteLine(string value)
         {
             Console.WriteLine(value);
-        }
+			Console.Out.Flush();
+		}
 
         /// <summary>
         /// Writes the text representation of the specified array of objects,
@@ -59,7 +62,8 @@ namespace Microsoft.PSharp.IO
         public override void WriteLine(string format, params object[] args)
         {
             Console.WriteLine(format, args);
-        }
+			Console.Out.Flush();
+		}
 
         /// <summary>
         /// Disposes the logger.

--- a/Source/Core/IO/Logging/InMemoryLogger.cs
+++ b/Source/Core/IO/Logging/InMemoryLogger.cs
@@ -42,6 +42,7 @@ namespace Microsoft.PSharp.IO
         public override void Write(string value)
         {
             Writer.Write(value);
+			Writer.Flush();
         }
 
         /// <summary>
@@ -52,7 +53,8 @@ namespace Microsoft.PSharp.IO
         public override void Write(string format, params object[] args)
         {
             Writer.Write(format, args);
-        }
+			Writer.Flush();
+		}
 
         /// <summary>
         /// Writes the specified string value, followed by the
@@ -62,7 +64,8 @@ namespace Microsoft.PSharp.IO
         public override void WriteLine(string value)
         {
             Writer.WriteLine(value);
-        }
+			Writer.Flush();
+		}
 
         /// <summary>
         /// Writes the text representation of the specified array of objects,
@@ -73,7 +76,8 @@ namespace Microsoft.PSharp.IO
         public override void WriteLine(string format, params object[] args)
         {
             Writer.WriteLine(format, args);
-        }
+			Writer.Flush();
+		}
 
         /// <summary>
         /// Returns the logged text as a string.

--- a/Source/Core/IO/Logging/InMemoryLogger.cs
+++ b/Source/Core/IO/Logging/InMemoryLogger.cs
@@ -42,7 +42,6 @@ namespace Microsoft.PSharp.IO
         public override void Write(string value)
         {
             Writer.Write(value);
-			Writer.Flush();
         }
 
         /// <summary>
@@ -53,7 +52,6 @@ namespace Microsoft.PSharp.IO
         public override void Write(string format, params object[] args)
         {
             Writer.Write(format, args);
-			Writer.Flush();
 		}
 
         /// <summary>
@@ -64,7 +62,6 @@ namespace Microsoft.PSharp.IO
         public override void WriteLine(string value)
         {
             Writer.WriteLine(value);
-			Writer.Flush();
 		}
 
         /// <summary>
@@ -76,7 +73,6 @@ namespace Microsoft.PSharp.IO
         public override void WriteLine(string format, params object[] args)
         {
             Writer.WriteLine(format, args);
-			Writer.Flush();
 		}
 
         /// <summary>

--- a/Source/TestingServices/Engines/BugFindingEngine.cs
+++ b/Source/TestingServices/Engines/BugFindingEngine.cs
@@ -316,6 +316,7 @@ namespace Microsoft.PSharp.TestingServices
             if (this.ShouldPrintIteration(iteration + 1))
             {
                 base.Logger.WriteLine($"..... Iteration #{iteration + 1}");
+				Console.Out.Flush();
             }
 
             // Runtime used to serialize and test the program in this iteration.
@@ -328,10 +329,6 @@ namespace Microsoft.PSharp.TestingServices
             // Gets a handle to the standard output and error streams.
             var stdOut = Console.Out;
             var stdErr = Console.Error;
-
-			// Flush buffers to allow streaming of console output.
-			stdOut.Flush();
-			stdErr.Flush();
 
             try
             {

--- a/Source/TestingServices/Engines/BugFindingEngine.cs
+++ b/Source/TestingServices/Engines/BugFindingEngine.cs
@@ -329,6 +329,10 @@ namespace Microsoft.PSharp.TestingServices
             var stdOut = Console.Out;
             var stdErr = Console.Error;
 
+			// Flush buffers to allow streaming of console output.
+			stdOut.Flush();
+			stdErr.Flush();
+
             try
             {
                 // Creates a new instance of the bug-finding runtime.


### PR DESCRIPTION
Added instructions which clears the buffers and flushes to device right away. 
Hopefully, this should resolve the issue where the output of PSharpTester cannot be streamed. 