### PR TITLE
Updates for building the NuGet package

### DIFF
--- a/Scripts/NuGet/PSharp.nuspec
+++ b/Scripts/NuGet/PSharp.nuspec
@@ -6,7 +6,7 @@
     <authors>Microsoft</authors>
     <licenseUrl>https://github.com/p-org/PSharp/blob/master/LICENSE.txt</licenseUrl>
     <projectUrl>https://github.com/p-org/PSharp</projectUrl>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>The P# language, runtime and testing infrastructure.</description>
     <releaseNotes>This release contains the 1.4.0 version of the P# language, runtime and testing infrastructure.</releaseNotes>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>

--- a/Scripts/create-nuget-package.ps1
+++ b/Scripts/create-nuget-package.ps1
@@ -18,7 +18,7 @@ if (-not (Test-Path $nuget)) {
     Write-Comment -prefix "..." -text "Installed 'nuget.exe' in '$nuget_exe_dir'" -color "white"
 }
 
-$command = "pack $nuget_exe_dir\PSharp.nuspec"
+$command = "pack $nuget_exe_dir\PSharp.nuspec -OutputDirectory $PSScriptRoot\..\bin\nuget"
 $error_msg = "Failed to create P# NuGet package"
 Invoke-ToolCommand -tool $nuget -command $command -error_msg $error_msg
 


### PR DESCRIPTION
Changeset:

- The property `requireLicenseAcceptance` in the NuGet spec is now true.
- The NuGet package is now placed under `bin\nuget`.