### PR TITLE
Fixed corner case in synchronous APIs

### DIFF
--- a/Source/TestingServices/Engines/AbstractTestingEngine.cs
+++ b/Source/TestingServices/Engines/AbstractTestingEngine.cs
@@ -482,7 +482,6 @@ namespace Microsoft.PSharp.TestingServices
             BindingFlags flags = BindingFlags.Static | BindingFlags.Public | BindingFlags.DeclaredOnly | BindingFlags.InvokeMethod;
             List<MethodInfo> testMethods = this.FindTestMethodsWithAttribute(typeof(Test), flags, this.Assembly);
 
-
             // Filter by test method name
             var filteredTestMethods = testMethods
                 .FindAll(mi => string.Format("{0}.{1}", mi.DeclaringType.FullName, mi.Name)

--- a/Source/TestingServices/Events/QuiescentEvent.cs
+++ b/Source/TestingServices/Events/QuiescentEvent.cs
@@ -8,19 +8,20 @@ using System.Runtime.Serialization;
 namespace Microsoft.PSharp
 {
     /// <summary>
-    /// Signals that a machine has reached Quiescence
+    /// Signals that a machine has reached quiescence.
     /// </summary>
     [DataContract]
     internal sealed class QuiescentEvent : Event
     {
         /// <summary>
-        /// MachineId
+        /// The id of the machine that has reached quiescence.
         /// </summary>
         public MachineId mid;
 
         /// <summary>
-        /// Constructor.
+        /// Creates a new instance of the <see cref="QuiescentEvent"/> class.
         /// </summary>
+        /// <param name="mid">The id of the machine that has reached quiescence.</param>
         public QuiescentEvent(MachineId mid)
             : base()
         {

--- a/Source/TestingServices/Runtime/TestingRuntime.cs
+++ b/Source/TestingServices/Runtime/TestingRuntime.cs
@@ -830,7 +830,6 @@ namespace Microsoft.PSharp.TestingServices
 
                     if (syncCaller != null)
                     {
-                        //this.SendEvent(syncCaller.Id, new QuiescentEvent(machine.Id));
                         bool runNewHandler = false;
                         var operationGroupId = base.GetNewOperationGroupId(machine, machine.Info.OperationGroupId);
                         this.EnqueueEvent(syncCaller, new QuiescentEvent(machine.Id), machine, operationGroupId, false, ref runNewHandler);

--- a/Source/TestingServices/Scheduling/BugFindingScheduler.cs
+++ b/Source/TestingServices/Scheduling/BugFindingScheduler.cs
@@ -143,7 +143,7 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
                     this.ScheduledMachine.IsActive = true;
                     System.Threading.Monitor.PulseAll(next);
                 }
-                
+
                 lock (current)
                 {
                     if (!current.IsEventHandlerRunning)
@@ -195,7 +195,7 @@ namespace Microsoft.PSharp.TestingServices.Scheduling
             {
                 this.Runtime.ScheduleTrace.AddFairNondeterministicBooleanChoice(uniqueId, choice);
             }
-            
+
             return choice;
         }
 

--- a/Tests/TestingServices.Tests.Unit/Features/OnExceptionTest.cs
+++ b/Tests/TestingServices.Tests.Unit/Features/OnExceptionTest.cs
@@ -88,7 +88,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
 
             async Task Act()
             {
-                await Task.Yield();
+                await Task.Delay(10);
                 throw new Ex1();
             }
 


### PR DESCRIPTION
Also fixes a buggy test (that was using `Task.Yield`), and suppresses a benign rare issue where the tester is disposing the logger but the runtime still tries to write which causes an exception to be thrown (this is still reported when using `/debug` for our own debugging purposes).

Also fixes some minor styling issues.