### PR TITLE
using regex to support multiple command line option prefixes

### DIFF
--- a/Source/Core/Utilities/Tooling/BaseCommandLineOptions.cs
+++ b/Source/Core/Utilities/Tooling/BaseCommandLineOptions.cs
@@ -4,6 +4,7 @@
 // ------------------------------------------------------------------------------------------------
 
 using System;
+using System.Text.RegularExpressions;
 using Microsoft.PSharp.IO;
 
 namespace Microsoft.PSharp.Utilities
@@ -13,8 +14,6 @@ namespace Microsoft.PSharp.Utilities
     /// </summary>
     public abstract class BaseCommandLineOptions
     {
-        #region fields
-
         /// <summary>
         /// Configuration.
         /// </summary>
@@ -24,10 +23,6 @@ namespace Microsoft.PSharp.Utilities
         /// Command line options.
         /// </summary>
         protected string[] Options;
-
-        #endregion
-
-        #region public API
 
         /// <summary>
         /// Constructor.
@@ -55,60 +50,56 @@ namespace Microsoft.PSharp.Utilities
             return Configuration;
         }
 
-        #endregion
-
-        #region protected methods
-
         /// <summary>
         /// Parses the given option.
         /// </summary>
         /// <param name="option">Option</param>
         protected virtual void ParseOption(string option)
         {
-            if (option.ToLower().Equals("/?"))
+            if (this.IsMatch(option, @"[\/|-]?$"))
             {
                 this.ShowHelp();
                 Environment.Exit(0);
             }
-            else if (option.ToLower().StartsWith("/s:") && option.Length > 3)
+            else if (this.IsMatch(option, @"[\/|-]s:") && option.Length > 3)
             {
                 this.Configuration.SolutionFilePath = option.Substring(3);
             }
-            else if (option.ToLower().StartsWith("/p:") && option.Length > 3)
+            else if (this.IsMatch(option, @"[\/|-]p:") && option.Length > 3)
             {
                 this.Configuration.ProjectName = option.Substring(3);
             }
-            else if (option.ToLower().StartsWith("/o:") && option.Length > 3)
+            else if (this.IsMatch(option, @"[\/|-]o:") && option.Length > 3)
             {
                 this.Configuration.OutputFilePath = option.Substring(3);
             }
-            else if (option.ToLower().StartsWith("/v:") && option.Length > 3)
+            else if (this.IsMatch(option, @"[\/|-]v:") && option.Length > 3)
             {
                 int i = 0;
                 if (!int.TryParse(option.Substring(3), out i) && i > 0 && i <= 3)
                 {
                     Error.ReportAndExit("Please give a valid verbosity level " +
-                        "'/v:[x]', where 1 <= [x] <= 3.");
+                        "'-v:[x]', where 1 <= [x] <= 3.");
                 }
 
                 this.Configuration.Verbose = i;
             }
-            else if (option.ToLower().Equals("/debug"))
+            else if (this.IsMatch(option, @"[\/|-]debug$"))
             {
                 this.Configuration.EnableDebugging = true;
                 Debug.IsEnabled = true;
             }
-            else if (option.ToLower().Equals("/warnings-on"))
+            else if (this.IsMatch(option, @"[\/|-]warnings-on$"))
             {
                 this.Configuration.ShowWarnings = true;
             }
-            else if (option.ToLower().StartsWith("/timeout:") && option.Length > 9)
+            else if (this.IsMatch(option, @"[\/|-]timeout:") && option.Length > 9)
             {
                 int i = 0;
                 if (!int.TryParse(option.Substring(9), out i) &&
                     i > 0)
                 {
-                    Error.ReportAndExit("Please give a valid timeout '/timeout:[x]', where [x] > 0 seconds.");
+                    Error.ReportAndExit("Please give a valid timeout '-timeout:[x]', where [x] > 0 seconds.");
                 }
 
                 this.Configuration.Timeout = i;
@@ -136,6 +127,15 @@ namespace Microsoft.PSharp.Utilities
         /// </summary>
         protected abstract void ShowHelp();
 
-        #endregion
+        /// <summary>
+        /// Checks if the given input is a matches the specified pattern.
+        /// </summary>
+        /// <param name="input">The input to match.</param>
+        /// <param name="pattern">The pattern to match.</param>
+        /// <returns>True if the input matches the pattern.</returns>
+        protected bool IsMatch(string input, string pattern)
+        {
+            return Regex.IsMatch(input, pattern, RegexOptions.IgnoreCase);
+        }
     }
 }

--- a/Source/Core/Utilities/Tooling/BaseCommandLineOptions.cs
+++ b/Source/Core/Utilities/Tooling/BaseCommandLineOptions.cs
@@ -56,24 +56,24 @@ namespace Microsoft.PSharp.Utilities
         /// <param name="option">Option</param>
         protected virtual void ParseOption(string option)
         {
-            if (this.IsMatch(option, @"[\/|-]?$"))
+            if (this.IsMatch(option, @"^[\/|-]?$"))
             {
                 this.ShowHelp();
                 Environment.Exit(0);
             }
-            else if (this.IsMatch(option, @"[\/|-]s:") && option.Length > 3)
+            else if (this.IsMatch(option, @"^[\/|-]s:") && option.Length > 3)
             {
                 this.Configuration.SolutionFilePath = option.Substring(3);
             }
-            else if (this.IsMatch(option, @"[\/|-]p:") && option.Length > 3)
+            else if (this.IsMatch(option, @"^[\/|-]p:") && option.Length > 3)
             {
                 this.Configuration.ProjectName = option.Substring(3);
             }
-            else if (this.IsMatch(option, @"[\/|-]o:") && option.Length > 3)
+            else if (this.IsMatch(option, @"^[\/|-]o:") && option.Length > 3)
             {
                 this.Configuration.OutputFilePath = option.Substring(3);
             }
-            else if (this.IsMatch(option, @"[\/|-]v:") && option.Length > 3)
+            else if (this.IsMatch(option, @"^[\/|-]v:") && option.Length > 3)
             {
                 int i = 0;
                 if (!int.TryParse(option.Substring(3), out i) && i > 0 && i <= 3)
@@ -84,16 +84,16 @@ namespace Microsoft.PSharp.Utilities
 
                 this.Configuration.Verbose = i;
             }
-            else if (this.IsMatch(option, @"[\/|-]debug$"))
+            else if (this.IsMatch(option, @"^[\/|-]debug$"))
             {
                 this.Configuration.EnableDebugging = true;
                 Debug.IsEnabled = true;
             }
-            else if (this.IsMatch(option, @"[\/|-]warnings-on$"))
+            else if (this.IsMatch(option, @"^[\/|-]warnings-on$"))
             {
                 this.Configuration.ShowWarnings = true;
             }
-            else if (this.IsMatch(option, @"[\/|-]timeout:") && option.Length > 9)
+            else if (this.IsMatch(option, @"^[\/|-]timeout:") && option.Length > 9)
             {
                 int i = 0;
                 if (!int.TryParse(option.Substring(9), out i) &&

--- a/Tools/Compilation/Compiler/Utilities/CompilerCommandLineOptions.cs
+++ b/Tools/Compilation/Compiler/Utilities/CompilerCommandLineOptions.cs
@@ -9,8 +9,6 @@ namespace Microsoft.PSharp.Utilities
 {
     public sealed class CompilerCommandLineOptions : BaseCommandLineOptions
     {
-        #region public API
-
         /// <summary>
         /// Constructor.
         /// </summary>
@@ -18,12 +16,7 @@ namespace Microsoft.PSharp.Utilities
         public CompilerCommandLineOptions(string[] args)
             : base (args)
         {
-            
         }
-
-        #endregion
-
-        #region protected methods
 
         /// <summary>
         /// Parses the given option.
@@ -31,21 +24,21 @@ namespace Microsoft.PSharp.Utilities
         /// <param name="option">Option</param>
         protected override void ParseOption(string option)
         {
-            if (option.ToLower().StartsWith("/t:") && option.Length > 3)
+            if (this.IsMatch(option, @"[\/|-]t:") && option.Length > 3)
             {
-                if (option.ToLower().Substring(3).Equals("exe"))
+                if (this.IsMatch(option.Substring(14), @"exe$"))
                 {
                     base.Configuration.CompilationTarget = CompilationTarget.Execution;
                 }
-                else if (option.ToLower().Substring(3).Equals("lib"))
+                else if (this.IsMatch(option.Substring(14), @"lib$"))
                 {
                     base.Configuration.CompilationTarget = CompilationTarget.Library;
                 }
-                else if (option.ToLower().Substring(3).Equals("test"))
+                else if (this.IsMatch(option.Substring(14), @"test$"))
                 {
                     base.Configuration.CompilationTarget = CompilationTarget.Testing;
                 }
-                else if (option.ToLower().Substring(3).Equals("remote"))
+                else if (this.IsMatch(option.Substring(14), @"remote$"))
                 {
                     base.Configuration.CompilationTarget = CompilationTarget.Remote;
                 }
@@ -55,13 +48,13 @@ namespace Microsoft.PSharp.Utilities
                         "'/t:[x]', where [x] is 'all', 'exe', 'lib' or 'test'.");
                 }
             }
-            else if (option.ToLower().StartsWith("/optimization:") && option.Length > 14)
+            else if (this.IsMatch(option, @"[\/|-]optimization:") && option.Length > 14)
             {
-                if (option.ToLower().Substring(14).Equals("debug"))
+                if (this.IsMatch(option.Substring(14), @"debug$"))
                 {
                     base.Configuration.OptimizationTarget = OptimizationTarget.Debug;
                 }
-                else if (option.ToLower().Substring(14).Equals("release"))
+                else if (this.IsMatch(option.Substring(14), @"release$"))
                 {
                     base.Configuration.OptimizationTarget = OptimizationTarget.Release;
                 }
@@ -71,7 +64,7 @@ namespace Microsoft.PSharp.Utilities
                         "'/optimization:[x]', where [x] is 'debug' or 'release'.");
                 }
             }
-            else if (option.ToLower().StartsWith("/pass:") && option.Length > 6)
+            else if (this.IsMatch(option, @"[\/|-]pass:") && option.Length > 6)
             {
                 if (!option.ToLower().Substring(6).EndsWith(".dll"))
                 {
@@ -81,29 +74,29 @@ namespace Microsoft.PSharp.Utilities
 
                 base.Configuration.CustomCompilerPassAssemblyPaths.Add(option.Substring(6));
             }
-            else if (option.ToLower().Equals("/dfa"))
+            else if (this.IsMatch(option, @"[\/|-]dfa$"))
             {
                 base.Configuration.AnalyzeDataFlow = true;
             }
-            else if (option.ToLower().Equals("/check-races"))
+            else if (this.IsMatch(option, @"[\/|-]check-races$"))
             {
                 base.Configuration.AnalyzeDataRaces = true;
             }
-            else if (option.ToLower().Equals("/emit-control-flow"))
+            else if (this.IsMatch(option, @"[\/|-]emit-control-flow$"))
             {
                 base.Configuration.ShowControlFlowInformation = true;
             }
-            else if (option.ToLower().Equals("/emit-data-flow"))
+            else if (this.IsMatch(option, @"[\/|-]emit-data-flow$"))
             {
                 base.Configuration.ShowDataFlowInformation = true;
             }
-            else if (option.ToLower().StartsWith("/emit-data-flow:") && option.Length > 16)
+            else if (this.IsMatch(option, @"[\/|-]emit-control-flow:") && option.Length > 16)
             {
-                if (option.ToLower().Substring(16).Equals("default"))
+                if (this.IsMatch(option.Substring(16), @"default$"))
                 {
                     base.Configuration.ShowDataFlowInformation = true;
                 }
-                else if (option.ToLower().Substring(16).Equals("full"))
+                else if (this.IsMatch(option.Substring(16), @"full$"))
                 {
                     base.Configuration.ShowFullDataFlowInformation = true;
                 }
@@ -113,11 +106,11 @@ namespace Microsoft.PSharp.Utilities
                         "level '/emit-data-flow:[x]', where [x] is 'default' or 'full'.");
                 }
             }
-            else if (option.ToLower().Equals("/time"))
+            else if (this.IsMatch(option, @"[\/|-]time$"))
             {
                 base.Configuration.EnableProfiling = true;
             }
-            else if (option.ToLower().Equals("/xsa"))
+            else if (this.IsMatch(option, @"[\/|-]xsa$"))
             {
                 base.Configuration.DoStateTransitionAnalysis = true;
             }
@@ -160,31 +153,29 @@ namespace Microsoft.PSharp.Utilities
             help += " --------------";
             help += "\n Basic options:";
             help += "\n --------------";
-            help += "\n  /?\t\t Show this help menu";
-            help += "\n  /s:[x]\t Path to a P# solution";
-            help += "\n  /p:[x]\t Name of a project in the P# solution";
-            help += "\n  /o:[x]\t Path for output files";
-            help += "\n  /timeout:[x]\t Timeout for the tool (default is no timeout)";
-            help += "\n  /v:[x]\t Enable verbose mode (values from '1' to '3')";
-            help += "\n  /warnings-on\t Show warnings";
-            help += "\n  /debug\t Enable debugging";
+            help += "\n  -?\t\t Show this help menu";
+            help += "\n  -s:[x]\t Path to a P# solution";
+            help += "\n  -p:[x]\t Name of a project in the P# solution";
+            help += "\n  -o:[x]\t Path for output files";
+            help += "\n  -timeout:[x]\t Timeout for the tool (default is no timeout)";
+            help += "\n  -v:[x]\t Enable verbose mode (values from '1' to '3')";
+            help += "\n  -warnings-on\t Show warnings";
+            help += "\n  -debug\t Enable debugging";
 
             help += "\n\n --------------------";
             help += "\n Compilation options:";
             help += "\n --------------------";
-            help += "\n  /t:[x]\t The compilation target ('exe', 'lib' or 'test')";
+            help += "\n  -t:[x]\t The compilation target ('exe', 'lib' or 'test')";
 
             help += "\n\n --------------------";
             help += "\n Analysis options:";
             help += "\n --------------------";
-            help += "\n  /dfa\t\t Enables data-flow analysis";
-            help += "\n  /check-races\t Enables race-checking analysis";
+            help += "\n  -dfa\t\t Enables data-flow analysis";
+            help += "\n  -check-races\t Enables race-checking analysis";
 
             help += "\n";
 
             Output.WriteLine(help);
         }
-
-        #endregion
     }
 }

--- a/Tools/Compilation/Compiler/Utilities/CompilerCommandLineOptions.cs
+++ b/Tools/Compilation/Compiler/Utilities/CompilerCommandLineOptions.cs
@@ -24,21 +24,21 @@ namespace Microsoft.PSharp.Utilities
         /// <param name="option">Option</param>
         protected override void ParseOption(string option)
         {
-            if (this.IsMatch(option, @"[\/|-]t:") && option.Length > 3)
+            if (this.IsMatch(option, @"^[\/|-]t:") && option.Length > 3)
             {
-                if (this.IsMatch(option.Substring(14), @"exe$"))
+                if (this.IsMatch(option.Substring(14), @"^exe$"))
                 {
                     base.Configuration.CompilationTarget = CompilationTarget.Execution;
                 }
-                else if (this.IsMatch(option.Substring(14), @"lib$"))
+                else if (this.IsMatch(option.Substring(14), @"^lib$"))
                 {
                     base.Configuration.CompilationTarget = CompilationTarget.Library;
                 }
-                else if (this.IsMatch(option.Substring(14), @"test$"))
+                else if (this.IsMatch(option.Substring(14), @"^test$"))
                 {
                     base.Configuration.CompilationTarget = CompilationTarget.Testing;
                 }
-                else if (this.IsMatch(option.Substring(14), @"remote$"))
+                else if (this.IsMatch(option.Substring(14), @"^remote$"))
                 {
                     base.Configuration.CompilationTarget = CompilationTarget.Remote;
                 }
@@ -48,13 +48,13 @@ namespace Microsoft.PSharp.Utilities
                         "'/t:[x]', where [x] is 'all', 'exe', 'lib' or 'test'.");
                 }
             }
-            else if (this.IsMatch(option, @"[\/|-]optimization:") && option.Length > 14)
+            else if (this.IsMatch(option, @"^[\/|-]optimization:") && option.Length > 14)
             {
-                if (this.IsMatch(option.Substring(14), @"debug$"))
+                if (this.IsMatch(option.Substring(14), @"^debug$"))
                 {
                     base.Configuration.OptimizationTarget = OptimizationTarget.Debug;
                 }
-                else if (this.IsMatch(option.Substring(14), @"release$"))
+                else if (this.IsMatch(option.Substring(14), @"^release$"))
                 {
                     base.Configuration.OptimizationTarget = OptimizationTarget.Release;
                 }
@@ -64,7 +64,7 @@ namespace Microsoft.PSharp.Utilities
                         "'/optimization:[x]', where [x] is 'debug' or 'release'.");
                 }
             }
-            else if (this.IsMatch(option, @"[\/|-]pass:") && option.Length > 6)
+            else if (this.IsMatch(option, @"^[\/|-]pass:") && option.Length > 6)
             {
                 if (!option.ToLower().Substring(6).EndsWith(".dll"))
                 {
@@ -74,29 +74,29 @@ namespace Microsoft.PSharp.Utilities
 
                 base.Configuration.CustomCompilerPassAssemblyPaths.Add(option.Substring(6));
             }
-            else if (this.IsMatch(option, @"[\/|-]dfa$"))
+            else if (this.IsMatch(option, @"^[\/|-]dfa$"))
             {
                 base.Configuration.AnalyzeDataFlow = true;
             }
-            else if (this.IsMatch(option, @"[\/|-]check-races$"))
+            else if (this.IsMatch(option, @"^[\/|-]check-races$"))
             {
                 base.Configuration.AnalyzeDataRaces = true;
             }
-            else if (this.IsMatch(option, @"[\/|-]emit-control-flow$"))
+            else if (this.IsMatch(option, @"^[\/|-]emit-control-flow$"))
             {
                 base.Configuration.ShowControlFlowInformation = true;
             }
-            else if (this.IsMatch(option, @"[\/|-]emit-data-flow$"))
+            else if (this.IsMatch(option, @"^[\/|-]emit-data-flow$"))
             {
                 base.Configuration.ShowDataFlowInformation = true;
             }
-            else if (this.IsMatch(option, @"[\/|-]emit-control-flow:") && option.Length > 16)
+            else if (this.IsMatch(option, @"^[\/|-]emit-control-flow:") && option.Length > 16)
             {
-                if (this.IsMatch(option.Substring(16), @"default$"))
+                if (this.IsMatch(option.Substring(16), @"^default$"))
                 {
                     base.Configuration.ShowDataFlowInformation = true;
                 }
-                else if (this.IsMatch(option.Substring(16), @"full$"))
+                else if (this.IsMatch(option.Substring(16), @"^full$"))
                 {
                     base.Configuration.ShowFullDataFlowInformation = true;
                 }
@@ -106,11 +106,11 @@ namespace Microsoft.PSharp.Utilities
                         "level '/emit-data-flow:[x]', where [x] is 'default' or 'full'.");
                 }
             }
-            else if (this.IsMatch(option, @"[\/|-]time$"))
+            else if (this.IsMatch(option, @"^[\/|-]time$"))
             {
                 base.Configuration.EnableProfiling = true;
             }
-            else if (this.IsMatch(option, @"[\/|-]xsa$"))
+            else if (this.IsMatch(option, @"^[\/|-]xsa$"))
             {
                 base.Configuration.DoStateTransitionAnalysis = true;
             }

--- a/Tools/Testing/Replayer/Utilities/ReplayerCommandLineOptions.cs
+++ b/Tools/Testing/Replayer/Utilities/ReplayerCommandLineOptions.cs
@@ -25,39 +25,38 @@ namespace Microsoft.PSharp.Utilities
         /// <param name="option">Option</param>
         protected override void ParseOption(string option)
         {
-            if (option.ToLower().StartsWith("/test:") && option.Length > 6)
+            if (this.IsMatch(option, @"[\/|-]test:") && option.Length > 6)
             {
                 base.Configuration.AssemblyToBeAnalyzed = option.Substring(6);
             }
-            else if (option.ToLower().StartsWith("/runtime:") && option.Length > 9)
+            else if (this.IsMatch(option, @"[\/|-]runtime:") && option.Length > 9)
             {
                 base.Configuration.TestingRuntimeAssembly = option.Substring(9);
             }
-            else if (option.ToLower().StartsWith("/method:") && option.Length > 8)
+            else if (this.IsMatch(option, @"[\/|-]method:") && option.Length > 8)
             {
                 base.Configuration.TestMethodName = option.Substring(8);
             }
-            else if (option.ToLower().StartsWith("/replay:") && option.Length > 8)
+            else if (this.IsMatch(option, @"[\/|-]replay:") && option.Length > 8)
             {
                 string extension = System.IO.Path.GetExtension(option.Substring(8));
                 if (!extension.Equals(".schedule"))
                 {
                     Error.ReportAndExit("Please give a valid schedule file " +
-                        "'/replay:[x]', where [x] has extension '.schedule'.");
+                        "'-replay:[x]', where [x] has extension '.schedule'.");
                 }
 
                 base.Configuration.ScheduleFile = option.Substring(8);
             }
-            else if (option.ToLower().Equals("/attach-debugger") ||
-                option.ToLower().Equals("/break"))
+            else if (this.IsMatch(option, @"[\/|-][attach-debugger|break]$"))
             {
                 base.Configuration.AttachDebugger = true;
             }
-            else if (option.ToLower().Equals("/cycle-detection"))
+            else if (this.IsMatch(option, @"[\/|-]cycle-detection$"))
             {
                 base.Configuration.EnableCycleDetection = true;
             }
-            else if (option.ToLower().Equals("/custom-state-hashing"))
+            else if (this.IsMatch(option, @"[\/|-]custom-state-hashing$"))
             {
                 base.Configuration.EnableUserDefinedStateHashing = true;
             }
@@ -75,13 +74,13 @@ namespace Microsoft.PSharp.Utilities
             if (base.Configuration.AssemblyToBeAnalyzed.Equals(""))
             {
                 Error.ReportAndExit("Please give a valid path to a P# " +
-                    "program's dll using '/test:[x]'.");
+                    "program's dll using '-test:[x]'.");
             }
 
             if (base.Configuration.ScheduleFile.Equals(""))
             {
                 Error.ReportAndExit("Please give a valid path to a P# schedule " +
-                    "file using '/replay:[x]', where [x] has extension '.schedule'.");
+                    "file using '-replay:[x]', where [x] has extension '.schedule'.");
             }
         }
 
@@ -101,16 +100,16 @@ namespace Microsoft.PSharp.Utilities
             help += " --------------";
             help += "\n Basic options:";
             help += "\n --------------";
-            help += "\n  /?\t\t Show this help menu";
-            help += "\n  /test:[x]\t Path to the P# program to test";
-            help += "\n  /timeout:[x]\t Timeout (default is no timeout)";
-            help += "\n  /v:[x]\t Enable verbose mode (values from '1' to '3')";
+            help += "\n  -?\t\t Show this help menu";
+            help += "\n  -test:[x]\t Path to the P# program to test";
+            help += "\n  -timeout:[x]\t Timeout (default is no timeout)";
+            help += "\n  -v:[x]\t Enable verbose mode (values from '1' to '3')";
 
             help += "\n\n ------------------";
             help += "\n Replaying options:";
             help += "\n ------------------";
-            help += "\n  /replay:[x]\t Schedule to replay";
-            help += "\n  /break:[x]\t Attach debugger and break at bug";
+            help += "\n  -replay:[x]\t Schedule to replay";
+            help += "\n  -break:[x]\t Attach debugger and break at bug";
 
             help += "\n";
 

--- a/Tools/Testing/Replayer/Utilities/ReplayerCommandLineOptions.cs
+++ b/Tools/Testing/Replayer/Utilities/ReplayerCommandLineOptions.cs
@@ -25,19 +25,19 @@ namespace Microsoft.PSharp.Utilities
         /// <param name="option">Option</param>
         protected override void ParseOption(string option)
         {
-            if (this.IsMatch(option, @"[\/|-]test:") && option.Length > 6)
+            if (this.IsMatch(option, @"^[\/|-]test:") && option.Length > 6)
             {
                 base.Configuration.AssemblyToBeAnalyzed = option.Substring(6);
             }
-            else if (this.IsMatch(option, @"[\/|-]runtime:") && option.Length > 9)
+            else if (this.IsMatch(option, @"^[\/|-]runtime:") && option.Length > 9)
             {
                 base.Configuration.TestingRuntimeAssembly = option.Substring(9);
             }
-            else if (this.IsMatch(option, @"[\/|-]method:") && option.Length > 8)
+            else if (this.IsMatch(option, @"^[\/|-]method:") && option.Length > 8)
             {
                 base.Configuration.TestMethodName = option.Substring(8);
             }
-            else if (this.IsMatch(option, @"[\/|-]replay:") && option.Length > 8)
+            else if (this.IsMatch(option, @"^[\/|-]replay:") && option.Length > 8)
             {
                 string extension = System.IO.Path.GetExtension(option.Substring(8));
                 if (!extension.Equals(".schedule"))
@@ -48,15 +48,15 @@ namespace Microsoft.PSharp.Utilities
 
                 base.Configuration.ScheduleFile = option.Substring(8);
             }
-            else if (this.IsMatch(option, @"[\/|-][attach-debugger|break]$"))
+            else if (this.IsMatch(option, @"^[\/|-][attach-debugger|break]$"))
             {
                 base.Configuration.AttachDebugger = true;
             }
-            else if (this.IsMatch(option, @"[\/|-]cycle-detection$"))
+            else if (this.IsMatch(option, @"^[\/|-]cycle-detection$"))
             {
                 base.Configuration.EnableCycleDetection = true;
             }
-            else if (this.IsMatch(option, @"[\/|-]custom-state-hashing$"))
+            else if (this.IsMatch(option, @"^[\/|-]custom-state-hashing$"))
             {
                 base.Configuration.EnableUserDefinedStateHashing = true;
             }

--- a/Tools/Testing/Tester/Utilities/TesterCommandLineOptions.cs
+++ b/Tools/Testing/Tester/Utilities/TesterCommandLineOptions.cs
@@ -26,37 +26,37 @@ namespace Microsoft.PSharp.Utilities
         /// <param name="option">Option</param>
         protected override void ParseOption(string option)
         {
-            if (this.IsMatch(option, @"[\/|-]test:") && option.Length > 6)
+            if (this.IsMatch(option, @"^[\/|-]test:") && option.Length > 6)
             {
                 base.Configuration.AssemblyToBeAnalyzed = option.Substring(6);
             }
-            else if (this.IsMatch(option, @"[\/|-]runtime:") && option.Length > 9)
+            else if (this.IsMatch(option, @"^[\/|-]runtime:") && option.Length > 9)
             {
                 base.Configuration.TestingRuntimeAssembly = option.Substring(9);
             }
-            else if (this.IsMatch(option, @"[\/|-]method:") && option.Length > 8)
+            else if (this.IsMatch(option, @"^[\/|-]method:") && option.Length > 8)
             {
                 base.Configuration.TestMethodName = option.Substring(8);
             }
-            else if (this.IsMatch(option, @"[\/|-]interactive$"))
+            else if (this.IsMatch(option, @"^[\/|-]interactive$"))
             {
                 base.Configuration.SchedulingStrategy = SchedulingStrategy.Interactive;
             }
-            else if (this.IsMatch(option, @"[\/|-]sch:"))
+            else if (this.IsMatch(option, @"^[\/|-]sch:"))
             {
                 string scheduler = option.Substring(5);
-                if (this.IsMatch(scheduler, @"portfolio$"))
+                if (this.IsMatch(scheduler, @"^portfolio$"))
                 {
                     base.Configuration.SchedulingStrategy = SchedulingStrategy.Portfolio;
                 }
-                else if (this.IsMatch(scheduler, @"random$"))
+                else if (this.IsMatch(scheduler, @"^random$"))
                 {
                     base.Configuration.SchedulingStrategy = SchedulingStrategy.Random;
                 }
-                else if (this.IsMatch(scheduler, @"probabilistic"))
+                else if (this.IsMatch(scheduler, @"^probabilistic"))
                 {
                     int i = 0;
-                    if (this.IsMatch(scheduler, @"probabilistic$") ||
+                    if (this.IsMatch(scheduler, @"^probabilistic$") ||
                         !int.TryParse(scheduler.Substring(14), out i) && i >= 0)
                     {
                         Error.ReportAndExit("Please give a valid number of coin " +
@@ -66,10 +66,10 @@ namespace Microsoft.PSharp.Utilities
                     base.Configuration.SchedulingStrategy = SchedulingStrategy.ProbabilisticRandom;
                     base.Configuration.CoinFlipBound = i;
                 }
-                else if (this.IsMatch(scheduler, @"pct"))
+                else if (this.IsMatch(scheduler, @"^pct"))
                 {
                     int i = 0;
-                    if (this.IsMatch(scheduler, @"pct$") ||
+                    if (this.IsMatch(scheduler, @"^pct$") ||
                         !int.TryParse(scheduler.Substring(4), out i) && i >= 0)
                     {
                         Error.ReportAndExit("Please give a valid number of priority " +
@@ -79,10 +79,10 @@ namespace Microsoft.PSharp.Utilities
                     base.Configuration.SchedulingStrategy = SchedulingStrategy.PCT;
                     base.Configuration.PrioritySwitchBound = i;
                 }
-                else if (this.IsMatch(scheduler, @"fairpct"))
+                else if (this.IsMatch(scheduler, @"^fairpct"))
                 {
                     int i = 0;
-                    if (this.IsMatch(scheduler, @"fairpct$") ||
+                    if (this.IsMatch(scheduler, @"^fairpct$") ||
                         !int.TryParse(scheduler.Substring("fairpct:".Length), out i) && i >= 0)
                     {
                         Error.ReportAndExit("Please give a valid number of priority " +
@@ -92,26 +92,26 @@ namespace Microsoft.PSharp.Utilities
                     base.Configuration.SchedulingStrategy = SchedulingStrategy.FairPCT;
                     base.Configuration.PrioritySwitchBound = i;
                 }
-                else if (this.IsMatch(scheduler, @"dfs$"))
+                else if (this.IsMatch(scheduler, @"^dfs$"))
                 {
                     base.Configuration.SchedulingStrategy = SchedulingStrategy.DFS;
                 }
-                else if (this.IsMatch(scheduler, @"iddfs$"))
+                else if (this.IsMatch(scheduler, @"^iddfs$"))
                 {
                     base.Configuration.SchedulingStrategy = SchedulingStrategy.IDDFS;
                 }
-                else if (this.IsMatch(scheduler, @"dpor$"))
+                else if (this.IsMatch(scheduler, @"^dpor$"))
                 {
                     base.Configuration.SchedulingStrategy = SchedulingStrategy.DPOR;
                 }
-                else if (this.IsMatch(scheduler, @"rdpor$"))
+                else if (this.IsMatch(scheduler, @"^rdpor$"))
                 {
                     base.Configuration.SchedulingStrategy = SchedulingStrategy.RDPOR;
                 }
-                else if (this.IsMatch(scheduler, @"db"))
+                else if (this.IsMatch(scheduler, @"^db"))
                 {
                     int i = 0;
-                    if (this.IsMatch(scheduler, @"db$") ||
+                    if (this.IsMatch(scheduler, @"^db$") ||
                         !int.TryParse(scheduler.Substring(3), out i) && i >= 0)
                     {
                         Error.ReportAndExit("Please give a valid delay " +
@@ -121,10 +121,10 @@ namespace Microsoft.PSharp.Utilities
                     base.Configuration.SchedulingStrategy = SchedulingStrategy.DelayBounding;
                     base.Configuration.DelayBound = i;
                 }
-                else if (this.IsMatch(scheduler, @"rdb"))
+                else if (this.IsMatch(scheduler, @"^rdb"))
                 {
                     int i = 0;
-                    if (this.IsMatch(scheduler, @"rdb$") ||
+                    if (this.IsMatch(scheduler, @"^rdb$") ||
                         !int.TryParse(scheduler.Substring(4), out i) && i >= 0)
                     {
                         Error.ReportAndExit("Please give a valid delay " +
@@ -141,7 +141,7 @@ namespace Microsoft.PSharp.Utilities
                         "experimental strategies also exist, but are not listed here).");
                 }
             }
-            else if (this.IsMatch(option, @"[\/|-]replay:") && option.Length > 8)
+            else if (this.IsMatch(option, @"^[\/|-]replay:") && option.Length > 8)
             {
                 string extension = System.IO.Path.GetExtension(option.Substring(8));
                 if (!extension.Equals(".schedule"))
@@ -152,18 +152,18 @@ namespace Microsoft.PSharp.Utilities
 
                 base.Configuration.ScheduleFile = option.Substring(8);
             }
-            else if (this.IsMatch(option, @"[\/|-]reduction:"))
+            else if (this.IsMatch(option, @"^[\/|-]reduction:"))
             {
                 string reduction = option.Substring(11);
-                if (this.IsMatch(reduction, @"none$"))
+                if (this.IsMatch(reduction, @"^none$"))
                 {
                     base.Configuration.ReductionStrategy = ReductionStrategy.None;
                 }
-                else if (this.IsMatch(reduction, @"omit$"))
+                else if (this.IsMatch(reduction, @"^omit$"))
                 {
                     base.Configuration.ReductionStrategy = ReductionStrategy.OmitSchedulingPoints;
                 }
-                else if (this.IsMatch(reduction, @"force$"))
+                else if (this.IsMatch(reduction, @"^force$"))
                 {
                     base.Configuration.ReductionStrategy = ReductionStrategy.ForceSchedule;
                 }
@@ -173,7 +173,7 @@ namespace Microsoft.PSharp.Utilities
                         "'-reduction:[x]', where [x] is 'none', 'omit' or 'force'.");
                 }
             }
-            else if (this.IsMatch(option, @"[\/|-]i:") && option.Length > 3)
+            else if (this.IsMatch(option, @"^[\/|-]i:") && option.Length > 3)
             {
                 int i = 0;
                 if (!int.TryParse(option.Substring(3), out i) && i > 0)
@@ -184,7 +184,7 @@ namespace Microsoft.PSharp.Utilities
 
                 base.Configuration.SchedulingIterations = i;
             }
-            else if (this.IsMatch(option, @"[\/|-]parallel:") && option.Length > 10)
+            else if (this.IsMatch(option, @"^[\/|-]parallel:") && option.Length > 10)
             {
                 uint i = 0;
                 if (!uint.TryParse(option.Substring(10), out i) || i <= 1)
@@ -195,11 +195,11 @@ namespace Microsoft.PSharp.Utilities
 
                 base.Configuration.ParallelBugFindingTasks = i;
             }
-            else if (this.IsMatch(option, @"[\/|-]run-as-parallel-testing-task$"))
+            else if (this.IsMatch(option, @"^[\/|-]run-as-parallel-testing-task$"))
             {
                 base.Configuration.RunAsParallelBugFindingTask = true;
             }
-            else if (this.IsMatch(option, @"[\/|-]testing-scheduler-endpoint:") && option.Length > 28)
+            else if (this.IsMatch(option, @"^[\/|-]testing-scheduler-endpoint:") && option.Length > 28)
             {
                 string endpoint = option.Substring(28);
                 if (endpoint.Length != 36)
@@ -210,7 +210,7 @@ namespace Microsoft.PSharp.Utilities
 
                 base.Configuration.TestingSchedulerEndPoint = endpoint;
             }
-            else if (this.IsMatch(option, @"[\/|-]testing-scheduler-process-id:") && option.Length > 30)
+            else if (this.IsMatch(option, @"^[\/|-]testing-scheduler-process-id:") && option.Length > 30)
             {
                 int i = 0;
                 if (!int.TryParse(option.Substring(30), out i) && i >= 0)
@@ -221,7 +221,7 @@ namespace Microsoft.PSharp.Utilities
 
                 base.Configuration.TestingSchedulerProcessId = i;
             }
-            else if (this.IsMatch(option, @"[\/|-]testing-process-id:") && option.Length > 20)
+            else if (this.IsMatch(option, @"^[\/|-]testing-process-id:") && option.Length > 20)
             {
                 uint i = 0;
                 if (!uint.TryParse(option.Substring(20), out i) && i >= 0)
@@ -232,41 +232,41 @@ namespace Microsoft.PSharp.Utilities
 
                 base.Configuration.TestingProcessId = i;
             }
-            else if (this.IsMatch(option, @"[\/|-]explore$"))
+            else if (this.IsMatch(option, @"^[\/|-]explore$"))
             {
                 base.Configuration.PerformFullExploration = true;
             }
-            else if (this.IsMatch(option, @"[\/|-]coverage$"))
+            else if (this.IsMatch(option, @"^[\/|-]coverage$"))
             {
                 base.Configuration.ReportCodeCoverage = true;
                 base.Configuration.ReportActivityCoverage = true;
             }
-            else if (this.IsMatch(option, @"[\/|-]coverage:code$"))
+            else if (this.IsMatch(option, @"^[\/|-]coverage:code$"))
             {
                 base.Configuration.ReportCodeCoverage = true;
             }
-            else if (this.IsMatch(option, @"[\/|-]coverage:activity$"))
+            else if (this.IsMatch(option, @"^[\/|-]coverage:activity$"))
             {
                 base.Configuration.ReportActivityCoverage = true;
             }
-            else if (this.IsMatch(option, @"[\/|-]coverage:activity-debug$"))
+            else if (this.IsMatch(option, @"^[\/|-]coverage:activity-debug$"))
             {
                 base.Configuration.ReportActivityCoverage = true;
                 base.Configuration.DebugActivityCoverage = true;
             }
-            else if (this.IsMatch(option, @"[\/|-]instr:"))
+            else if (this.IsMatch(option, @"^[\/|-]instr:"))
             {
                 base.Configuration.AdditionalCodeCoverageAssemblies[option.Substring(7)] = false;
             }
-            else if (this.IsMatch(option, @"[\/|-]instr-list:"))
+            else if (this.IsMatch(option, @"^[\/|-]instr-list:"))
             {
                 base.Configuration.AdditionalCodeCoverageAssemblies[option.Substring(12)] = true;
             }
-            else if (this.IsMatch(option, @"[\/|-]detect-races$"))
+            else if (this.IsMatch(option, @"^[\/|-]detect-races$"))
             {
                 base.Configuration.EnableDataRaceDetection = true;
             }
-            else if (this.IsMatch(option, @"[\/|-]sch-seed:") && option.Length > 10)
+            else if (this.IsMatch(option, @"^[\/|-]sch-seed:") && option.Length > 10)
             {
                 int seed;
                 if (!int.TryParse(option.Substring(10), out seed))
@@ -277,7 +277,7 @@ namespace Microsoft.PSharp.Utilities
 
                 base.Configuration.RandomSchedulingSeed = seed;
             }
-            else if (this.IsMatch(option, @"[\/|-]max-steps:") && option.Length > 11)
+            else if (this.IsMatch(option, @"^[\/|-]max-steps:") && option.Length > 11)
             {
                 int i = 0;
                 int j = 0;
@@ -314,11 +314,11 @@ namespace Microsoft.PSharp.Utilities
                 base.Configuration.MaxUnfairSchedulingSteps = i;
                 base.Configuration.MaxFairSchedulingSteps = j;
             }
-            else if (this.IsMatch(option, @"[\/|-]depth-bound-bug$"))
+            else if (this.IsMatch(option, @"^[\/|-]depth-bound-bug$"))
             {
                 base.Configuration.ConsiderDepthBoundHitAsBug = true;
             }
-            else if (this.IsMatch(option, @"[\/|-]prefix:") && option.Length > 8)
+            else if (this.IsMatch(option, @"^[\/|-]prefix:") && option.Length > 8)
             {
                 int i = 0;
                 if (!int.TryParse(option.Substring(8), out i) && i >= 0)
@@ -329,7 +329,7 @@ namespace Microsoft.PSharp.Utilities
 
                 base.Configuration.SafetyPrefixBound = i;
             }
-            else if (this.IsMatch(option, @"[\/|-]liveness-temperature-threshold:") && option.Length > 32)
+            else if (this.IsMatch(option, @"^[\/|-]liveness-temperature-threshold:") && option.Length > 32)
             {
                 int i = 0;
                 if (!int.TryParse(option.Substring(32), out i) && i >= 0)
@@ -340,11 +340,11 @@ namespace Microsoft.PSharp.Utilities
 
                 base.Configuration.LivenessTemperatureThreshold = i;
             }
-            else if (this.IsMatch(option, @"[\/|-]cycle-detection$"))
+            else if (this.IsMatch(option, @"^[\/|-]cycle-detection$"))
             {
                 base.Configuration.EnableCycleDetection = true;
             }
-            else if (this.IsMatch(option, @"[\/|-]custom-state-hashing$"))
+            else if (this.IsMatch(option, @"^[\/|-]custom-state-hashing$"))
             {
                 base.Configuration.EnableUserDefinedStateHashing = true;
             }

--- a/Tools/Testing/Tester/Utilities/TesterCommandLineOptions.cs
+++ b/Tools/Testing/Tester/Utilities/TesterCommandLineOptions.cs
@@ -4,7 +4,6 @@
 // ------------------------------------------------------------------------------------------------
 
 using System;
-
 using Microsoft.PSharp.IO;
 
 namespace Microsoft.PSharp.Utilities
@@ -27,109 +26,109 @@ namespace Microsoft.PSharp.Utilities
         /// <param name="option">Option</param>
         protected override void ParseOption(string option)
         {
-            if (option.ToLower().StartsWith("/test:") && option.Length > 6)
+            if (this.IsMatch(option, @"[\/|-]test:") && option.Length > 6)
             {
                 base.Configuration.AssemblyToBeAnalyzed = option.Substring(6);
             }
-            else if (option.ToLower().StartsWith("/runtime:") && option.Length > 9)
+            else if (this.IsMatch(option, @"[\/|-]runtime:") && option.Length > 9)
             {
                 base.Configuration.TestingRuntimeAssembly = option.Substring(9);
             }
-            else if (option.ToLower().StartsWith("/method:") && option.Length > 8)
+            else if (this.IsMatch(option, @"[\/|-]method:") && option.Length > 8)
             {
                 base.Configuration.TestMethodName = option.Substring(8);
             }
-            else if (option.ToLower().Equals("/interactive"))
+            else if (this.IsMatch(option, @"[\/|-]interactive$"))
             {
                 base.Configuration.SchedulingStrategy = SchedulingStrategy.Interactive;
             }
-            else if (option.ToLower().StartsWith("/sch:"))
+            else if (this.IsMatch(option, @"[\/|-]sch:"))
             {
-                string scheduler = option.ToLower().Substring(5);
-                if (scheduler.ToLower().Equals("portfolio"))
+                string scheduler = option.Substring(5);
+                if (this.IsMatch(scheduler, @"portfolio$"))
                 {
                     base.Configuration.SchedulingStrategy = SchedulingStrategy.Portfolio;
                 }
-                else if (scheduler.ToLower().Equals("random"))
+                else if (this.IsMatch(scheduler, @"random$"))
                 {
                     base.Configuration.SchedulingStrategy = SchedulingStrategy.Random;
                 }
-                else if (scheduler.StartsWith("probabilistic"))
+                else if (this.IsMatch(scheduler, @"probabilistic"))
                 {
                     int i = 0;
-                    if (scheduler.Equals("probabilistic") ||
+                    if (this.IsMatch(scheduler, @"probabilistic$") ||
                         !int.TryParse(scheduler.Substring(14), out i) && i >= 0)
                     {
                         Error.ReportAndExit("Please give a valid number of coin " +
-                            "flip bound '/sch:probabilistic:[bound]', where [bound] >= 0.");
+                            "flip bound '-sch:probabilistic:[bound]', where [bound] >= 0.");
                     }
 
                     base.Configuration.SchedulingStrategy = SchedulingStrategy.ProbabilisticRandom;
                     base.Configuration.CoinFlipBound = i;
                 }
-                else if (scheduler.StartsWith("pct"))
+                else if (this.IsMatch(scheduler, @"pct"))
                 {
                     int i = 0;
-                    if (scheduler.Equals("pct") ||
+                    if (this.IsMatch(scheduler, @"pct$") ||
                         !int.TryParse(scheduler.Substring(4), out i) && i >= 0)
                     {
                         Error.ReportAndExit("Please give a valid number of priority " +
-                            "switch bound '/sch:pct:[bound]', where [bound] >= 0.");
+                            "switch bound '-sch:pct:[bound]', where [bound] >= 0.");
                     }
 
                     base.Configuration.SchedulingStrategy = SchedulingStrategy.PCT;
                     base.Configuration.PrioritySwitchBound = i;
                 }
-                else if (scheduler.StartsWith("fairpct"))
+                else if (this.IsMatch(scheduler, @"fairpct"))
                 {
                     int i = 0;
-                    if (scheduler.Equals("fairpct") ||
+                    if (this.IsMatch(scheduler, @"fairpct$") ||
                         !int.TryParse(scheduler.Substring("fairpct:".Length), out i) && i >= 0)
                     {
                         Error.ReportAndExit("Please give a valid number of priority " +
-                            "switch bound '/sch:fairpct:[bound]', where [bound] >= 0.");
+                            "switch bound '-sch:fairpct:[bound]', where [bound] >= 0.");
                     }
 
                     base.Configuration.SchedulingStrategy = SchedulingStrategy.FairPCT;
                     base.Configuration.PrioritySwitchBound = i;
                 }
-                else if (scheduler.ToLower().Equals("dfs"))
+                else if (this.IsMatch(scheduler, @"dfs$"))
                 {
                     base.Configuration.SchedulingStrategy = SchedulingStrategy.DFS;
                 }
-                else if (scheduler.ToLower().Equals("iddfs"))
+                else if (this.IsMatch(scheduler, @"iddfs$"))
                 {
                     base.Configuration.SchedulingStrategy = SchedulingStrategy.IDDFS;
                 }
-                else if (scheduler.ToLower().Equals("dpor"))
+                else if (this.IsMatch(scheduler, @"dpor$"))
                 {
                     base.Configuration.SchedulingStrategy = SchedulingStrategy.DPOR;
                 }
-                else if (scheduler.ToLower().Equals("rdpor"))
+                else if (this.IsMatch(scheduler, @"rdpor$"))
                 {
                     base.Configuration.SchedulingStrategy = SchedulingStrategy.RDPOR;
                 }
-                else if (scheduler.StartsWith("db"))
+                else if (this.IsMatch(scheduler, @"db"))
                 {
                     int i = 0;
-                    if (scheduler.Equals("db") ||
+                    if (this.IsMatch(scheduler, @"db$") ||
                         !int.TryParse(scheduler.Substring(3), out i) && i >= 0)
                     {
                         Error.ReportAndExit("Please give a valid delay " +
-                            "bound '/sch:db:[bound]', where [bound] >= 0.");
+                            "bound '-sch:db:[bound]', where [bound] >= 0.");
                     }
 
                     base.Configuration.SchedulingStrategy = SchedulingStrategy.DelayBounding;
                     base.Configuration.DelayBound = i;
                 }
-                else if (scheduler.StartsWith("rdb"))
+                else if (this.IsMatch(scheduler, @"rdb"))
                 {
                     int i = 0;
-                    if (scheduler.Equals("rdb") ||
+                    if (this.IsMatch(scheduler, @"rdb$") ||
                         !int.TryParse(scheduler.Substring(4), out i) && i >= 0)
                     {
                         Error.ReportAndExit("Please give a valid delay " +
-                            "bound '/sch:rdb:[bound]', where [bound] >= 0.");
+                            "bound '-sch:rdb:[bound]', where [bound] >= 0.");
                     }
 
                     base.Configuration.SchedulingStrategy = SchedulingStrategy.RandomDelayBounding;
@@ -138,154 +137,154 @@ namespace Microsoft.PSharp.Utilities
                 else
                 {
                     Error.ReportAndExit("Please give a valid scheduling strategy " +
-                        "'/sch:[x]', where [x] is 'random', 'pct' or 'dfs' (other " +
+                        "'-sch:[x]', where [x] is 'random', 'pct' or 'dfs' (other " +
                         "experimental strategies also exist, but are not listed here).");
                 }
             }
-            else if (option.ToLower().StartsWith("/replay:") && option.Length > 8)
+            else if (this.IsMatch(option, @"[\/|-]replay:") && option.Length > 8)
             {
                 string extension = System.IO.Path.GetExtension(option.Substring(8));
                 if (!extension.Equals(".schedule"))
                 {
                     Error.ReportAndExit("Please give a valid schedule file " +
-                        "'/replay:[x]', where [x] has extension '.schedule'.");
+                        "'-replay:[x]', where [x] has extension '.schedule'.");
                 }
 
                 base.Configuration.ScheduleFile = option.Substring(8);
             }
-            else if (option.ToLower().StartsWith("/reduction:"))
+            else if (this.IsMatch(option, @"[\/|-]reduction:"))
             {
-                string reduction = option.ToLower().Substring(11);
-                if (reduction.ToLower().Equals("none"))
+                string reduction = option.Substring(11);
+                if (this.IsMatch(reduction, @"none$"))
                 {
                     base.Configuration.ReductionStrategy = ReductionStrategy.None;
                 }
-                else if (reduction.ToLower().Equals("omit"))
+                else if (this.IsMatch(reduction, @"omit$"))
                 {
                     base.Configuration.ReductionStrategy = ReductionStrategy.OmitSchedulingPoints;
                 }
-                else if (reduction.ToLower().Equals("force"))
+                else if (this.IsMatch(reduction, @"force$"))
                 {
                     base.Configuration.ReductionStrategy = ReductionStrategy.ForceSchedule;
                 }
                 else
                 {
                     Error.ReportAndExit("Please give a valid reduction strategy " +
-                        "'/reduction:[x]', where [x] is 'none', 'omit' or 'force'.");
+                        "'-reduction:[x]', where [x] is 'none', 'omit' or 'force'.");
                 }
             }
-            else if (option.ToLower().StartsWith("/i:") && option.Length > 3)
+            else if (this.IsMatch(option, @"[\/|-]i:") && option.Length > 3)
             {
                 int i = 0;
                 if (!int.TryParse(option.Substring(3), out i) && i > 0)
                 {
                     Error.ReportAndExit("Please give a valid number of " +
-                        "iterations '/i:[x]', where [x] > 0.");
+                        "iterations '-i:[x]', where [x] > 0.");
                 }
 
                 base.Configuration.SchedulingIterations = i;
             }
-            else if (option.ToLower().StartsWith("/parallel:") && option.Length > 10)
+            else if (this.IsMatch(option, @"[\/|-]parallel:") && option.Length > 10)
             {
                 uint i = 0;
                 if (!uint.TryParse(option.Substring(10), out i) || i <= 1)
                 {
                     Error.ReportAndExit("Please give a valid number of " +
-                        "parallel tasks '/parallel:[x]', where [x] > 1.");
+                        "parallel tasks '-parallel:[x]', where [x] > 1.");
                 }
 
                 base.Configuration.ParallelBugFindingTasks = i;
             }
-            else if (option.ToLower().StartsWith("/run-as-parallel-testing-task"))
+            else if (this.IsMatch(option, @"[\/|-]run-as-parallel-testing-task$"))
             {
                 base.Configuration.RunAsParallelBugFindingTask = true;
             }
-            else if (option.ToLower().StartsWith("/testing-scheduler-endpoint:") && option.Length > 28)
+            else if (this.IsMatch(option, @"[\/|-]testing-scheduler-endpoint:") && option.Length > 28)
             {
                 string endpoint = option.Substring(28);
                 if (endpoint.Length != 36)
                 {
                     Error.ReportAndExit("Please give a valid testing scheduler endpoint " +
-                        "'/testing-scheduler-endpoint:[x]', where [x] is a unique GUID.");
+                        "'-testing-scheduler-endpoint:[x]', where [x] is a unique GUID.");
                 }
 
                 base.Configuration.TestingSchedulerEndPoint = endpoint;
             }
-            else if (option.ToLower().StartsWith("/testing-scheduler-process-id:") && option.Length > 30)
+            else if (this.IsMatch(option, @"[\/|-]testing-scheduler-process-id:") && option.Length > 30)
             {
                 int i = 0;
                 if (!int.TryParse(option.Substring(30), out i) && i >= 0)
                 {
                     Error.ReportAndExit("Please give a valid testing scheduler " +
-                        "process id '/testing-scheduler-process-id:[x]', where [x] >= 0.");
+                        "process id '-testing-scheduler-process-id:[x]', where [x] >= 0.");
                 }
 
                 base.Configuration.TestingSchedulerProcessId = i;
             }
-            else if (option.ToLower().StartsWith("/testing-process-id:") && option.Length > 20)
+            else if (this.IsMatch(option, @"[\/|-]testing-process-id:") && option.Length > 20)
             {
                 uint i = 0;
                 if (!uint.TryParse(option.Substring(20), out i) && i >= 0)
                 {
                     Error.ReportAndExit("Please give a valid testing " +
-                        "process id '/testing-process-id:[x]', where [x] >= 0.");
+                        "process id '-testing-process-id:[x]', where [x] >= 0.");
                 }
 
                 base.Configuration.TestingProcessId = i;
             }
-            else if (option.ToLower().Equals("/explore"))
+            else if (this.IsMatch(option, @"[\/|-]explore$"))
             {
                 base.Configuration.PerformFullExploration = true;
             }
-            else if (option.ToLower().Equals("/coverage"))
+            else if (this.IsMatch(option, @"[\/|-]coverage$"))
             {
                 base.Configuration.ReportCodeCoverage = true;
                 base.Configuration.ReportActivityCoverage = true;
             }
-            else if (option.ToLower().Equals("/coverage:code"))
+            else if (this.IsMatch(option, @"[\/|-]coverage:code$"))
             {
                 base.Configuration.ReportCodeCoverage = true;
             }
-            else if (option.ToLower().Equals("/coverage:activity"))
+            else if (this.IsMatch(option, @"[\/|-]coverage:activity$"))
             {
                 base.Configuration.ReportActivityCoverage = true;
             }
-            else if (option.ToLower().Equals("/coverage:activity-debug"))
+            else if (this.IsMatch(option, @"[\/|-]coverage:activity-debug$"))
             {
                 base.Configuration.ReportActivityCoverage = true;
                 base.Configuration.DebugActivityCoverage = true;
             }
-            else if (option.ToLower().StartsWith("/instr:"))
+            else if (this.IsMatch(option, @"[\/|-]instr:"))
             {
                 base.Configuration.AdditionalCodeCoverageAssemblies[option.Substring(7)] = false;
             }
-            else if (option.ToLower().StartsWith("/instr-list:"))
+            else if (this.IsMatch(option, @"[\/|-]instr-list:"))
             {
                 base.Configuration.AdditionalCodeCoverageAssemblies[option.Substring(12)] = true;
             }
-            else if (option.ToLower().Equals("/detect-races"))
+            else if (this.IsMatch(option, @"[\/|-]detect-races$"))
             {
                 base.Configuration.EnableDataRaceDetection = true;
             }
-            else if (option.ToLower().StartsWith("/sch-seed:") && option.Length > 10)
+            else if (this.IsMatch(option, @"[\/|-]sch-seed:") && option.Length > 10)
             {
                 int seed;
                 if (!int.TryParse(option.Substring(10), out seed))
                 {
                     Error.ReportAndExit("Please give a valid random scheduling " +
-                        "seed '/sch-seed:[x]', where [x] is a signed 32-bit integer.");
+                        "seed '-sch-seed:[x]', where [x] is a signed 32-bit integer.");
                 }
 
                 base.Configuration.RandomSchedulingSeed = seed;
             }
-            else if (option.ToLower().StartsWith("/max-steps:") && option.Length > 11)
+            else if (this.IsMatch(option, @"[\/|-]max-steps:") && option.Length > 11)
             {
                 int i = 0;
                 int j = 0;
                 var tokens = option.Split(new char[] { ':' }, System.StringSplitOptions.RemoveEmptyEntries);
                 if (tokens.Length > 3 || tokens.Length <= 1)
                 {
-                    Error.ReportAndExit("Invalid number of options supplied via '/max-steps'.");
+                    Error.ReportAndExit("Invalid number of options supplied via '-max-steps'.");
                 }
 
                 if (tokens.Length >= 2)
@@ -293,7 +292,7 @@ namespace Microsoft.PSharp.Utilities
                     if (!int.TryParse(tokens[1], out i) && i >= 0)
                     {
                         Error.ReportAndExit("Please give a valid number of max scheduling " +
-                            " steps to explore '/max-steps:[x]', where [x] >= 0.");
+                            " steps to explore '-max-steps:[x]', where [x] >= 0.");
                     }
                 }
 
@@ -302,7 +301,7 @@ namespace Microsoft.PSharp.Utilities
                     if (!int.TryParse(tokens[2], out j) && j >= 0)
                     {
                         Error.ReportAndExit("Please give a valid number of max scheduling " +
-                            " steps to explore '/max-steps:[x]:[y]', where [y] >= 0.");
+                            " steps to explore '-max-steps:[x]:[y]', where [y] >= 0.");
                     }
 
                     base.Configuration.UserExplicitlySetMaxFairSchedulingSteps = true;
@@ -315,37 +314,37 @@ namespace Microsoft.PSharp.Utilities
                 base.Configuration.MaxUnfairSchedulingSteps = i;
                 base.Configuration.MaxFairSchedulingSteps = j;
             }
-            else if (option.ToLower().Equals("/depth-bound-bug"))
+            else if (this.IsMatch(option, @"[\/|-]depth-bound-bug$"))
             {
                 base.Configuration.ConsiderDepthBoundHitAsBug = true;
             }
-            else if (option.ToLower().StartsWith("/prefix:") && option.Length > 8)
+            else if (this.IsMatch(option, @"[\/|-]prefix:") && option.Length > 8)
             {
                 int i = 0;
                 if (!int.TryParse(option.Substring(8), out i) && i >= 0)
                 {
                     Error.ReportAndExit("Please give a valid safety prefix " +
-                        "bound '/prefix:[x]', where [x] >= 0.");
+                        "bound '-prefix:[x]', where [x] >= 0.");
                 }
 
                 base.Configuration.SafetyPrefixBound = i;
             }
-            else if (option.ToLower().StartsWith("/liveness-temperature-threshold:") && option.Length > 32)
+            else if (this.IsMatch(option, @"[\/|-]liveness-temperature-threshold:") && option.Length > 32)
             {
                 int i = 0;
                 if (!int.TryParse(option.Substring(32), out i) && i >= 0)
                 {
                     Error.ReportAndExit("Please give a valid liveness temperature threshold " +
-                        "'/liveness-temperature-threshold:[x]', where [x] >= 0.");
+                        "'-liveness-temperature-threshold:[x]', where [x] >= 0.");
                 }
 
                 base.Configuration.LivenessTemperatureThreshold = i;
             }
-            else if (option.ToLower().Equals("/cycle-detection"))
+            else if (this.IsMatch(option, @"[\/|-]cycle-detection$"))
             {
                 base.Configuration.EnableCycleDetection = true;
             }
-            else if (option.ToLower().Equals("/custom-state-hashing"))
+            else if (this.IsMatch(option, @"[\/|-]custom-state-hashing$"))
             {
                 base.Configuration.EnableUserDefinedStateHashing = true;
             }
@@ -363,7 +362,7 @@ namespace Microsoft.PSharp.Utilities
             if (base.Configuration.AssemblyToBeAnalyzed.Equals(""))
             {
                 Error.ReportAndExit("Please give a valid path to a P# " +
-                    "program's dll using '/test:[x]'.");
+                    "program's dll using '-test:[x]'.");
             }
 
             if (base.Configuration.SchedulingStrategy != SchedulingStrategy.Interactive &&
@@ -380,13 +379,13 @@ namespace Microsoft.PSharp.Utilities
                 base.Configuration.SchedulingStrategy != SchedulingStrategy.RandomDelayBounding)
             {
                 Error.ReportAndExit("Please give a valid scheduling strategy " +
-                        "'/sch:[x]', where [x] is 'random' or 'pct' (other experimental " +
+                        "'-sch:[x]', where [x] is 'random' or 'pct' (other experimental " +
                         "strategies also exist, but are not listed here).");
             }
 
             if (base.Configuration.MaxFairSchedulingSteps < base.Configuration.MaxUnfairSchedulingSteps)
             {
-                Error.ReportAndExit("For the option '/max-steps:[N]:[M]', please make sure that [M] >= [N].");
+                Error.ReportAndExit("For the option '-max-steps:[N]:[M]', please make sure that [M] >= [N].");
             }
 
             if (base.Configuration.SafetyPrefixBound > 0 &&
@@ -401,7 +400,7 @@ namespace Microsoft.PSharp.Utilities
             {
                 Error.ReportAndExit("The Iterative Deepening DFS scheduler ('iddfs') " +
                     "must have a max scheduling steps bound, which can be given using " +
-                    "'/max-steps:[bound]', where [bound] > 0.");
+                    "'-max-steps:[bound]', where [bound] > 0.");
             }
 
 #if NETCOREAPP2_1
@@ -452,32 +451,32 @@ namespace Microsoft.PSharp.Utilities
             help += " --------------";
             help += "\n Basic options:";
             help += "\n --------------";
-            help += "\n  /?\t\t Show this help menu";
-            help += "\n  /test:[x]\t Path to the P# program to test";
-            help += "\n  /method:[x]\t Suffix of the test method to execute";
-            help += "\n  /timeout:[x]\t Timeout in seconds (disabled by default)";
-            help += "\n  /v:[x]\t Enable verbose mode (values from '1' to '3')";
-            help += "\n  /o:[x]\t Dump output to directory x (absolute path or relative to current directory)";
+            help += "\n  -?\t\t Show this help menu";
+            help += "\n  -test:[x]\t Path to the P# program to test";
+            help += "\n  -method:[x]\t Suffix of the test method to execute";
+            help += "\n  -timeout:[x]\t Timeout in seconds (disabled by default)";
+            help += "\n  -v:[x]\t Enable verbose mode (values from '1' to '3')";
+            help += "\n  -o:[x]\t Dump output to directory x (absolute path or relative to current directory)";
 
             help += "\n\n ---------------------------";
             help += "\n Systematic testing options:";
             help += "\n ---------------------------";
-            help += "\n  /i:[x]\t\t Number of schedules to explore for bugs";
-            help += "\n  /parallel:[x]\t\t Number of parallel testing tasks ('1' by default)";
-            help += "\n  /sch:[x]\t\t Choose a systematic testing strategy ('random' by default)";
-            help += "\n  /max-steps:[x]\t Max scheduling steps to be explored (disabled by default)";
-            help += "\n  /replay:[x]\t Tries to replay the schedule, and then switches to the specified strategy";
+            help += "\n  -i:[x]\t\t Number of schedules to explore for bugs";
+            help += "\n  -parallel:[x]\t\t Number of parallel testing tasks ('1' by default)";
+            help += "\n  -sch:[x]\t\t Choose a systematic testing strategy ('random' by default)";
+            help += "\n  -max-steps:[x]\t Max scheduling steps to be explored (disabled by default)";
+            help += "\n  -replay:[x]\t Tries to replay the schedule, and then switches to the specified strategy";
 
             help += "\n\n ---------------------------";
             help += "\n Testing code coverage options:";
             help += "\n ---------------------------";
-            help += "\n  /coverage:code\t Generate code coverage statistics (via VS instrumentation)";
-            help += "\n  /coverage:activity\t Generate activity (machine, event, etc.) coverage statistics";
-            help += "\n  /coverage\t Generate both code and activity coverage statistics";
-            help += "\n  /coverage:activity-debug\t Print activity coverage statistics with debug info";
-            help += "\n  /instr:[filespec]\t Additional file spec(s) to instrument for /coverage:code; wildcards supported";
-            help += "\n  /instr-list:[listfilename]\t File containing the names of additional file(s), one per line,";
-            help += "\n         wildcards supported, to instrument for /coverage:code; lines starting with '//' are skipped";
+            help += "\n  -coverage:code\t Generate code coverage statistics (via VS instrumentation)";
+            help += "\n  -coverage:activity\t Generate activity (machine, event, etc.) coverage statistics";
+            help += "\n  -coverage\t Generate both code and activity coverage statistics";
+            help += "\n  -coverage:activity-debug\t Print activity coverage statistics with debug info";
+            help += "\n  -instr:[filespec]\t Additional file spec(s) to instrument for -coverage:code; wildcards supported";
+            help += "\n  -instr-list:[listfilename]\t File containing the names of additional file(s), one per line,";
+            help += "\n         wildcards supported, to instrument for -coverage:code; lines starting with '//' are skipped";
 
             help += "\n";
 


### PR DESCRIPTION
Someone can now do either (for example) `/i:10` or `-i:10`. By default, the tool instructions now suggest to use `-`. This affects the tester, replayer and compiler.