### PR TITLE
Halt on unhandled exception

### DIFF
--- a/Source/Core/Library/Machine.cs
+++ b/Source/Core/Library/Machine.cs
@@ -1806,11 +1806,11 @@ namespace Microsoft.PSharp
                 case OnExceptionOutcome.HaltMachine:
                 case OnExceptionOutcome.HandledException:
                     OnExceptionRequestedGracefulHalt = true;
-                    break;
+                    return true;
                 case OnExceptionOutcome.ThrowException:
                     return false;
             }
-            return true;
+            return false;
         }
 
         /// <summary>
@@ -1838,13 +1838,13 @@ namespace Microsoft.PSharp
                     return false;
                 case OnExceptionOutcome.HandledException:
                     this.Logger.OnMachineExceptionHandled(this.Id, CurrentStateName, methodName, ex);
-                    break;
+                    return true;
                 case OnExceptionOutcome.HaltMachine:
                     OnExceptionRequestedGracefulHalt = true;
-                    break;
+                    return false;
             }
 
-            return true;
+            return false;
         }
 
         /// <summary>

--- a/Source/Core/Library/Machine.cs
+++ b/Source/Core/Library/Machine.cs
@@ -864,7 +864,7 @@ namespace Microsoft.PSharp
                         return;
                     }
 
-                    var unhandledEx = new UnHandledEventException(this.Id, currentState, e, "Unhandled Event");
+                    var unhandledEx = new UnhandledEventException(this.Id, currentState, e, "Unhandled Event");
                     if (OnUnhandledEventExceptionHandler("HandleEvent", unhandledEx))
                     {
                         HaltMachine();

--- a/Source/Core/Library/Machine.cs
+++ b/Source/Core/Library/Machine.cs
@@ -1798,13 +1798,17 @@ namespace Microsoft.PSharp
         /// <param name="ex">The exception thrown by the machine</param>
         /// <param name="methodName">The handler (outermost) that threw the exception</param>
         /// <returns>False if the exception should continue to get thrown, true if the machine should gracefully halt</returns>
-        private bool OnUnhandledEventExceptionHandler(string methodName, Exception ex)
+        private bool OnUnhandledEventExceptionHandler(string methodName, UnhandledEventException ex)
         {
+            this.Logger.OnMachineExceptionThrown(this.Id, ex.CurrentStateName, methodName, ex);
+
             var ret = OnException(methodName, ex);
-            switch(ret)
+            OnExceptionRequestedGracefulHalt = false;
+            switch (ret)
             {
                 case OnExceptionOutcome.HaltMachine:
                 case OnExceptionOutcome.HandledException:
+                    this.Logger.OnMachineExceptionHandled(this.Id, ex.CurrentStateName, methodName, ex);
                     OnExceptionRequestedGracefulHalt = true;
                     return true;
                 case OnExceptionOutcome.ThrowException:

--- a/Source/Core/Library/UnHandledEventException.cs
+++ b/Source/Core/Library/UnHandledEventException.cs
@@ -19,7 +19,7 @@ namespace Microsoft.PSharp
     /// <summary>
     /// Signals that a machine received an unhandled event
     /// </summary>
-    internal sealed class UnHandledEventException : RuntimeException
+    public sealed class UnhandledEventException : RuntimeException
     {
         /// <summary>
         /// The machine that threw the exception
@@ -43,7 +43,7 @@ namespace Microsoft.PSharp
         /// <param name="CurrentStateName">Current state name</param>
         /// <param name="UnhandledEvent">The event that was unhandled</param>
         /// <param name="message">Message</param>
-        internal UnHandledEventException(MachineId mid, string CurrentStateName, Event UnhandledEvent, string message)
+        internal UnhandledEventException(MachineId mid, string CurrentStateName, Event UnhandledEvent, string message)
             : base(message)
         {
             this.mid = mid;

--- a/Source/Core/Library/UnHandledEventException.cs
+++ b/Source/Core/Library/UnHandledEventException.cs
@@ -1,0 +1,56 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="UnHandledEventException.cs">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// 
+//      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+
+namespace Microsoft.PSharp
+{
+    /// <summary>
+    /// Signals that a machine received an unhandled event
+    /// </summary>
+    internal sealed class UnHandledEventException : RuntimeException
+    {
+        /// <summary>
+        /// The machine that threw the exception
+        /// </summary>
+        public MachineId mid;
+
+        /// <summary>
+        /// Name of the current state of the machine
+        /// </summary>
+        public string CurrentStateName;
+
+        /// <summary>
+        ///  The event
+        /// </summary>
+        public Event UnhandledEvent;
+
+        /// <summary>
+        /// Initializes a new instance of the exception.
+        /// </summary>
+        /// <param name="mid">MachineId</param>
+        /// <param name="CurrentStateName">Current state name</param>
+        /// <param name="UnhandledEvent">The event that was unhandled</param>
+        /// <param name="message">Message</param>
+        internal UnHandledEventException(MachineId mid, string CurrentStateName, Event UnhandledEvent, string message)
+            : base(message)
+        {
+            this.mid = mid;
+            this.CurrentStateName = CurrentStateName;
+            this.UnhandledEvent = UnhandledEvent;
+        }
+
+    }
+}
+

--- a/Source/Core/Runtime/Exceptions/OnExceptionOutcome.cs
+++ b/Source/Core/Runtime/Exceptions/OnExceptionOutcome.cs
@@ -1,0 +1,37 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="OnExceptionOutcome.cs">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// 
+//      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+//      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+//      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace Microsoft.PSharp
+{
+    /// <summary>
+    /// Outcome of Machine.OnException
+    /// </summary>
+    public enum OnExceptionOutcome
+    {
+        /// <summary>
+        /// Throw the exception causing the runtime to fail
+        /// </summary>
+        ThrowException = 0,
+
+        /// <summary>
+        /// The exception was handled and Machine should continue execution
+        /// </summary>
+        HandledException = 1,
+
+        /// <summary>
+        /// Halt the machine (do not throw the exception)
+        /// </summary>
+        HaltMachine = 2
+    }
+}

--- a/Tests/Core.Tests.Unit/ExceptionPropagation/OnExceptionTest.cs
+++ b/Tests/Core.Tests.Unit/ExceptionPropagation/OnExceptionTest.cs
@@ -46,7 +46,7 @@ namespace Microsoft.PSharp.Core.Tests.Unit
                 throw new NotImplementedException();
             }
 
-            protected override bool OnException(string methodName, Exception ex)
+            protected override bool OnException(string methodName, Exception ex, ref bool gracefulHalt)
             {
                 e.x++;
                 return true;
@@ -67,7 +67,7 @@ namespace Microsoft.PSharp.Core.Tests.Unit
                 throw new NotImplementedException();
             }
 
-            protected override bool OnException(string methodName, Exception ex)
+            protected override bool OnException(string methodName, Exception ex, ref bool gracefulHalt)
             {
                 e.x++;
                 return false;
@@ -90,7 +90,7 @@ namespace Microsoft.PSharp.Core.Tests.Unit
                 throw new NotImplementedException();                
             }
 
-            protected override bool OnException(string methodName, Exception ex)
+            protected override bool OnException(string methodName, Exception ex, ref bool gracefulHalt)
             {
                 e.x++;
                 return true;
@@ -112,7 +112,7 @@ namespace Microsoft.PSharp.Core.Tests.Unit
                 throw new NotImplementedException();
             }
 
-            protected override bool OnException(string methodName, Exception ex)
+            protected override bool OnException(string methodName, Exception ex, ref bool gracefulHalt)
             {
                 e.x++;
                 return false;

--- a/Tests/Core.Tests.Unit/ExceptionPropagation/OnExceptionTest.cs
+++ b/Tests/Core.Tests.Unit/ExceptionPropagation/OnExceptionTest.cs
@@ -46,10 +46,10 @@ namespace Microsoft.PSharp.Core.Tests.Unit
                 throw new NotImplementedException();
             }
 
-            protected override bool OnException(string methodName, Exception ex, ref bool gracefulHalt)
+            protected override OnExceptionOutcome OnException(string methodName, Exception ex)
             {
                 e.x++;
-                return true;
+                return OnExceptionOutcome.HandledException;
             }
         }
 
@@ -67,10 +67,10 @@ namespace Microsoft.PSharp.Core.Tests.Unit
                 throw new NotImplementedException();
             }
 
-            protected override bool OnException(string methodName, Exception ex, ref bool gracefulHalt)
+            protected override OnExceptionOutcome OnException(string methodName, Exception ex)
             {
                 e.x++;
-                return false;
+                return OnExceptionOutcome.ThrowException;
             }
 
         }
@@ -90,10 +90,10 @@ namespace Microsoft.PSharp.Core.Tests.Unit
                 throw new NotImplementedException();                
             }
 
-            protected override bool OnException(string methodName, Exception ex, ref bool gracefulHalt)
+            protected override OnExceptionOutcome OnException(string methodName, Exception ex)
             {
                 e.x++;
-                return true;
+                return OnExceptionOutcome.HandledException;
             }
         }
 
@@ -112,10 +112,10 @@ namespace Microsoft.PSharp.Core.Tests.Unit
                 throw new NotImplementedException();
             }
 
-            protected override bool OnException(string methodName, Exception ex, ref bool gracefulHalt)
+            protected override OnExceptionOutcome OnException(string methodName, Exception ex)
             {
                 e.x++;
-                return false;
+                return OnExceptionOutcome.ThrowException;
             }
 
         }

--- a/Tests/Core.Tests.Unit/ExceptionPropagation/OnExceptionTest.cs
+++ b/Tests/Core.Tests.Unit/ExceptionPropagation/OnExceptionTest.cs
@@ -32,6 +32,8 @@ namespace Microsoft.PSharp.Core.Tests.Unit
             }
         }
 
+        class F : Event { }
+
         class M1a : Machine
         {
             E e;
@@ -120,6 +122,60 @@ namespace Microsoft.PSharp.Core.Tests.Unit
 
         }
 
+        class M3 : Machine
+        {
+            E e;
+
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            class Init : MachineState { }
+
+            void InitOnEntry()
+            {
+                this.e = this.ReceivedEvent as E;
+                throw new NotImplementedException();
+            }
+
+            protected override OnExceptionOutcome OnException(string methodName, Exception ex)
+            {
+                return OnExceptionOutcome.HaltMachine;
+            }
+
+            protected override void OnHalt()
+            {
+                e.tcs.TrySetResult(true);
+            }
+        }
+
+        class M4 : Machine
+        {
+            E e;
+
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            class Init : MachineState { }
+
+            void InitOnEntry()
+            {
+                this.e = this.ReceivedEvent as E;
+            }
+
+            protected override OnExceptionOutcome OnException(string methodName, Exception ex)
+            {
+                if(ex is UnHandledEventException)
+                {
+                    return OnExceptionOutcome.HaltMachine;
+                }
+                return OnExceptionOutcome.ThrowException;
+            }
+
+            protected override void OnHalt()
+            {
+                e.tcs.TrySetResult(true);
+            }
+        }
+
+
         [Fact]
         public void TestOnExceptionCalledOnce1()
         {
@@ -198,6 +254,47 @@ namespace Microsoft.PSharp.Core.Tests.Unit
             tcs.Task.Wait(1000);
             Assert.True(failed);
             Assert.True(e.x == 1);
+        }
+
+        [Fact]
+        public void TestOnExceptionCanHalt()
+        {
+            var runtime = PSharpRuntime.Create();
+            var failed = false;
+            var tcs = new TaskCompletionSource<bool>();
+            runtime.OnFailure += delegate
+            {
+                failed = true;
+                tcs.TrySetResult(false);
+            };
+
+            var e = new E(tcs);
+            runtime.CreateMachine(typeof(M3), e);
+
+            tcs.Task.Wait(1000);
+            Assert.False(failed);
+            Assert.True(tcs.Task.Result);
+        }
+
+        [Fact]
+        public void TestUnHandledEventCanHalt()
+        {
+            var runtime = PSharpRuntime.Create();
+            var failed = false;
+            var tcs = new TaskCompletionSource<bool>();
+            runtime.OnFailure += delegate
+            {
+                failed = true;
+                tcs.TrySetResult(false);
+            };
+
+            var e = new E(tcs);
+            var m = runtime.CreateMachine(typeof(M4), e);
+            runtime.SendEvent(m, new F());
+
+            tcs.Task.Wait(1000);
+            Assert.False(failed);
+            Assert.True(tcs.Task.Result);
         }
 
     }

--- a/Tests/Core.Tests.Unit/ExceptionPropagation/OnExceptionTest.cs
+++ b/Tests/Core.Tests.Unit/ExceptionPropagation/OnExceptionTest.cs
@@ -162,7 +162,7 @@ namespace Microsoft.PSharp.Core.Tests.Unit
 
             protected override OnExceptionOutcome OnException(string methodName, Exception ex)
             {
-                if(ex is UnHandledEventException)
+                if(ex is UnhandledEventException)
                 {
                     return OnExceptionOutcome.HaltMachine;
                 }

--- a/Tests/Core.Tests.Unit/RuntimeInterface/SendAndExecuteTest6.cs
+++ b/Tests/Core.Tests.Unit/RuntimeInterface/SendAndExecuteTest6.cs
@@ -52,10 +52,10 @@ namespace Microsoft.PSharp.Core.Tests.Unit
                 tcs.TrySetResult(true);
             }
 
-            protected override bool OnException(string methodName, Exception ex, ref bool gracefulHalt)
+            protected override OnExceptionOutcome OnException(string methodName, Exception ex)
             {
                 this.Assert(false);
-                return false;
+                return OnExceptionOutcome.ThrowException;
             }
         }
 
@@ -78,9 +78,9 @@ namespace Microsoft.PSharp.Core.Tests.Unit
                 throw new Exception();
             }
 
-            protected override bool OnException(string methodName, Exception ex, ref bool gracefulHalt)
+            protected override OnExceptionOutcome OnException(string methodName, Exception ex)
             {
-                return HandleException;
+                return HandleException ? OnExceptionOutcome.HandledException : OnExceptionOutcome.ThrowException;
             }
         }
 

--- a/Tests/Core.Tests.Unit/RuntimeInterface/SendAndExecuteTest6.cs
+++ b/Tests/Core.Tests.Unit/RuntimeInterface/SendAndExecuteTest6.cs
@@ -52,7 +52,7 @@ namespace Microsoft.PSharp.Core.Tests.Unit
                 tcs.TrySetResult(true);
             }
 
-            protected override bool OnException(string methodName, Exception ex)
+            protected override bool OnException(string methodName, Exception ex, ref bool gracefulHalt)
             {
                 this.Assert(false);
                 return false;
@@ -78,7 +78,7 @@ namespace Microsoft.PSharp.Core.Tests.Unit
                 throw new Exception();
             }
 
-            protected override bool OnException(string methodName, Exception ex)
+            protected override bool OnException(string methodName, Exception ex, ref bool gracefulHalt)
             {
                 return HandleException;
             }

--- a/Tests/TestingServices.Tests.Unit/Features/OnExceptionTest.cs
+++ b/Tests/TestingServices.Tests.Unit/Features/OnExceptionTest.cs
@@ -46,10 +46,10 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
                 throw new Ex1();
             }
 
-            protected override bool OnException(string method, Exception ex, ref bool gracefulHalt)
+            protected override OnExceptionOutcome OnException(string method, Exception ex)
             {
-                if(ex is Ex1) { return true; }
-                return false;
+                if(ex is Ex1) { return OnExceptionOutcome.HandledException; }
+                return OnExceptionOutcome.ThrowException;
             }
         }
 
@@ -70,10 +70,10 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
                 throw new Ex1();
             }
 
-            protected override bool OnException(string method, Exception ex, ref bool gracefulHalt)
+            protected override OnExceptionOutcome OnException(string method, Exception ex)
             {
-                if (ex is Ex1) { return true; }
-                return false;
+                if (ex is Ex1) { return OnExceptionOutcome.HandledException; }
+                return OnExceptionOutcome.ThrowException;
             }
         }
 
@@ -95,10 +95,10 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
                 throw new Ex1();
             }
 
-            protected override bool OnException(string method, Exception ex, ref bool gracefulHalt)
+            protected override OnExceptionOutcome OnException(string method, Exception ex)
             {
-                if (ex is Ex1) { return true; }
-                return false;
+                if (ex is Ex1) { return OnExceptionOutcome.HandledException; }
+                return OnExceptionOutcome.ThrowException;
             }
         }
 
@@ -122,10 +122,10 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
 
             class Done : MachineState { }
 
-            protected override bool OnException(string method, Exception ex, ref bool gracefulHalt)
+            protected override OnExceptionOutcome OnException(string method, Exception ex)
             {
-                if (ex is Ex1) { return true; }
-                return false;
+                if (ex is Ex1) { return OnExceptionOutcome.HandledException; }
+                return OnExceptionOutcome.ThrowException;
             }
         }
 
@@ -140,10 +140,10 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
                 throw new Ex2();
             }
 
-            protected override bool OnException(string method, Exception ex, ref bool gracefulHalt)
+            protected override OnExceptionOutcome OnException(string method, Exception ex)
             {
-                if (ex is Ex1) { return true; }
-                return false;
+                if (ex is Ex1) { return OnExceptionOutcome.HandledException; }
+                return OnExceptionOutcome.ThrowException;
             }
         }
 
@@ -164,14 +164,14 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
                 this.Assert(false);
             }
 
-            protected override bool OnException(string method, Exception ex, ref bool gracefulHalt)
+            protected override OnExceptionOutcome OnException(string method, Exception ex)
             {
                 if (ex is Ex1)
                 {
                     this.Raise(new E(this.Id));
-                    return true;
+                    return OnExceptionOutcome.HandledException;
                 }
-                return false;
+                return OnExceptionOutcome.HandledException;
             }
         }
 
@@ -192,14 +192,14 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
                 this.Assert(false);
             }
 
-            protected override bool OnException(string method, Exception ex, ref bool gracefulHalt)
+            protected override OnExceptionOutcome OnException(string method, Exception ex)
             {
                 if (ex is Ex1)
                 {
                     this.Send(this.Id, new E(this.Id));
-                    return true;
+                    return OnExceptionOutcome.HandledException;
                 }
-                return false;
+                return OnExceptionOutcome.ThrowException;
             }
         }
 

--- a/Tests/TestingServices.Tests.Unit/Features/OnExceptionTest.cs
+++ b/Tests/TestingServices.Tests.Unit/Features/OnExceptionTest.cs
@@ -46,7 +46,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
                 throw new Ex1();
             }
 
-            protected override bool OnException(string method, Exception ex)
+            protected override bool OnException(string method, Exception ex, ref bool gracefulHalt)
             {
                 if(ex is Ex1) { return true; }
                 return false;
@@ -70,7 +70,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
                 throw new Ex1();
             }
 
-            protected override bool OnException(string method, Exception ex)
+            protected override bool OnException(string method, Exception ex, ref bool gracefulHalt)
             {
                 if (ex is Ex1) { return true; }
                 return false;
@@ -95,7 +95,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
                 throw new Ex1();
             }
 
-            protected override bool OnException(string method, Exception ex)
+            protected override bool OnException(string method, Exception ex, ref bool gracefulHalt)
             {
                 if (ex is Ex1) { return true; }
                 return false;
@@ -122,7 +122,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
 
             class Done : MachineState { }
 
-            protected override bool OnException(string method, Exception ex)
+            protected override bool OnException(string method, Exception ex, ref bool gracefulHalt)
             {
                 if (ex is Ex1) { return true; }
                 return false;
@@ -140,7 +140,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
                 throw new Ex2();
             }
 
-            protected override bool OnException(string method, Exception ex)
+            protected override bool OnException(string method, Exception ex, ref bool gracefulHalt)
             {
                 if (ex is Ex1) { return true; }
                 return false;
@@ -164,7 +164,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
                 this.Assert(false);
             }
 
-            protected override bool OnException(string method, Exception ex)
+            protected override bool OnException(string method, Exception ex, ref bool gracefulHalt)
             {
                 if (ex is Ex1)
                 {
@@ -192,7 +192,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
                 this.Assert(false);
             }
 
-            protected override bool OnException(string method, Exception ex)
+            protected override bool OnException(string method, Exception ex, ref bool gracefulHalt)
             {
                 if (ex is Ex1)
                 {

--- a/Tests/TestingServices.Tests.Unit/Features/OnExceptionTest.cs
+++ b/Tests/TestingServices.Tests.Unit/Features/OnExceptionTest.cs
@@ -250,7 +250,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
 
             protected override OnExceptionOutcome OnException(string methodName, Exception ex)
             {
-                if (ex is UnHandledEventException)
+                if (ex is UnhandledEventException)
                 {
                     return OnExceptionOutcome.HaltMachine;
                 }

--- a/Tests/TestingServices.Tests.Unit/RuntimeInterface/SendAndExecuteTest6.cs
+++ b/Tests/TestingServices.Tests.Unit/RuntimeInterface/SendAndExecuteTest6.cs
@@ -49,7 +49,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
                 this.Assert(handled);
             }
 
-            protected override bool OnException(string methodName, Exception ex)
+            protected override bool OnException(string methodName, Exception ex, ref bool gracefulHalt)
             {
                 this.Assert(false);
                 return false;
@@ -75,7 +75,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
                 throw new Exception();
             }
 
-            protected override bool OnException(string methodName, Exception ex)
+            protected override bool OnException(string methodName, Exception ex, ref bool gracefulHalt)
             {
                 return HandleException;
             }

--- a/Tests/TestingServices.Tests.Unit/RuntimeInterface/SendAndExecuteTest6.cs
+++ b/Tests/TestingServices.Tests.Unit/RuntimeInterface/SendAndExecuteTest6.cs
@@ -49,10 +49,10 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
                 this.Assert(handled);
             }
 
-            protected override bool OnException(string methodName, Exception ex, ref bool gracefulHalt)
+            protected override OnExceptionOutcome OnException(string methodName, Exception ex)
             {
                 this.Assert(false);
-                return false;
+                return OnExceptionOutcome.ThrowException;
             }
         }
 
@@ -75,9 +75,9 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
                 throw new Exception();
             }
 
-            protected override bool OnException(string methodName, Exception ex, ref bool gracefulHalt)
+            protected override OnExceptionOutcome OnException(string methodName, Exception ex)
             {
-                return HandleException;
+                return HandleException ? OnExceptionOutcome.HandledException : OnExceptionOutcome.ThrowException;
             }
         }
 


### PR DESCRIPTION
The OnException can now request for the machine to be gracefully halted (as an alternative to crashing the runtime).

Further, an UnHandled event now goes through OnException (which can choose to halt the machine).