### PR TITLE
Disabled assert on sending QuisceEvent

### DIFF
--- a/Common/version.props
+++ b/Common/version.props
@@ -1,7 +1,7 @@
 <!-- This file may be overwritten by automation. Only values allowed here are VersionPrefix and VersionSuffix.  -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.4.3</VersionPrefix>
+    <VersionPrefix>1.4.4</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/Scripts/NuGet/PSharp.nuspec
+++ b/Scripts/NuGet/PSharp.nuspec
@@ -2,13 +2,13 @@
 <package >
   <metadata>
     <id>Microsoft.PSharp</id>
-    <version>1.4.3</version>
+    <version>1.4.4</version>
     <authors>Microsoft</authors>
     <licenseUrl>https://github.com/p-org/PSharp/blob/master/LICENSE.txt</licenseUrl>
     <projectUrl>https://github.com/p-org/PSharp</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>The P# language, runtime and testing infrastructure.</description>
-    <releaseNotes>This release contains the 1.4.3 version of the P# language, runtime and testing infrastructure.</releaseNotes>
+    <releaseNotes>This release contains the 1.4.4 version of the P# language, runtime and testing infrastructure.</releaseNotes>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <tags>asynchrony testing .NET programming actors state-machines</tags>
   </metadata>

--- a/Source/Core/Configuration.cs
+++ b/Source/Core/Configuration.cs
@@ -311,6 +311,13 @@ namespace Microsoft.PSharp
         [DataMember]
         public bool AttachDebugger;
 
+        /// <summary>
+        /// Enables the testing assertion that raise/goto/push/pop must 
+        /// be the last P# API called in an event handler.
+        /// </summary>
+        [DataMember]
+        public bool EnableRaiseMustBeLastAssert;
+
         #endregion
 
         #region trace replay options
@@ -512,6 +519,7 @@ namespace Microsoft.PSharp
             this.EnableCycleDetection = false;
             this.EnableUserDefinedStateHashing = false;
             this.EnableMonitorsInProduction = false;
+            this.EnableRaiseMustBeLastAssert = true;
 
             this.AttachDebugger = false;
 

--- a/Source/Core/Configuration.cs
+++ b/Source/Core/Configuration.cs
@@ -312,11 +312,11 @@ namespace Microsoft.PSharp
         public bool AttachDebugger;
 
         /// <summary>
-        /// Enables the testing assertion that raise/goto/push/pop must 
-        /// be the last P# API called in an event handler.
+        /// Enables the testing assertion that a raise/goto/push/pop transition must 
+        /// be the last API called in an event handler.
         /// </summary>
         [DataMember]
-        public bool EnableRaiseMustBeLastAssert;
+        public bool EnableNoApiCallAfterTransitionStmtAssertion;
 
         #endregion
 
@@ -519,7 +519,7 @@ namespace Microsoft.PSharp
             this.EnableCycleDetection = false;
             this.EnableUserDefinedStateHashing = false;
             this.EnableMonitorsInProduction = false;
-            this.EnableRaiseMustBeLastAssert = true;
+            this.EnableNoApiCallAfterTransitionStmtAssertion = true;
 
             this.AttachDebugger = false;
 

--- a/Source/TestingServices/Runtime/TestingRuntime.cs
+++ b/Source/TestingServices/Runtime/TestingRuntime.cs
@@ -1049,9 +1049,9 @@ namespace Microsoft.PSharp.TestingServices
         /// <param name="calledAPI">Called API</param>
         internal void AssertNoPendingTransitionStatement(Machine machine, string calledAPI)
         {
-            if(!this.Configuration.EnableRaiseMustBeLastAssert)
+            if (!this.Configuration.EnableNoApiCallAfterTransitionStmtAssertion)
             {
-                // check disabled
+                // The check is disabled.
                 return;
             }
 

--- a/Tests/TestingServices.Tests.Unit/RuntimeInterface/SendAndExecuteTest8.cs
+++ b/Tests/TestingServices.Tests.Unit/RuntimeInterface/SendAndExecuteTest8.cs
@@ -31,12 +31,10 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
                 var handled = await this.Runtime.SendEventAndExecute(m, new E1());
                 this.Assert(handled);
             }
-
         }
 
         class M : Machine
         {
-
             [Start]
             [OnEventDoAction(typeof(E1), nameof(Handle))]
             [IgnoreEvents(typeof(E2))]
@@ -57,6 +55,5 @@ namespace Microsoft.PSharp.TestingServices.Tests.Unit
 
             base.AssertSucceeded(test);
         }
-
     }
 }

--- a/Tests/TestingServices.Tests.Unit/RuntimeInterface/SendAndExecuteTest8.cs
+++ b/Tests/TestingServices.Tests.Unit/RuntimeInterface/SendAndExecuteTest8.cs
@@ -1,0 +1,62 @@
+﻿// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.PSharp.TestingServices.Tests.Unit
+{
+    public class SendAndExecuteTest8 : BaseTest
+    {
+        public SendAndExecuteTest8(ITestOutputHelper output)
+            : base(output)
+        { }
+
+        class E1 : Event { }
+        class E2 : Event { }
+
+        class Harness : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            class Init : MachineState { }
+
+            async Task InitOnEntry()
+            {
+                var m = await this.Runtime.CreateMachineAndExecute(typeof(M));
+                var handled = await this.Runtime.SendEventAndExecute(m, new E1());
+                this.Assert(handled);
+            }
+
+        }
+
+        class M : Machine
+        {
+
+            [Start]
+            [OnEventDoAction(typeof(E1), nameof(Handle))]
+            [IgnoreEvents(typeof(E2))]
+            class Init : MachineState { }
+
+            void Handle()
+            {
+                this.Raise(new E2());
+            }
+        }
+
+        [Fact]
+        public void TestUnhandledEventOnSendExec()
+        {
+            var test = new Action<PSharpRuntime>((r) => {
+                r.CreateMachine(typeof(Harness));
+            });
+
+            base.AssertSucceeded(test);
+        }
+
+    }
+}

--- a/Tools/Visualization/TraceViewer/Properties/AssemblyInfo.cs
+++ b/Tools/Visualization/TraceViewer/Properties/AssemblyInfo.cs
@@ -52,5 +52,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.4.3.0")]
-[assembly: AssemblyFileVersion("1.4.3.0")]
+[assembly: AssemblyVersion("1.4.4.0")]
+[assembly: AssemblyFileVersion("1.4.4.0")]


### PR DESCRIPTION
Disabled the assert that P# APi cannot be called after an raise/goto/pop/push, when sending the quiesce event. That is not applicable because the event handler has necessarily finished by then.