### PR TITLE
added exit codes for the tester

### DIFF
--- a/Source/TestingServices/Engines/BugFindingEngine.cs
+++ b/Source/TestingServices/Engines/BugFindingEngine.cs
@@ -79,8 +79,17 @@ namespace Microsoft.PSharp.TestingServices
         /// <returns>ITestingEngine</returns>
         public override ITestingEngine Run()
         {
-            Task task = this.CreateBugFindingTask();
-            this.Execute(task);
+            try
+            {
+                Task task = this.CreateBugFindingTask();
+                this.Execute(task);
+            }
+            catch (Exception ex)
+            {
+                base.Logger.WriteLine($"... Task {this.Configuration.TestingProcessId} failed due to an internal error: {ex}");
+                this.TestReport.InternalErrors.Add(ex.ToString());
+            }
+
             return this;
         }
 

--- a/Source/TestingServices/Statistics/TestReport.cs
+++ b/Source/TestingServices/Statistics/TestReport.cs
@@ -50,7 +50,7 @@ namespace Microsoft.PSharp.TestingServices
         public int NumOfFoundBugs { get; internal set; }
 
         /// <summary>
-        /// List of unique bug reports.
+        /// Set of unique bug reports.
         /// </summary>
         [DataMember]
         public HashSet<string> BugReports { get; internal set; }
@@ -98,9 +98,16 @@ namespace Microsoft.PSharp.TestingServices
         public int MaxUnfairStepsHitInUnfairTests { get; internal set; }
 
         /// <summary>
+        /// Set of internal errors. If no internal errors
+        /// occurred, then this set is empty.
+        /// </summary>
+        [DataMember]
+        public HashSet<string> InternalErrors { get; internal set; }
+
+        /// <summary>
         /// Lock for the test report.
         /// </summary>
-        private object Lock;
+        private readonly object Lock;
 
         #endregion
 
@@ -127,6 +134,8 @@ namespace Microsoft.PSharp.TestingServices
             this.MaxFairStepsHitInFairTests = 0;
             this.MaxUnfairStepsHitInFairTests = 0;
             this.MaxUnfairStepsHitInUnfairTests = 0;
+
+            this.InternalErrors = new HashSet<string>();
 
             this.Lock = new object();
         }
@@ -177,6 +186,8 @@ namespace Microsoft.PSharp.TestingServices
                 this.MaxFairStepsHitInFairTests += testReport.MaxFairStepsHitInFairTests;
                 this.MaxUnfairStepsHitInFairTests += testReport.MaxUnfairStepsHitInFairTests;
                 this.MaxUnfairStepsHitInUnfairTests += testReport.MaxUnfairStepsHitInUnfairTests;
+
+                this.InternalErrors.UnionWith(testReport.InternalErrors);
             }
 
             return true;

--- a/Tools/Testing/Tester/Program.cs
+++ b/Tools/Testing/Tester/Program.cs
@@ -32,7 +32,7 @@ namespace Microsoft.PSharp
             {
                 // Creates and runs a testing process.
                 TestingProcess testingProcess = TestingProcess.Create(configuration);
-                testingProcess.Start();
+                testingProcess.Run();
                 return;
             }
 
@@ -64,6 +64,9 @@ namespace Microsoft.PSharp
             Output.WriteLine(". Done");
         }
 
+        /// <summary>
+        /// Shutdowns any active monitors.
+        /// </summary>
         static void Shutdown()
         {
 #if NET46 || NET45
@@ -76,13 +79,18 @@ namespace Microsoft.PSharp
 #endif
         }
 
+        /// <summary>
+        /// Cancels the testing process.
+        /// </summary>
         static void CancelProcess()
         {
             if (TestingProcessScheduler.ProcessCanceled)
             {
                 return;
             }
+
             TestingProcessScheduler.ProcessCanceled = true;
+
 #if NET46 || NET45
             var monitorMessage = CodeCoverageMonitor.IsRunning ? " Shutting down the code coverage monitor (this may take a few seconds)..." : string.Empty;
 #else

--- a/Tools/Testing/Tester/Scheduling/TestingProcessScheduler.cs
+++ b/Tools/Testing/Tester/Scheduling/TestingProcessScheduler.cs
@@ -186,7 +186,7 @@ namespace Microsoft.PSharp.TestingServices
         /// Creates a new P# testing process scheduler.
         /// </summary>
         /// <param name="configuration">Configuration</param>
-        /// <returns>TestingProcessScheduler</returns>
+        /// <returns>The testing process scheduler.</returns>
         internal static TestingProcessScheduler Create(Configuration configuration)
         {
             return new TestingProcessScheduler(configuration);
@@ -225,9 +225,9 @@ namespace Microsoft.PSharp.TestingServices
             this.CloseNotificationListener();
 #endif
 
-            // Merges and emits the test report.
             if (!ProcessCanceled)
             {
+                // Merges and emits the test report.
                 this.EmitTestReport();
             }
         }
@@ -285,8 +285,8 @@ namespace Microsoft.PSharp.TestingServices
 
             Output.WriteLine($"... Created '1' testing task.");
 
-            // Starts the testing process.
-            testingProcess.Start();
+            // Runs the testing process.
+            testingProcess.Run();
 
             // Get and merge the test report.
             TestReport testReport = this.GetTestReport(0);
@@ -466,6 +466,7 @@ namespace Microsoft.PSharp.TestingServices
 
             if (this.TestReports.Count == 0)
             {
+                Environment.ExitCode = (int)ExitCode.InternalError;
                 return;
             }
 
@@ -488,6 +489,19 @@ namespace Microsoft.PSharp.TestingServices
 
             Output.WriteLine(this.GlobalTestReport.GetText(this.Configuration, "..."));
             Output.WriteLine($"... Elapsed {this.Profiler.Results()} sec.");
+
+            if (this.GlobalTestReport.InternalErrors.Count > 0)
+            {
+                Environment.ExitCode = (int)ExitCode.InternalError;
+            }
+            else if (this.GlobalTestReport.NumOfFoundBugs > 0)
+            {
+                Environment.ExitCode = (int)ExitCode.BugFound;
+            }
+            else
+            {
+                Environment.ExitCode = (int)ExitCode.Success;
+            }
         }
     }
 }

--- a/Tools/Testing/Tester/Testing/TestingProcess.cs
+++ b/Tools/Testing/Tester/Testing/TestingProcess.cs
@@ -79,9 +79,9 @@ namespace Microsoft.PSharp.TestingServices
         }
 
         /// <summary>
-        /// Starts the P# testing process.
+        /// Runs the P# testing process.
         /// </summary>
-        internal void Start()
+        internal void Run()
         {
 #if NET46 || NET45
             // Opens the remote notification listener.
@@ -100,12 +100,13 @@ namespace Microsoft.PSharp.TestingServices
 #if NET46 || NET45
             if (this.Configuration.RunAsParallelBugFindingTask)
             {
-                if (this.TestingEngine.TestReport.NumOfFoundBugs > 0)
+                if (this.TestingEngine.TestReport.InternalErrors.Count > 0)
                 {
-                    // A bug was found, set the exit code to a non-zero error code for general processing.
-                    // See https://msdn.microsoft.com/en-gb/library/windows/desktop/ms681381(v=vs.85).aspx
-                    Environment.ExitCode = 13804;
-
+                    Environment.ExitCode = (int)ExitCode.InternalError;
+                }
+                else if (this.TestingEngine.TestReport.NumOfFoundBugs > 0)
+                {
+                    Environment.ExitCode = (int)ExitCode.BugFound;
                     this.NotifyBugFound();
                 }
 

--- a/Tools/Testing/Tester/Utilities/ExitCode.cs
+++ b/Tools/Testing/Tester/Utilities/ExitCode.cs
@@ -1,0 +1,28 @@
+﻿// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace Microsoft.PSharp.TestingServices
+{
+    /// <summary>
+    /// The exit code returned by the tester.
+    /// </summary>
+    public enum ExitCode
+    {
+        /// <summary>
+        /// Indicates that no bugs were found.
+        /// </summary>
+        Success = 0,
+
+        /// <summary>
+        /// Indicates that a bug was found.
+        /// </summary>
+        BugFound = 1,
+
+        /// <summary>
+        /// Indicates that an internal exception was thrown.
+        /// </summary>
+        InternalError = 2
+    }
+}


### PR DESCRIPTION
The exit codes are:

`0` for success (no bugs found)
`1` for bug(s) found
`2` for internal error

Also fixed a bit the behavior of when an internal error occurs. Now internal errors are captured as strings in the test report, and the tester does not crash, instead tries to exit gracefully.