### PR TITLE
Fixes in nuspec and removed dependency in P# tester for .NET core

### DIFF
--- a/Scripts/NuGet/PSharp.nuspec
+++ b/Scripts/NuGet/PSharp.nuspec
@@ -13,25 +13,31 @@
     <tags>asynchrony testing .NET programming actors state-machines</tags>
   </metadata>
   <files>
+    <!-- .NET Standard 2.0 -->
     <file src="..\..\bin\netstandard2.0\*.dll" target="lib\netstandard2.0" />
-    <file src="..\..\bin\netstandard1.1\*.dll" target="lib\netstandard1.1" />
-    <file src="..\..\bin\netcoreapp2.1\*.dll" target="lib\netcoreapp2.1" />
-    <file src="..\..\bin\net46\*.dll" target="lib\net46" />
-    <file src="..\..\bin\net45\*.dll" target="lib\net45" />
     <file src="..\..\bin\netstandard2.0\*.mdb" target="lib\netstandard2.0" />
-    <file src="..\..\bin\netstandard1.1\*.mdb" target="lib\netstandard1.1" />
-    <file src="..\..\bin\netcoreapp2.1\*.mdb" target="lib\netcoreapp2.1" />
-    <file src="..\..\bin\net46\*.mdb" target="lib\net46" />
-    <file src="..\..\bin\net45\*.mdb" target="lib\net45" />
     <file src="..\..\bin\netstandard2.0\*.xml" target="lib\netstandard2.0" />
+    <!-- .NET Standard 1.1 -->
+    <file src="..\..\bin\netstandard1.1\*.dll" target="lib\netstandard1.1" />
+    <file src="..\..\bin\netstandard1.1\*.mdb" target="lib\netstandard1.1" />
     <file src="..\..\bin\netstandard1.1\*.xml" target="lib\netstandard1.1" />
+    <!-- .NET Core 2.1 -->
+    <file src="..\..\bin\netcoreapp2.1\*.dll" target="lib\netcoreapp2.1" />
+    <file src="..\..\bin\netcoreapp2.1\*.mdb" target="lib\netcoreapp2.1" />
     <file src="..\..\bin\netcoreapp2.1\*.xml" target="lib\netcoreapp2.1" />
+    <file src="..\..\bin\netcoreapp2.1\*.runtimeconfig.json" target="lib\netcoreapp2.1" />
+    <!-- .NET Framework 4.6 -->
+    <file src="..\..\bin\net46\*.dll" target="lib\net46" />
+    <file src="..\..\bin\net46\*.mdb" target="lib\net46" />
     <file src="..\..\bin\net46\*.xml" target="lib\net46" />
+    <file src="..\..\bin\net46\*.exe" target="lib\net46" />
+    <file src="..\..\bin\net46\*.exe.config" target="lib\net46" />
+    <file src="..\..\bin\net46\*.targets" target="lib\net46" />
+    <!-- .NET Framework 4.5 -->
+    <file src="..\..\bin\net45\*.dll" target="lib\net45" />
+    <file src="..\..\bin\net45\*.mdb" target="lib\net45" />
     <file src="..\..\bin\net45\*.xml" target="lib\net45" />
-    <file src="..\..\bin\netstandard2.0\*" target="tools\netstandard2.0" />
-    <file src="..\..\bin\netstandard1.1\*" target="tools\netstandard1.1" />
-    <file src="..\..\bin\netcoreapp2.1\*" target="tools\netcoreapp2.1" />
-    <file src="..\..\bin\net46\*" target="tools\net46" />
-    <file src="..\..\bin\net45\*" target="tools\net45" />
+    <file src="..\..\bin\net45\*.exe" target="lib\net45" />
+    <file src="..\..\bin\net45\*.exe.config" target="lib\net45" />
   </files>
 </package>

--- a/Tools/Testing/Tester/Interfaces/ITestingProcess.cs
+++ b/Tools/Testing/Tester/Interfaces/ITestingProcess.cs
@@ -12,8 +12,9 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+#if NET46 || NET45
 using System.ServiceModel;
-
+#endif
 using Microsoft.PSharp.TestingServices.Coverage;
 
 namespace Microsoft.PSharp.TestingServices
@@ -21,21 +22,27 @@ namespace Microsoft.PSharp.TestingServices
     /// <summary>
     /// Interface for a remote P# testing process.
     /// </summary>
+#if NET46 || NET45
     [ServiceContract(Namespace = "Microsoft.PSharp")]
     [ServiceKnownType("GetKnownTypes", typeof(KnownTypesProvider))]
+#endif
     internal interface ITestingProcess
     {
         /// <summary>
         /// Returns the test report.
         /// </summary>
         /// <returns>TestReport</returns>
+#if NET46 || NET45
         [OperationContract]
+#endif
         TestReport GetTestReport();
 
         /// <summary>
         /// Stops testing.
         /// </summary>
+#if NET46 || NET45
         [OperationContract]
+#endif
         void Stop();
     }
 }

--- a/Tools/Testing/Tester/Interfaces/ITestingProcessScheduler.cs
+++ b/Tools/Testing/Tester/Interfaces/ITestingProcessScheduler.cs
@@ -12,6 +12,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+#if NET46 || NET45
 using System.ServiceModel;
 
 namespace Microsoft.PSharp.TestingServices
@@ -41,3 +42,4 @@ namespace Microsoft.PSharp.TestingServices
         void SetTestReport(TestReport testReport, uint processId);
     }
 }
+#endif

--- a/Tools/Testing/Tester/Interfaces/KnownTypesProvider.cs
+++ b/Tools/Testing/Tester/Interfaces/KnownTypesProvider.cs
@@ -12,6 +12,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+#if NET46 || NET45
 using System;
 using System.Collections.Generic;
 using System.Reflection;
@@ -40,3 +41,4 @@ namespace Microsoft.PSharp.TestingServices
         }
     }
 }
+#endif

--- a/Tools/Testing/Tester/Tester.csproj
+++ b/Tools/Testing/Tester/Tester.csproj
@@ -17,9 +17,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\Source\TestingServices\TestingServices.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.1'">
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.5.1" />
-  </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net46'">
     <Reference Include="System.Configuration" />
     <Reference Include="System.ServiceModel" />

--- a/Tools/Testing/Tester/Testing/TestingProcess.cs
+++ b/Tools/Testing/Tester/Testing/TestingProcess.cs
@@ -16,8 +16,10 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+#if NET46 || NET45
 using System.ServiceModel;
 using System.ServiceModel.Description;
+#endif
 using System.Timers;
 
 using Microsoft.PSharp.IO;


### PR DESCRIPTION
Fixes packaging of .NET Core in NuGet. Also removes dependency of `System.ServiceModel` in .NET Core version of `PSharpTester`. This fix will also result into a smaller size NuGet package!