### PR TITLE
refactored the P# runtime to expose an interface

### DIFF
--- a/Docs/Features/Logging.md
+++ b/Docs/Features/Logging.md
@@ -2,13 +2,13 @@ Logging in P#
 =============
 By default, the P# runtime logger writes all log output to `Console` during production (when verbosity is enabled). During testing, the log output is redirected to an in-memory writer (which dumps it to a file when a bug is found).
 
-The runtime logger can be accessed via the following `PSharpRuntime`, `Machine` or `Monitor` property:
+The runtime logger can be accessed via the following `IMachineRuntime`, `Machine` or `Monitor` property:
 ```C#
 ILogger Logger { get; }
 ```
 
 # Using a custom logger
-It is possible to replace the default P# runtime logger with a custom one that implements the `ILogger` interface:
+It is possible to replace the default P# runtime logger with a custom one that implements the `ILogger` and `IDisposable` interfaces:
 ```C#
 public interface ILogger : IDisposable
 {
@@ -18,16 +18,10 @@ public interface ILogger : IDisposable
   void WriteLine(string format, params object[] args);
 }
 ```
-
-To replace the runtime logger, call the following `PSharpRuntime` method:
+To replace the default runtime logger, call the following `IMachineRuntime` method:
 ```C#
 void SetLogger(ILogger logger);
 ```
 The above method replaces the previously installed logger, and installs the specified logger.
 
-To remove the installed logger, and replace it with the default runtime one, call the following `PSharpRuntime` method:
-```C#
-void RemoveLogger();
-```
-
-Note that `SetLogger` and `RemoveLogger` are _not_ calling `Dispose` on the previously installed logger. This must be called explicitly by the user. This allows the logger to be accessed and used after being removed from the P# runtime.
+Note that `SetLogger` is _not_ calling `Dispose` on the previously installed logger. This must be called explicitly by the user. This allows the logger to be accessed and used after being removed from the P# runtime.

--- a/Docs/Features/TrackingOperationGroups.md
+++ b/Docs/Features/TrackingOperationGroups.md
@@ -1,6 +1,6 @@
 Tracking operation groups
 =========================
-For some applications, it is useful to know which machine is processing an event derived from some user request. P# offers the notion of an _operations group_ that can be tracked automatically. The following `PSharpRuntime` APIs take an optional `Guid` parameter.
+For some applications, it is useful to know which machine is processing an event derived from some user request. P# offers the notion of an _operations group_ that can be tracked automatically. The following `IMachineRuntime` APIs take an optional `Guid` parameter.
 
 ```C#
 public MachineId CreateMachine(Type type, Event e = null, Guid? operationGroupId = null);
@@ -13,7 +13,7 @@ When the user passes a non-null operation group, the runtime takes care of propa
 Guid OperationGroupId;
 ```
 
-Additionally one may use the following `PSharpRuntime` API to get the operations group of a machine. However, the user must ensure that `currentMachine` is the currently executing machine (otherwise `PSharpTester` will report an assertion failure).
+Additionally one may use the following `IMachineRuntime` API to get the operations group of a machine. However, the user must ensure that `currentMachine` is the currently executing machine (otherwise `PSharpTester` will report an assertion failure).
 
 ```C#
 public Guid GetCurrentOperationGroupId(MachineId currentMachine);

--- a/Docs/Testing/TestingAsyncAwait.md
+++ b/Docs/Testing/TestingAsyncAwait.md
@@ -50,7 +50,7 @@ Note: Similar scenarios also exist very commonly inside the operating systems su
 To use `PSharpTester` we must tame the `C#` code and work towards exposing the concurrency to P#. First and foremost, _the code must not spawn `Tasks` (same applies to `Threads`)_. This is the most important rule to follow. Creation of `Tasks` will surely make `PSharpTester` unusable. To eliminate `Task` creation, try replacing them with `Machine` creation instead, which should work for the most part. For our running example, we modify our `Test` method to instead create machines:
 ```C#
 [Microsoft.PSharp.Test]
-void Test(PSharpRuntime runtime)
+void Test(IMachineRuntime runtime)
 {
    runtime.CreateMachine(typeof(RunTask), new TaskPayload(async () => await HandleRequest1(...)));
    runtime.CreateMachine(typeof(RunTask), new TaskPayload(async () => await HandleRequest2(...)));

--- a/Docs/Testing/TestingMethodology.md
+++ b/Docs/Testing/TestingMethodology.md
@@ -21,7 +21,7 @@ Read [here](#reproducing-and-debugging-traces) to learn how to reproduce traces 
 A P# test method can be declared as follows:
 ```c#
 [Microsoft.PSharp.Test]
-public static void Execute(PSharpRuntime runtime)
+public static void Execute(IMachineRuntime runtime)
 {
   runtime.RegisterMonitor(typeof(SomeMonitor));
   runtime.CreateMachine(typeof(SomeMachine));

--- a/Docs/WriteFirstProgram.md
+++ b/Docs/WriteFirstProgram.md
@@ -173,17 +173,18 @@ Because P# is built on top of the C# language, the entry point of a P# program (
 using Microsoft.PSharp;
 public class HostProgram {
   static void Main(string[] args) {
-    PSharpRuntime.Create().CreateMachine(typeof(Server));
+    IMachineRuntime runtime = PSharpRuntime.Create();
+    runtime.CreateMachine(typeof(Server));
     Console.ReadLine();
   }
 }
 ```
 
-The developer must first import the P# runtime library (`Microsoft.PSharp.dll`), then create a `PSharpRuntime` instance, and finally invoke the `CreateMachine` runtime method to instantiate the first P# machine (`Server` in the above example).
+The developer must first import the P# runtime library (`Microsoft.PSharp.dll`), then create a `runtime` instance (of type `IMachineRuntime`), and finally invoke the `CreateMachine` method of `runtime` to instantiate the first P# machine (`Server` in the above example).
 
-The `CreateMachine` method is part of the .NET interoperability API (a set of methods for calling P# from native C# code) that is exposed by `PSharpRuntime`. This method accepts as a parameter the type of the machine to be instantiated, and returns an object of the `MachineId` type, which contains a reference to the created P# machine. Because `CreateMachine` is an asynchronous method, we call the `Console.ReadLine` method, which pauses the main thread until a console input has been given, so that the host C# program does not exit prematurely.
+The `CreateMachine` method accepts as a parameter the type of the machine to be instantiated, and returns an object of the `MachineId` type, which contains a reference to the created P# machine. Because `CreateMachine` is an asynchronous method, we call the `Console.ReadLine` method, which pauses the main thread until a console input has been given, so that the host C# program does not exit prematurely.
 
-The `PSharpRuntime` .NET interoperability API also provides the `SendEvent` method for sending events to a P# machine from native C#. This method accepts as parameters an object of type `MachineId`, an event and an optional payload. Although the developer has to use `CreateMachine` and `SendEvent` to call P# code from native C#, the opposite is straightforward, as it only requires accessing a C# object from P# code.
+The `IMachineRuntime` interface also provides the `SendEvent` method for sending events to a P# machine from C#. This method accepts as parameters an object of type `MachineId`, an event and an optional payload. Although the developer has to use `CreateMachine` and `SendEvent` to interact with the P# runtime from C#, the opposite is straightforward, as it only requires accessing a C# object from inside a P# machine.
 
 ## Using P# as a C# library
 The above example can be written using P# as a C# library as follows:

--- a/Samples/Framework/BoundedAsync/Test.cs
+++ b/Samples/Framework/BoundedAsync/Test.cs
@@ -39,7 +39,7 @@ namespace BoundedAsync
         }
 
         [Microsoft.PSharp.Test]
-        public static void Execute(PSharpRuntime runtime)
+        public static void Execute(IMachineRuntime runtime)
         {
             runtime.CreateMachine(typeof(Scheduler), new Scheduler.Config(3));
         }

--- a/Samples/Framework/CacheCoherence/Test.cs
+++ b/Samples/Framework/CacheCoherence/Test.cs
@@ -38,7 +38,7 @@ namespace CacheCoherence
         }
 
         [Microsoft.PSharp.Test]
-        public static void Execute(PSharpRuntime runtime)
+        public static void Execute(IMachineRuntime runtime)
         {
             runtime.CreateMachine(typeof(Host));
         }

--- a/Samples/Framework/ChainReplication/Test.cs
+++ b/Samples/Framework/ChainReplication/Test.cs
@@ -38,7 +38,7 @@ namespace ChainReplication
         }
 
         [Microsoft.PSharp.Test]
-        public static void Execute(PSharpRuntime runtime)
+        public static void Execute(IMachineRuntime runtime)
         {
             runtime.RegisterMonitor(typeof(InvariantMonitor));
             runtime.RegisterMonitor(typeof(ServerResponseSeqMonitor));

--- a/Samples/Framework/Chord/Test.cs
+++ b/Samples/Framework/Chord/Test.cs
@@ -38,7 +38,7 @@ namespace Chord
         }
 
         [Microsoft.PSharp.Test]
-        public static void Execute(PSharpRuntime runtime)
+        public static void Execute(IMachineRuntime runtime)
         {
             runtime.RegisterMonitor(typeof(LivenessMonitor));
             runtime.CreateMachine(typeof(ClusterManager));

--- a/Samples/Framework/FailureDetector/Test.cs
+++ b/Samples/Framework/FailureDetector/Test.cs
@@ -40,7 +40,7 @@ namespace FailureDetector
         }
 
         [Microsoft.PSharp.Test]
-        public static void Execute(PSharpRuntime runtime)
+        public static void Execute(IMachineRuntime runtime)
         {
             // Monitors must be registered before the first P# machine
             // gets created (which will kickstart the runtime).

--- a/Samples/Framework/MultiPaxos/Test.cs
+++ b/Samples/Framework/MultiPaxos/Test.cs
@@ -38,7 +38,7 @@ namespace MultiPaxos
         }
 
         [Microsoft.PSharp.Test]
-        public static void Execute(PSharpRuntime runtime)
+        public static void Execute(IMachineRuntime runtime)
         {
             runtime.RegisterMonitor(typeof(ValidityCheck));
             runtime.CreateMachine(typeof(GodMachine));

--- a/Samples/Framework/PingPong.AsyncAwait/Test.cs
+++ b/Samples/Framework/PingPong.AsyncAwait/Test.cs
@@ -47,9 +47,9 @@ namespace PingPong.AsyncAwait
         /// P# non-determinstic choices) and systematically executes the test method a user
         /// specified number of iterations to detect bugs.
         /// </summary>
-        /// <param name="runtime">PSharpRuntime</param>
+        /// <param name="runtime">The machine runtime.</param>
         [Microsoft.PSharp.Test]
-        public static void Execute(PSharpRuntime runtime)
+        public static void Execute(IMachineRuntime runtime)
         {
             // This is the root machine to the P# PingPong program. CreateMachine
             // executes asynchronously (i.e. non-blocking).

--- a/Samples/Framework/PingPong/Test.cs
+++ b/Samples/Framework/PingPong/Test.cs
@@ -47,9 +47,9 @@ namespace PingPong
         /// P# non-determinstic choices) and systematically executes the test method a user
         /// specified number of iterations to detect bugs.
         /// </summary>
-        /// <param name="runtime">PSharpRuntime</param>
+        /// <param name="runtime">The machine runtime.</param>
         [Microsoft.PSharp.Test]
-        public static void Execute(PSharpRuntime runtime)
+        public static void Execute(IMachineRuntime runtime)
         {
             // This is the root machine to the P# PingPong program. CreateMachine
             // executes asynchronously (i.e. non-blocking).

--- a/Samples/Framework/Raft/Test.cs
+++ b/Samples/Framework/Raft/Test.cs
@@ -37,7 +37,7 @@ namespace Raft
         }
 
         [Microsoft.PSharp.Test]
-        public static void Execute(PSharpRuntime runtime)
+        public static void Execute(IMachineRuntime runtime)
         {
             runtime.RegisterMonitor(typeof(SafetyMonitor));
             runtime.CreateMachine(typeof(ClusterManager));

--- a/Samples/Framework/ReplicatingStorage/Test.cs
+++ b/Samples/Framework/ReplicatingStorage/Test.cs
@@ -41,7 +41,7 @@ namespace ReplicatingStorage
         }
 
         [Microsoft.PSharp.Test]
-        public static void Execute(PSharpRuntime runtime)
+        public static void Execute(IMachineRuntime runtime)
         {
             runtime.RegisterMonitor(typeof(LivenessMonitor));
             runtime.CreateMachine(typeof(Environment));

--- a/Samples/Framework/SendAndReceive/GenericSendAndReceiveMachine.cs
+++ b/Samples/Framework/SendAndReceive/GenericSendAndReceiveMachine.cs
@@ -24,12 +24,12 @@ namespace SendAndReceive
         /// <param name="runtime">The runtime.</param>
         /// <param name="mid">Target machine id.</param>
         /// <param name="ev">Event to send whose respose we're interested in getting.</param>
-        public static async Task<T> GetResponse(PSharpRuntime runtime, MachineId mid, Func<MachineId, Event> ev)
+        public static async Task<T> GetResponse(IMachineRuntime runtime, MachineId mid, Func<MachineId, Event> ev)
         {
             var conf = new Config(mid, ev);
             // This method awaits until the GetResponseMachine finishes its Execute method
-            await runtime.CreateMachineAndExecute(typeof(GetReponseMachine<T>), conf);
-            // Safety return the result back (no race condition here)
+            await runtime.CreateMachineAndExecuteAsync(typeof(GetReponseMachine<T>), conf);
+            // Safely return the result back (no race condition here)
             return conf.ReceivedEvent;
         }
 

--- a/Samples/Framework/SendAndReceive/Test.cs
+++ b/Samples/Framework/SendAndReceive/Test.cs
@@ -33,7 +33,7 @@ namespace SendAndReceive
         /// </summary>
         /// <param name="runtime">The P# runtime.</param>
         /// <param name="mid">Machine to get response from.</param>
-        static async Task GetDataAndPrint(PSharpRuntime runtime, MachineId mid)
+        static async Task GetDataAndPrint(IMachineRuntime runtime, MachineId mid)
         {
             var resp = await GetReponseMachine<M1.Response>.GetResponse(runtime, mid, m => new M1.Get(m));
             Console.WriteLine("Got response: {0}", resp.v);

--- a/Samples/Framework/Timers/Test.cs
+++ b/Samples/Framework/Timers/Test.cs
@@ -28,7 +28,7 @@ namespace Timers
         }
 
         [Microsoft.PSharp.Test]
-        public static void Execute(PSharpRuntime runtime)
+        public static void Execute(IMachineRuntime runtime)
         {
             runtime.CreateMachine(typeof(Client));
         }

--- a/Samples/Framework/TwoPhaseCommit/Test.cs
+++ b/Samples/Framework/TwoPhaseCommit/Test.cs
@@ -38,7 +38,7 @@ namespace TwoPhaseCommit
         }
 
         [Microsoft.PSharp.Test]
-        public static void Execute(PSharpRuntime runtime)
+        public static void Execute(IMachineRuntime runtime)
         {
             runtime.CreateMachine(typeof(TwoPhaseCommit));
         }

--- a/Samples/Language/BoundedAsync/Test.cs
+++ b/Samples/Language/BoundedAsync/Test.cs
@@ -39,7 +39,7 @@ namespace BoundedAsync
         }
 
         [Microsoft.PSharp.Test]
-        public static void Execute(PSharpRuntime runtime)
+        public static void Execute(IMachineRuntime runtime)
         {
             runtime.CreateMachine(typeof(Scheduler), new Scheduler.Config(3));
         }

--- a/Samples/Language/CacheCoherence/Test.cs
+++ b/Samples/Language/CacheCoherence/Test.cs
@@ -38,7 +38,7 @@ namespace CacheCoherence
         }
 
         [Microsoft.PSharp.Test]
-        public static void Execute(PSharpRuntime runtime)
+        public static void Execute(IMachineRuntime runtime)
         {
             runtime.CreateMachine(typeof(Host));
         }

--- a/Samples/Language/FailureDetector/Test.cs
+++ b/Samples/Language/FailureDetector/Test.cs
@@ -40,7 +40,7 @@ namespace FailureDetector
         }
 
         [Microsoft.PSharp.Test]
-        public static void Execute(PSharpRuntime runtime)
+        public static void Execute(IMachineRuntime runtime)
         {
             // Monitors must be registered before the first P# machine
             // gets created (which will kickstart the runtime).

--- a/Samples/Language/MultiPaxos/Test.cs
+++ b/Samples/Language/MultiPaxos/Test.cs
@@ -38,7 +38,7 @@ namespace MultiPaxos
         }
 
         [Microsoft.PSharp.Test]
-        public static void Execute(PSharpRuntime runtime)
+        public static void Execute(IMachineRuntime runtime)
         {
             runtime.RegisterMonitor(typeof(ValidityCheck));
             runtime.CreateMachine(typeof(GodMachine));

--- a/Samples/Language/PingPong.AsyncAwait/Test.cs
+++ b/Samples/Language/PingPong.AsyncAwait/Test.cs
@@ -52,7 +52,7 @@ namespace PingPong.AsyncAwait
         /// </summary>
         /// <param name="runtime">PSharpRuntime</param>
         [Microsoft.PSharp.Test]
-        public static void Execute(PSharpRuntime runtime)
+        public static void Execute(IMachineRuntime runtime)
         {
             // This is the root machine to the P# PingPong program. CreateMachine
             // executes asynchronously (i.e. non-blocking).

--- a/Samples/Language/PingPong.CustomLogging/Test.cs
+++ b/Samples/Language/PingPong.CustomLogging/Test.cs
@@ -39,9 +39,8 @@ namespace PingPong.CustomLogging
             // Executes the P# program.
             Program.Execute(runtime);
 
-            // Disposes the logger and removes it from the runtime.
+            // Disposes the logger.
             myLogger.Dispose();
-            runtime.RemoveLogger();
 
             // The P# runtime executes asynchronously, so we wait
             // to not terminate the process.
@@ -55,7 +54,7 @@ namespace PingPong.CustomLogging
         /// </summary>
         /// <param name="runtime"></param>
         [Microsoft.PSharp.Test]
-        public static void Execute(PSharpRuntime runtime)
+        public static void Execute(IMachineRuntime runtime)
         {
             // Assigns a user-defined name to this network environment machine.
             runtime.CreateMachine(typeof(NetworkEnvironment), "TheUltimateNetworkEnvironmentMachine");

--- a/Samples/Language/PingPong.MixedMode/Test.cs
+++ b/Samples/Language/PingPong.MixedMode/Test.cs
@@ -52,7 +52,7 @@ namespace PingPong.MixedMode
         /// </summary>
         /// <param name="runtime">PSharpRuntime</param>
         [Microsoft.PSharp.Test]
-        public static void Execute(PSharpRuntime runtime)
+        public static void Execute(IMachineRuntime runtime)
         {
             // This is the root machine to the P# PingPong program. CreateMachine
             // executes asynchronously (i.e. non-blocking).

--- a/Samples/Language/PingPong/Test.cs
+++ b/Samples/Language/PingPong/Test.cs
@@ -52,7 +52,7 @@ namespace PingPong
         /// </summary>
         /// <param name="runtime">PSharpRuntime</param>
         [Microsoft.PSharp.Test]
-        public static void Execute(PSharpRuntime runtime)
+        public static void Execute(IMachineRuntime runtime)
         {
             // This is the root machine to the P# PingPong program. CreateMachine
             // executes asynchronously (i.e. non-blocking).

--- a/Samples/Language/Raft/Test.cs
+++ b/Samples/Language/Raft/Test.cs
@@ -37,7 +37,7 @@ namespace Raft
         }
 
         [Microsoft.PSharp.Test]
-        public static void Execute(PSharpRuntime runtime)
+        public static void Execute(IMachineRuntime runtime)
         {
             runtime.RegisterMonitor(typeof(SafetyMonitor));
             runtime.CreateMachine(typeof(ClusterManager));

--- a/Samples/Language/ReplicatingStorage/Test.cs
+++ b/Samples/Language/ReplicatingStorage/Test.cs
@@ -41,7 +41,7 @@ namespace ReplicatingStorage
         }
 
         [Microsoft.PSharp.Test]
-        public static void Execute(PSharpRuntime runtime)
+        public static void Execute(IMachineRuntime runtime)
         {
             runtime.RegisterMonitor(typeof(LivenessMonitor));
             runtime.CreateMachine(typeof(Environment));

--- a/Source/Core/IMachineRuntime.cs
+++ b/Source/Core/IMachineRuntime.cs
@@ -1,0 +1,291 @@
+﻿// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------------------------------------------
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+using Microsoft.PSharp.IO;
+using Microsoft.PSharp.Runtime;
+
+namespace Microsoft.PSharp
+{
+    /// <summary>
+    /// Interface of the machine runtime. It provides APIs for creating machines,
+    /// sending events, checking specifications, and other runtime utilities.
+    /// </summary>
+    public interface IMachineRuntime : IDisposable
+    {
+        /// <summary>
+        /// The installed logger.
+        /// </summary>
+        ILogger Logger { get; }
+
+        /// <summary>
+        /// Callback that is fired when the P# program throws an exception.
+        /// </summary>
+        event OnFailureHandler OnFailure;
+
+        /// <summary>
+        /// Callback that is fired when a P# event is dropped.
+        /// </summary>
+        event OnEventDroppedHandler OnEventDropped;
+
+        /// <summary>
+        /// Creates a fresh machine id that has not yet been bound to any machine.
+        /// </summary>
+        /// <param name="type">Type of the machine.</param>
+        /// <param name="machineName">Optional machine name used for logging.</param>
+        /// <returns>The result is the <see cref="MachineId"/>.</returns>
+        MachineId CreateMachineId(Type type, string machineName = null);
+
+        /// <summary>
+        /// Creates a machine id that is uniquely tied to the specified unique name. The
+        /// returned machine id can either be a fresh id (not yet bound to any machine),
+        /// or it can be bound to a previously created machine. In the second case, this
+        /// machine id can be directly used to communicate with the corresponding machine.
+        /// </summary>
+        /// <param name="type">Type of the machine.</param>
+        /// <param name="machineName">Unique name used to create or get the machine id.</param>
+        /// <returns>The result is the <see cref="MachineId"/>.</returns>
+        MachineId CreateMachineIdFromName(Type type, string machineName);
+
+        /// <summary>
+        /// Creates a new machine of the specified <see cref="Type"/> and with
+        /// the specified optional <see cref="Event"/>. This event can only be
+        /// used to access its payload, and cannot be handled.
+        /// </summary>
+        /// <param name="type">Type of the machine.</param>
+        /// <param name="e">Optional event used during initialization.</param>
+        /// <param name="operationGroupId">Optional operation group id.</param>
+        /// <returns>The result is the <see cref="MachineId"/>.</returns>
+        MachineId CreateMachine(Type type, Event e = null, Guid? operationGroupId = null);
+
+        /// <summary>
+        /// Creates a new machine of the specified <see cref="Type"/> and name, and
+        /// with the specified optional <see cref="Event"/>. This event can only be
+        /// used to access its payload, and cannot be handled.
+        /// </summary>
+        /// <param name="type">Type of the machine.</param>
+        /// <param name="machineName">Optional machine name used for logging.</param>
+        /// <param name="e">Optional event used during initialization.</param>
+        /// <param name="operationGroupId">Optional operation group id.</param>
+        /// <returns>The result is the <see cref="MachineId"/>.</returns>
+        MachineId CreateMachine(Type type, string machineName, Event e = null, Guid? operationGroupId = null);
+
+        /// <summary>
+        /// Creates a new machine of the specified type, using the specified <see cref="MachineId"/>.
+        /// This method optionally passes an <see cref="Event"/> to the new machine, which can only
+        /// be used to access its payload, and cannot be handled.
+        /// </summary>
+        /// <param name="mid">Unbound machine id.</param>
+        /// <param name="type">Type of the machine.</param>
+        /// <param name="e">Optional event used during initialization.</param>
+        /// <param name="operationGroupId">Optional operation group id.</param>
+        /// <returns>The result is the <see cref="MachineId"/>.</returns>
+        MachineId CreateMachine(MachineId mid, Type type, Event e = null, Guid? operationGroupId = null);
+
+        /// <summary>
+        /// Creates a new machine of the specified <see cref="Type"/> and with the
+        /// specified optional <see cref="Event"/>. This event can only be used to
+        /// access its payload, and cannot be handled. The method returns only when
+        /// the machine is initialized and the <see cref="Event"/> (if any) is handled.
+        /// </summary>
+        /// <param name="type">Type of the machine.</param>
+        /// <param name="e">Optional event used during initialization.</param>
+        /// <param name="operationGroupId">Optional operation group id.</param>
+        /// <returns>Task that represents the asynchronous operation. The task result is the <see cref="MachineId"/>.</returns>
+        Task<MachineId> CreateMachineAndExecuteAsync(Type type, Event e = null, Guid? operationGroupId = null);
+
+        /// <summary>
+        /// Creates a new machine of the specified <see cref="Type"/> and name, and with
+        /// the specified optional <see cref="Event"/>. This event can only be used to
+        /// access its payload, and cannot be handled. The method returns only when the
+        /// machine is initialized and the <see cref="Event"/> (if any) is handled.
+        /// </summary>
+        /// <param name="type">Type of the machine.</param>
+        /// <param name="machineName">Optional machine name used for logging.</param>
+        /// <param name="e">Optional event used during initialization.</param>
+        /// <param name="operationGroupId">Optional operation group id.</param>
+        /// <returns>Task that represents the asynchronous operation. The task result is the <see cref="MachineId"/>.</returns>
+        Task<MachineId> CreateMachineAndExecuteAsync(Type type, string machineName, Event e = null, Guid? operationGroupId = null);
+
+        /// <summary>
+        /// Creates a new machine of the specified <see cref="Type"/>, using the specified
+        /// unbound machine id, and passes the specified optional <see cref="Event"/>. This
+        /// event can only be used to access its payload, and cannot be handled. The method
+        /// returns only when the machine is initialized and the <see cref="Event"/> (if any)
+        /// is handled.
+        /// </summary>
+        /// <param name="mid">Unbound machine id.</param>
+        /// <param name="type">Type of the machine.</param>
+        /// <param name="e">Optional event used during initialization.</param>
+        /// <param name="operationGroupId">Optional operation group id.</param>
+        /// <returns>Task that represents the asynchronous operation. The task result is the <see cref="MachineId"/>.</returns>
+        Task<MachineId> CreateMachineAndExecuteAsync(MachineId mid, Type type, Event e = null, Guid? operationGroupId = null);
+
+        /// <summary>
+        /// Creates a new machine of the specified <see cref="Type"/> and with the
+        /// specified optional <see cref="Event"/>. This event can only be used to
+        /// access its payload, and cannot be handled. The method returns only when
+        /// the machine is initialized and the <see cref="Event"/> (if any) is handled.
+        /// </summary>
+        /// <param name="type">Type of the machine.</param>
+        /// <param name="e">Optional event used during initialization.</param>
+        /// <param name="operationGroupId">Optional operation group id.</param>
+        /// <returns>Task that represents the asynchronous operation. The task result is the <see cref="MachineId"/>.</returns>
+        [Obsolete("Please use IMachineRuntime.CreateMachineAndExecuteAsync(...) instead.")]
+        Task<MachineId> CreateMachineAndExecute(Type type, Event e = null, Guid? operationGroupId = null);
+
+        /// <summary>
+        /// Creates a new machine of the specified <see cref="Type"/> and name, and with
+        /// the specified optional <see cref="Event"/>. This event can only be used to
+        /// access its payload, and cannot be handled. The method returns only when the
+        /// machine is initialized and the <see cref="Event"/> (if any) is handled.
+        /// </summary>
+        /// <param name="type">Type of the machine.</param>
+        /// <param name="machineName">Optional machine name used for logging.</param>
+        /// <param name="e">Optional event used during initialization.</param>
+        /// <param name="operationGroupId">Optional operation group id.</param>
+        /// <returns>Task that represents the asynchronous operation. The task result is the <see cref="MachineId"/>.</returns>
+        [Obsolete("Please use IMachineRuntime.CreateMachineAndExecuteAsync(...) instead.")]
+        Task<MachineId> CreateMachineAndExecute(Type type, string machineName, Event e = null, Guid? operationGroupId = null);
+
+        /// <summary>
+        /// Creates a new machine of the specified <see cref="Type"/>, using the specified
+        /// unbound machine id, and passes the specified optional <see cref="Event"/>. This
+        /// event can only be used to access its payload, and cannot be handled. The method
+        /// returns only when the machine is initialized and the <see cref="Event"/> (if any)
+        /// is handled.
+        /// </summary>
+        /// <param name="mid">Unbound machine id.</param>
+        /// <param name="type">Type of the machine.</param>
+        /// <param name="e">Optional event used during initialization.</param>
+        /// <param name="operationGroupId">Optional operation group id.</param>
+        /// <returns>Task that represents the asynchronous operation. The task result is the <see cref="MachineId"/>.</returns>
+        [Obsolete("Please use IMachineRuntime.CreateMachineAndExecuteAsync(...) instead.")]
+        Task<MachineId> CreateMachineAndExecute(MachineId mid, Type type, Event e = null, Guid? operationGroupId = null);
+
+        /// <summary>
+        /// Sends an asynchronous <see cref="Event"/> to a machine.
+        /// </summary>
+        /// <param name="target">The id of the target machine.</param>
+        /// <param name="e">The event to send.</param>
+        /// <param name="options">Optional parameters of a send operation.</param>
+        void SendEvent(MachineId target, Event e, SendOptions options = null);
+
+        /// <summary>
+        /// Sends an <see cref="Event"/> to a machine. Returns immediately if the target machine was already
+        /// running. Otherwise blocks until the machine handles the event and reaches quiescense again.
+        /// </summary>
+        /// <param name="target">The id of the target machine.</param>
+        /// <param name="e">The event to send.</param>
+        /// <param name="options">Optional parameters of a send operation.</param>
+        /// <returns>Task that represents the asynchronous operation. The task result is true if
+        /// the event was handled, false if the event was only enqueued.</returns>
+        Task<bool> SendEventAndExecuteAsync(MachineId target, Event e, SendOptions options = null);
+
+        /// <summary>
+        /// Sends an <see cref="Event"/> to a machine. Returns immediately if the target machine was already
+        /// running. Otherwise blocks until the machine handles the event and reaches quiescense again.
+        /// </summary>
+        /// <param name="target">The id of the target machine.</param>
+        /// <param name="e">The event to send.</param>
+        /// <param name="options">Optional parameters of a send operation.</param>
+        /// <returns>Task that represents the asynchronous operation. The task result is true if
+        /// the event was handled, false if the event was only enqueued.</returns>
+        [Obsolete("Please use IMachineRuntime.SendEventAndExecuteAsync(...) instead.")]
+        Task<bool> SendEventAndExecute(MachineId target, Event e, SendOptions options = null);
+
+        /// <summary>
+        /// Registers a new specification monitor of the specified <see cref="Type"/>.
+        /// </summary>
+        /// <param name="type">Type of the monitor.</param>
+        void RegisterMonitor(Type type);
+
+        /// <summary>
+        /// Invokes the specified monitor with the specified <see cref="Event"/>.
+        /// </summary>
+        /// <typeparam name="T">Type of the monitor.</typeparam>
+        /// <param name="e">Event</param>
+        void InvokeMonitor<T>(Event e);
+
+        /// <summary>
+        /// Invokes the specified monitor with the specified <see cref="Event"/>.
+        /// </summary>
+        /// <param name="type">Type of the monitor.</param>
+        /// <param name="e">Event</param>
+        void InvokeMonitor(Type type, Event e);
+
+        /// <summary>
+        /// Returns a nondeterministic boolean choice, that can be controlled
+        /// during analysis or testing.
+        /// </summary>
+        /// <returns>The nondeterministic boolean choice.</returns>
+        bool Random();
+
+        /// <summary>
+        /// Returns a fair nondeterministic boolean choice, that can be
+        /// controlled during analysis or testing.
+        /// </summary>
+        /// <param name="callerMemberName">CallerMemberName</param>
+        /// <param name="callerFilePath">CallerFilePath</param>
+        /// <param name="callerLineNumber">CallerLineNumber</param>
+        /// <returns>The controlled nondeterministic choice.</returns>
+        bool FairRandom(
+            [CallerMemberName] string callerMemberName = "",
+            [CallerFilePath] string callerFilePath = "",
+            [CallerLineNumber] int callerLineNumber = 0);
+
+        /// <summary>
+        /// Returns a nondeterministic boolean choice, that can be controlled
+        /// during analysis or testing. The value is used to generate a number
+        /// in the range [0..maxValue), where 0 triggers true.
+        /// </summary>
+        /// <param name="maxValue">The max value.</param>
+        /// <returns>The nondeterministic boolean choice.</returns>
+        bool Random(int maxValue);
+
+        /// <summary>
+        /// Returns a nondeterministic integer choice, that can be
+        /// controlled during analysis or testing. The value is used
+        /// to generate an integer in the range [0..maxValue).
+        /// </summary>
+        /// <param name="maxValue">The max value.</param>
+        /// <returns>The nondeterministic integer choice.</returns>
+        int RandomInteger(int maxValue);
+
+        /// <summary>
+        /// Checks if the assertion holds, and if not it throws an
+        /// <see cref="AssertionFailureException"/> exception.
+        /// </summary>
+        /// <param name="predicate">The predicate to check.</param>
+        void Assert(bool predicate);
+
+        /// <summary>
+        /// Checks if the assertion holds, and if not it throws an
+        /// <see cref="AssertionFailureException"/> exception.
+        /// </summary>
+        /// <param name="predicate">The predicate to check.</param>
+        /// <param name="s">The message to print if the assertion fails.</param>
+        /// <param name="args">The message arguments.</param>
+        void Assert(bool predicate, string s, params object[] args);
+
+        /// <summary>
+        /// Returns the operation group id of the specified machine id. Returns <see cref="Guid.Empty"/>
+        /// if the id is not set, or if the <see cref="MachineId"/> is not associated with this runtime.
+        /// During testing, the runtime asserts that the specified machine is currently executing.
+        /// </summary>
+        /// <param name="currentMachineId">The id of the currently executing machine.</param>
+        /// <returns>The unique identifier.</returns>
+        Guid GetCurrentOperationGroupId(MachineId currentMachineId);
+
+        /// <summary>
+        /// Installs the specified <see cref="ILogger"/>.
+        /// </summary>
+        /// <param name="logger">The logger to install.</param>
+        void SetLogger(ILogger logger);
+    }
+}

--- a/Source/Core/IO/Logging/MachineLogger.cs
+++ b/Source/Core/IO/Logging/MachineLogger.cs
@@ -37,7 +37,7 @@ namespace Microsoft.PSharp.IO
         /// <summary>
         /// Initializes a new instance of the <see cref="MachineLogger"/> class. The logger
         /// will be assigned the runtime <see cref="PSharp.Configuration"/> object when it
-        /// is passed to <see cref="PSharpRuntime.SetLogger(ILogger)"/>.
+        /// is passed to <see cref="IMachineRuntime.SetLogger(ILogger)"/>.
         /// </summary>
         /// <param name="loggingVerbosity">The initial logging verbosity level.</param>
         public MachineLogger(int loggingVerbosity = 2)

--- a/Source/Core/Networking/NetworkProviders/LocalNetworkProvider.cs
+++ b/Source/Core/Networking/NetworkProviders/LocalNetworkProvider.cs
@@ -15,7 +15,7 @@ namespace Microsoft.PSharp.Net
         /// <summary>
         /// Instance of the P# runtime.
         /// </summary>
-        private readonly PSharpRuntime Runtime;
+        private readonly IMachineRuntime Runtime;
 
         /// <summary>
         /// The local endpoint.
@@ -25,7 +25,7 @@ namespace Microsoft.PSharp.Net
         /// <summary>
         /// Initializes a new instance of the <see cref="LocalNetworkProvider"/> class.
         /// </summary>
-        public LocalNetworkProvider(PSharpRuntime runtime)
+        public LocalNetworkProvider(IMachineRuntime runtime)
         {
             this.Runtime = runtime;
             this.LocalEndpoint = string.Empty;

--- a/Source/Core/PSharpRuntime.cs
+++ b/Source/Core/PSharpRuntime.cs
@@ -1,0 +1,34 @@
+﻿// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------------------------------------------
+
+using Microsoft.PSharp.Runtime;
+
+namespace Microsoft.PSharp
+{
+    /// <summary>
+    /// The runtime for creating and executing P# machines.
+    /// </summary>
+    public static class PSharpRuntime
+    {
+        /// <summary>
+        /// Creates a new machine runtime.
+        /// </summary>
+        /// <returns>The machine runtime.</returns>
+        public static IMachineRuntime Create()
+        {
+            return new ProductionRuntime(Configuration.Create());
+        }
+
+        /// <summary>
+        /// Creates a new machine runtime with the specified <see cref="Configuration"/>.
+        /// </summary>
+        /// <param name="configuration">The runtime configuration to use.</param>
+        /// <returns>The machine runtime.</returns>
+        public static IMachineRuntime Create(Configuration configuration)
+        {
+            return new ProductionRuntime(configuration ?? Configuration.Create());
+        }
+    }
+}

--- a/Source/Core/Properties/codeanalysis.ruleset
+++ b/Source/Core/Properties/codeanalysis.ruleset
@@ -75,7 +75,7 @@
     <Rule Id="SA1101" Action="Error" />
     <Rule Id="SA1106" Action="Error" />
     <Rule Id="SA1108" Action="Error" />
-    <Rule Id="SA1116" Action="Error" />
+    <Rule Id="SA1116" Action="None" />
     <Rule Id="SA1117" Action="None" />
     <Rule Id="SA1118" Action="None" />
     <Rule Id="SA1119" Action="Error" />

--- a/Source/Core/Runtime/BaseRuntime.cs
+++ b/Source/Core/Runtime/BaseRuntime.cs
@@ -11,21 +11,19 @@ using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
 using Microsoft.PSharp.IO;
-using Microsoft.PSharp.Net;
-using Microsoft.PSharp.Runtime;
 using Microsoft.PSharp.Timers;
 
-namespace Microsoft.PSharp
+namespace Microsoft.PSharp.Runtime
 {
     /// <summary>
-    /// Runtime for executing state-machines.
+    /// Runtime for executing machines.
     /// </summary>
-    public abstract class PSharpRuntime : IDisposable
+    internal abstract class BaseRuntime : IMachineRuntime
     {
         /// <summary>
         /// The configuration used by the runtime.
         /// </summary>
-        internal Configuration Configuration;
+        internal readonly Configuration Configuration;
 
         /// <summary>
         /// Monotonically increasing machine id counter.
@@ -40,12 +38,7 @@ namespace Microsoft.PSharp
         /// <summary>
         /// Map from unique machine ids to machines.
         /// </summary>
-        protected ConcurrentDictionary<MachineId, Machine> MachineMap;
-
-        /// <summary>
-        /// Network provider used for remote communication.
-        /// </summary>
-        public INetworkProvider NetworkProvider { get; private set; }
+        protected readonly ConcurrentDictionary<MachineId, Machine> MachineMap;
 
         /// <summary>
         /// The installed logger.
@@ -53,7 +46,7 @@ namespace Microsoft.PSharp
         public ILogger Logger { get; private set; }
 
         /// <summary>
-        /// Event that is fired when the P# program throws an exception.
+        /// Callback that is fired when the P# program throws an exception.
         /// </summary>
         public event OnFailureHandler OnFailure;
 
@@ -63,35 +56,13 @@ namespace Microsoft.PSharp
         public event OnEventDroppedHandler OnEventDropped;
 
         /// <summary>
-        /// Creates a new state-machine runtime.
+        /// Initializes a new instance of the <see cref="BaseRuntime"/> class.
         /// </summary>
-        /// <returns>Runtime</returns>
-        public static PSharpRuntime Create()
-        {
-            return new ProductionRuntime(Configuration.Create());
-        }
-
-        /// <summary>
-        /// Creates a new state-machine runtime with the specified
-        /// <see cref="PSharp.Configuration"/>.
-        /// </summary>
-        /// <param name="configuration">Configuration</param>
-        /// <returns>Runtime</returns>
-        public static PSharpRuntime Create(Configuration configuration)
-        {
-            return new ProductionRuntime(configuration);
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PSharpRuntime"/> class.
-        /// </summary>
-        /// <param name="configuration">Configuration</param>
-        protected PSharpRuntime(Configuration configuration)
+        protected BaseRuntime(Configuration configuration)
         {
             this.Configuration = configuration;
             this.MachineMap = new ConcurrentDictionary<MachineId, Machine>();
             this.MachineIdCounter = 0;
-            this.NetworkProvider = new LocalNetworkProvider(this);
             this.SetLogger(new ConsoleLogger());
             this.IsRunning = true;
         }
@@ -99,10 +70,7 @@ namespace Microsoft.PSharp
         /// <summary>
         /// Creates a fresh machine id that has not yet been bound to any machine.
         /// </summary>
-        /// <param name="type">Type of the machine</param>
-        /// <param name="friendlyName">Friendly machine name used for logging</param>
-        /// <returns>MachineId</returns>
-        public MachineId CreateMachineId(Type type, string friendlyName = null) => new MachineId(type, friendlyName, this);
+        public MachineId CreateMachineId(Type type, string machineName = null) => new MachineId(type, machineName, this);
 
         /// <summary>
         /// Creates a machine id that is uniquely tied to the specified unique name. The
@@ -110,44 +78,28 @@ namespace Microsoft.PSharp
         /// or it can be bound to a previously created machine. In the second case, this
         /// machine id can be directly used to communicate with the corresponding machine.
         /// </summary>
-        /// <param name="type">Type of the machine</param>
-        /// <param name="uniqueName">Unique name used to create the machine id</param>
-        /// <returns>MachineId</returns>
-        public abstract MachineId CreateMachineIdFromName(Type type, string uniqueName);
+        public abstract MachineId CreateMachineIdFromName(Type type, string machineName);
 
         /// <summary>
         /// Creates a new machine of the specified <see cref="Type"/> and with
         /// the specified optional <see cref="Event"/>. This event can only be
         /// used to access its payload, and cannot be handled.
         /// </summary>
-        /// <param name="type">Type of the machine</param>
-        /// <param name="e">Event</param>
-        /// <param name="operationGroupId">Optional operation group id</param>
-        /// <returns>MachineId</returns>
         public abstract MachineId CreateMachine(Type type, Event e = null, Guid? operationGroupId = null);
-
-        /// <summary>
-        /// Creates a new machine of the specified <see cref="Type"/>, using the specified
-        /// machine id, and passes the specified optional <see cref="Event"/>. This
-        /// event can only be used to access its payload, and cannot be handled.
-        /// </summary>
-        /// <param name="mid">Unbound machine id</param>
-        /// <param name="type">Type of the machine</param>
-        /// <param name="e">Event</param>
-        /// <param name="operationGroupId">Optional operation group id</param>
-        public abstract void CreateMachine(MachineId mid, Type type, Event e = null, Guid? operationGroupId = null);
 
         /// <summary>
         /// Creates a new machine of the specified <see cref="Type"/> and name, and
         /// with the specified optional <see cref="Event"/>. This event can only be
         /// used to access its payload, and cannot be handled.
         /// </summary>
-        /// <param name="type">Type of the machine</param>
-        /// <param name="friendlyName">Friendly machine name used for logging</param>
-        /// <param name="e">Event</param>
-        /// <param name="operationGroupId">Optional operation group id</param>
-        /// <returns>MachineId</returns>
-        public abstract MachineId CreateMachine(Type type, string friendlyName, Event e = null, Guid? operationGroupId = null);
+        public abstract MachineId CreateMachine(Type type, string machineName, Event e = null, Guid? operationGroupId = null);
+
+        /// <summary>
+        /// Creates a new machine of the specified type, using the specified <see cref="MachineId"/>.
+        /// This method optionally passes an <see cref="Event"/> to the new machine, which can only
+        /// be used to access its payload, and cannot be handled.
+        /// </summary>
+        public abstract MachineId CreateMachine(MachineId mid, Type type, Event e = null, Guid? operationGroupId = null);
 
         /// <summary>
         /// Creates a new machine of the specified <see cref="Type"/> and with the
@@ -155,11 +107,15 @@ namespace Microsoft.PSharp
         /// access its payload, and cannot be handled. The method returns only when
         /// the machine is initialized and the <see cref="Event"/> (if any) is handled.
         /// </summary>
-        /// <param name="type">Type of the machine</param>
-        /// <param name="e">Event</param>
-        /// <param name="operationGroupId">Optional operation group id</param>
-        /// <returns>MachineId</returns>
-        public abstract Task<MachineId> CreateMachineAndExecute(Type type, Event e = null, Guid? operationGroupId = null);
+        public abstract Task<MachineId> CreateMachineAndExecuteAsync(Type type, Event e = null, Guid? operationGroupId = null);
+
+        /// <summary>
+        /// Creates a new machine of the specified <see cref="Type"/> and name, and with
+        /// the specified optional <see cref="Event"/>. This event can only be used to
+        /// access its payload, and cannot be handled. The method returns only when the
+        /// machine is initialized and the <see cref="Event"/> (if any) is handled.
+        /// </summary>
+        public abstract Task<MachineId> CreateMachineAndExecuteAsync(Type type, string machineName, Event e = null, Guid? operationGroupId = null);
 
         /// <summary>
         /// Creates a new machine of the specified <see cref="Type"/>, using the specified
@@ -168,11 +124,15 @@ namespace Microsoft.PSharp
         /// returns only when the machine is initialized and the <see cref="Event"/> (if any)
         /// is handled.
         /// </summary>
-        /// <param name="mid">Unbound machine id</param>
-        /// <param name="type">Type of the machine</param>
-        /// <param name="e">Event</param>
-        /// <param name="operationGroupId">Optional operation group id</param>
-        public abstract Task CreateMachineAndExecute(MachineId mid, Type type, Event e = null, Guid? operationGroupId = null);
+        public abstract Task<MachineId> CreateMachineAndExecuteAsync(MachineId mid, Type type, Event e = null, Guid? operationGroupId = null);
+
+        /// <summary>
+        /// Creates a new machine of the specified <see cref="Type"/> and with the
+        /// specified optional <see cref="Event"/>. This event can only be used to
+        /// access its payload, and cannot be handled. The method returns only when
+        /// the machine is initialized and the <see cref="Event"/> (if any) is handled.
+        /// </summary>
+        public abstract Task<MachineId> CreateMachineAndExecute(Type type, Event e = null, Guid? operationGroupId = null);
 
         /// <summary>
         /// Creates a new machine of the specified <see cref="Type"/> and name, and with
@@ -180,91 +140,64 @@ namespace Microsoft.PSharp
         /// access its payload, and cannot be handled. The method returns only when the
         /// machine is initialized and the <see cref="Event"/> (if any) is handled.
         /// </summary>
-        /// <param name="type">Type of the machine</param>
-        /// <param name="friendlyName">Friendly machine name used for logging</param>
-        /// <param name="e">Event</param>
-        /// <param name="operationGroupId">Optional operation group id</param>
-        /// <returns>MachineId</returns>
-        public abstract Task<MachineId> CreateMachineAndExecute(Type type, string friendlyName, Event e = null, Guid? operationGroupId = null);
+        public abstract Task<MachineId> CreateMachineAndExecute(Type type, string machineName, Event e = null, Guid? operationGroupId = null);
 
         /// <summary>
-        /// Creates a new remote machine of the specified <see cref="Type"/> and with
-        /// the specified optional <see cref="Event"/>. This event can only be used
-        /// to access its payload, and cannot be handled.
+        /// Creates a new machine of the specified <see cref="Type"/>, using the specified
+        /// unbound machine id, and passes the specified optional <see cref="Event"/>. This
+        /// event can only be used to access its payload, and cannot be handled. The method
+        /// returns only when the machine is initialized and the <see cref="Event"/> (if any)
+        /// is handled.
         /// </summary>
-        /// <param name="type">Type of the machine</param>
-        /// <param name="endpoint">Endpoint</param>
-        /// <param name="e">Event</param>
-        /// <param name="operationGroupId">Optional operation group id</param>
-        /// <returns>MachineId</returns>
-        public abstract MachineId RemoteCreateMachine(Type type, string endpoint, Event e = null, Guid? operationGroupId = null);
-
-        /// <summary>
-        /// Creates a new remote machine of the specified <see cref="Type"/> and name, and
-        /// with the specified optional <see cref="Event"/>. This event can only be used
-        /// to access its payload, and cannot be handled.
-        /// </summary>
-        /// <param name="type">Type of the machine</param>
-        /// <param name="friendlyName">Friendly machine name used for logging</param>
-        /// <param name="endpoint">Endpoint</param>
-        /// <param name="e">Event</param>
-        /// <param name="operationGroupId">Optional operation group id</param>
-        /// <returns>MachineId</returns>
-        public abstract MachineId RemoteCreateMachine(Type type, string friendlyName,
-            string endpoint, Event e = null, Guid? operationGroupId = null);
+        public abstract Task<MachineId> CreateMachineAndExecute(MachineId mid, Type type, Event e = null, Guid? operationGroupId = null);
 
         /// <summary>
         /// Sends an asynchronous <see cref="Event"/> to a machine.
         /// </summary>
-        /// <param name="target">Target machine id</param>
-        /// <param name="e">Event</param>
-        /// <param name="options">Optional parameters of a send operation.</param>
         public abstract void SendEvent(MachineId target, Event e, SendOptions options = null);
 
         /// <summary>
-        /// Sends an <see cref="Event"/> to a machine. Returns immediately
-        /// if the target machine was already running. Otherwise blocks until the machine handles
-        /// the event and reaches quiescense again.
+        /// Sends an <see cref="Event"/> to a machine. Returns immediately if the target machine was already
+        /// running. Otherwise blocks until the machine handles the event and reaches quiescense again.
         /// </summary>
-        /// <param name="target">Target machine id</param>
-        /// <param name="e">Event</param>
-        /// <param name="options">Optional parameters of a send operation.</param>
-        /// <returns>True if event was handled, false if the event was only enqueued</returns>
-        public abstract Task<bool> SendEventAndExecute(MachineId target, Event e, SendOptions options = null);
+        public abstract Task<bool> SendEventAndExecuteAsync(MachineId target, Event e, SendOptions options = null);
 
         /// <summary>
-        /// Sends an asynchronous <see cref="Event"/> to a remote machine.
+        /// Sends an <see cref="Event"/> to a machine. Returns immediately if the target machine was already
+        /// running. Otherwise blocks until the machine handles the event and reaches quiescense again.
         /// </summary>
-        /// <param name="target">Target machine id</param>
-        /// <param name="e">Event</param>
-        /// <param name="options">Optional parameters of a send operation.</param>
-        public abstract void RemoteSendEvent(MachineId target, Event e, SendOptions options = null);
+        public abstract Task<bool> SendEventAndExecute(MachineId target, Event e, SendOptions options = null);
 
         /// <summary>
         /// Registers a new specification monitor of the specified <see cref="Type"/>.
         /// </summary>
-        /// <param name="type">Type of the monitor</param>
-        public abstract void RegisterMonitor(Type type);
+        public void RegisterMonitor(Type type)
+        {
+            this.TryCreateMonitor(type);
+        }
 
         /// <summary>
         /// Invokes the specified monitor with the specified <see cref="Event"/>.
         /// </summary>
-        /// <typeparam name="T">Type of the monitor</typeparam>
-        /// <param name="e">Event</param>
-        public abstract void InvokeMonitor<T>(Event e);
+        public void InvokeMonitor<T>(Event e)
+        {
+            this.InvokeMonitor(typeof(T), e);
+        }
 
         /// <summary>
         /// Invokes the specified monitor with the specified <see cref="Event"/>.
         /// </summary>
-        /// <param name="type">Type of the monitor</param>
-        /// <param name="e">Event</param>
-        public abstract void InvokeMonitor(Type type, Event e);
+        public void InvokeMonitor(Type type, Event e)
+        {
+            // If the event is null then report an error and exit.
+            this.Assert(e != null, "Cannot monitor a null event.");
+            this.Monitor(type, null, e);
+        }
 
         /// <summary>
         /// Returns a nondeterministic boolean choice, that can be controlled
         /// during analysis or testing.
         /// </summary>
-        /// <returns>The controlled nondeterministic choice.</returns>
         public bool Random()
         {
             return this.GetNondeterministicBooleanChoice(null, 2);
@@ -274,10 +207,6 @@ namespace Microsoft.PSharp
         /// Returns a fair nondeterministic boolean choice, that can be
         /// controlled during analysis or testing.
         /// </summary>
-        /// <param name="callerMemberName">CallerMemberName</param>
-        /// <param name="callerFilePath">CallerFilePath</param>
-        /// <param name="callerLineNumber">CallerLineNumber</param>
-        /// <returns>The controlled nondeterministic choice.</returns>
         public bool FairRandom(
             [CallerMemberName] string callerMemberName = "",
             [CallerFilePath] string callerFilePath = "",
@@ -294,8 +223,6 @@ namespace Microsoft.PSharp
         /// during analysis or testing. The value is used to generate a number
         /// in the range [0..maxValue), where 0 triggers true.
         /// </summary>
-        /// <param name="maxValue">The max value.</param>
-        /// <returns>The controlled nondeterministic choice.</returns>
         public bool Random(int maxValue)
         {
             return this.GetNondeterministicBooleanChoice(null, maxValue);
@@ -306,8 +233,6 @@ namespace Microsoft.PSharp
         /// analysis or testing. The value is used to generate an integer in
         /// the range [0..maxValue).
         /// </summary>
-        /// <param name="maxValue">The max value.</param>
-        /// <returns>The controlled nondeterministic integer.</returns>
         public int RandomInteger(int maxValue)
         {
             return this.GetNondeterministicIntegerChoice(null, maxValue);
@@ -317,8 +242,6 @@ namespace Microsoft.PSharp
         /// Returns the operation group id of the specified machine. During testing,
         /// the runtime asserts that the specified machine is currently executing.
         /// </summary>
-        /// <param name="currentMachine">MachineId of the currently executing machine.</param>
-        /// <returns>Guid</returns>
         public abstract Guid GetCurrentOperationGroupId(MachineId currentMachine);
 
         /// <summary>
@@ -326,16 +249,14 @@ namespace Microsoft.PSharp
         /// to reach quiescence. This is an experimental feature, which should
         /// be used only for testing purposes.
         /// </summary>
-        public abstract void Stop();
+        public void Stop()
+        {
+            this.IsRunning = false;
+        }
 
         /// <summary>
         /// Gets the target machine for an event; if not found, logs a halted-machine entry.
         /// </summary>
-        /// <param name="targetMachineId">The id of target machine.</param>
-        /// <param name="e">The event that will be sent.</param>
-        /// <param name="sender">The machine that is sending the event.</param>
-        /// <param name="operationGroupId">The operation group id.</param>
-        /// <param name="targetMachine">Receives the target machine, if found.</param>
         protected bool GetTargetMachine(MachineId targetMachineId, Event e, BaseMachine sender,
             Guid operationGroupId, out Machine targetMachine)
         {
@@ -353,77 +274,34 @@ namespace Microsoft.PSharp
         /// <summary>
         /// Creates a new <see cref="Machine"/> of the specified <see cref="Type"/>.
         /// </summary>
-        /// <param name="mid">Unbound machine id</param>
-        /// <param name="type">Type of the machine</param>
-        /// <param name="friendlyName">Friendly machine name used for logging</param>
-        /// <param name="e">Event passed during machine construction</param>
-        /// <param name="creator">Creator machine</param>
-        /// <param name="operationGroupId">Operation group id</param>
         /// <returns>MachineId</returns>
-        internal abstract MachineId CreateMachine(MachineId mid, Type type, string friendlyName, Event e, Machine creator, Guid? operationGroupId);
+        internal abstract MachineId CreateMachine(MachineId mid, Type type, string machineName, Event e, Machine creator, Guid? operationGroupId);
 
         /// <summary>
         /// Creates a new <see cref="Machine"/> of the specified <see cref="Type"/>. The
         /// method returns only when the machine is initialized and the <see cref="Event"/>
         /// (if any) is handled.
         /// </summary>
-        /// <param name="mid">Unbound machine id</param>
-        /// <param name="type">Type of the machine</param>
-        /// <param name="friendlyName">Friendly machine name used for logging</param>
-        /// <param name="e">Event passed during machine construction</param>
-        /// <param name="creator">Creator machine</param>
-        /// <param name="operationGroupId">Operation group id</param>
         /// <returns>MachineId</returns>
-        internal abstract Task<MachineId> CreateMachineAndExecute(MachineId mid, Type type, string friendlyName, Event e, Machine creator, Guid? operationGroupId);
-
-        /// <summary>
-        /// Creates a new remote <see cref="Machine"/> of the specified <see cref="System.Type"/>.
-        /// </summary>
-        /// <param name="type">Type of the machine</param>
-        /// <param name="friendlyName">Friendly machine name used for logging</param>
-        /// <param name="endpoint">Endpoint</param>
-        /// <param name="e">Event passed during machine construction</param>
-        /// <param name="creator">Creator machine</param>
-        /// <param name="operationGroupId">Operation group id</param>
-        /// <returns>MachineId</returns>
-        internal abstract MachineId CreateRemoteMachine(Type type, string friendlyName, string endpoint,
+        internal abstract Task<MachineId> CreateMachineAndExecute(MachineId mid, Type type, string machineName,
             Event e, Machine creator, Guid? operationGroupId);
 
         /// <summary>
         /// Sends an asynchronous <see cref="Event"/> to a machine.
         /// </summary>
-        /// <param name="mid">MachineId</param>
-        /// <param name="e">Event</param>
-        /// <param name="sender">Sender machine</param>
-        /// <param name="options">Optional parameters of a send operation.</param>
-        internal abstract void SendEvent(MachineId mid, Event e, BaseMachine sender, SendOptions options);
+        internal abstract void SendEvent(MachineId target, Event e, BaseMachine sender, SendOptions options);
 
         /// <summary>
         /// Sends an asynchronous <see cref="Event"/> to a machine. Returns immediately
         /// if the target machine was already running. Otherwise blocks until the machine handles
         /// the event and reaches quiescense again.
         /// </summary>
-        /// <param name="mid">MachineId</param>
-        /// <param name="e">Event</param>
-        /// <param name="sender">Sender machine</param>
-        /// <param name="options">Optional parameters of a send operation.</param>
-        /// <returns>True if event was handled, false if the event was only enqueued</returns>
-        internal abstract Task<bool> SendEventAndExecute(MachineId mid, Event e, BaseMachine sender, SendOptions options);
-
-        /// <summary>
-        /// Sends an asynchronous <see cref="Event"/> to a remote machine.
-        /// </summary>
-        /// <param name="mid">MachineId</param>
-        /// <param name="e">Event</param>
-        /// <param name="sender">Sender machine</param>
-        /// <param name="options">Optional parameters of a send operation.</param>
-        internal abstract void SendEventRemotely(MachineId mid, Event e, BaseMachine sender, SendOptions options);
+        internal abstract Task<bool> SendEventAndExecute(MachineId target, Event e, BaseMachine sender, SendOptions options);
 
         /// <summary>
         /// Checks that a machine can start its event handler. Returns false if the event
         /// handler should not be started.
         /// </summary>
-        /// <param name="machine">The caller machine.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal virtual bool CheckStartEventHandler(Machine machine)
         {
@@ -433,9 +311,6 @@ namespace Microsoft.PSharp
         /// <summary>
         /// Creates a new timer that sends a <see cref="TimerElapsedEvent"/> to its owner machine.
         /// </summary>
-        /// <param name="info">Stores information about the timer.</param>
-        /// <param name="owner">The owner machine.</param>
-        /// <returns>The machine timer.</returns>
         internal abstract IMachineTimer CreateMachineTimer(TimerInfo info, Machine owner);
 
         /// <summary>
@@ -446,22 +321,17 @@ namespace Microsoft.PSharp
         /// <summary>
         /// Tries to create a new <see cref="PSharp.Monitor"/> of the specified <see cref="Type"/>.
         /// </summary>
-        /// <param name="type">Type of the monitor</param>
         internal abstract void TryCreateMonitor(Type type);
 
         /// <summary>
         /// Invokes the specified <see cref="PSharp.Monitor"/> with the specified <see cref="Event"/>.
         /// </summary>
-        /// <param name="type">Type of the monitor</param>
-        /// <param name="sender">Sender machine</param>
-        /// <param name="e">Event</param>
         internal abstract void Monitor(Type type, BaseMachine sender, Event e);
 
         /// <summary>
         /// Checks if the assertion holds, and if not it throws an
         /// <see cref="AssertionFailureException"/> exception.
         /// </summary>
-        /// <param name="predicate">Predicate</param>
         public virtual void Assert(bool predicate)
         {
             if (!predicate)
@@ -474,9 +344,6 @@ namespace Microsoft.PSharp
         /// Checks if the assertion holds, and if not it throws an
         /// <see cref="AssertionFailureException"/> exception.
         /// </summary>
-        /// <param name="predicate">Predicate</param>
-        /// <param name="s">Message</param>
-        /// <param name="args">Message arguments</param>
         public virtual void Assert(bool predicate, string s, params object[] args)
         {
             if (!predicate)
@@ -489,33 +356,23 @@ namespace Microsoft.PSharp
         /// Returns a nondeterministic boolean choice, that can be
         /// controlled during analysis or testing.
         /// </summary>
-        /// <param name="machine">The caller machine.</param>
-        /// <param name="maxValue">The max value.</param>
-        /// <returns>Boolean</returns>
         internal abstract bool GetNondeterministicBooleanChoice(BaseMachine machine, int maxValue);
 
         /// <summary>
         /// Returns a fair nondeterministic boolean choice, that can be
         /// controlled during analysis or testing.
         /// </summary>
-        /// <param name="machine">The caller machine.</param>
-        /// <param name="uniqueId">Unique id</param>
-        /// <returns>Boolean</returns>
         internal abstract bool GetFairNondeterministicBooleanChoice(BaseMachine machine, string uniqueId);
 
         /// <summary>
         /// Returns a nondeterministic integer choice, that can be
         /// controlled during analysis or testing.
         /// </summary>
-        /// <param name="machine">The caller machine.</param>
-        /// <param name="maxValue">The max value.</param>
-        /// <returns>Integer</returns>
         internal abstract int GetNondeterministicIntegerChoice(BaseMachine machine, int maxValue);
 
         /// <summary>
         /// Notifies that a machine entered a state.
         /// </summary>
-        /// <param name="machine">The machine that triggered the notification.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal virtual void NotifyEnteredState(Machine machine)
         {
@@ -525,7 +382,6 @@ namespace Microsoft.PSharp
         /// <summary>
         /// Notifies that a monitor entered a state.
         /// </summary>
-        /// <param name="monitor">The monitor that triggered the notification.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal virtual void NotifyEnteredState(Monitor monitor)
         {
@@ -535,7 +391,6 @@ namespace Microsoft.PSharp
         /// <summary>
         /// Notifies that a machine exited a state.
         /// </summary>
-        /// <param name="machine">The machine that triggered the notification.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal virtual void NotifyExitedState(Machine machine)
         {
@@ -545,7 +400,6 @@ namespace Microsoft.PSharp
         /// <summary>
         /// Notifies that a monitor exited a state.
         /// </summary>
-        /// <param name="monitor">The monitor that triggered the notification.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal virtual void NotifyExitedState(Monitor monitor)
         {
@@ -555,9 +409,6 @@ namespace Microsoft.PSharp
         /// <summary>
         /// Notifies that a machine invoked an action.
         /// </summary>
-        /// <param name="machine">The machine that triggered the notification.</param>
-        /// <param name="action">Action</param>
-        /// <param name="receivedEvent">Event</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal virtual void NotifyInvokedAction(Machine machine, MethodInfo action, Event receivedEvent)
         {
@@ -567,9 +418,6 @@ namespace Microsoft.PSharp
         /// <summary>
         /// Notifies that a machine completed invoking an action.
         /// </summary>
-        /// <param name="machine">The machine that triggered the notification.</param>
-        /// <param name="action">Action</param>
-        /// <param name="receivedEvent">Event</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal virtual void NotifyCompletedAction(Machine machine, MethodInfo action, Event receivedEvent)
         {
@@ -579,9 +427,6 @@ namespace Microsoft.PSharp
         /// <summary>
         /// Notifies that a monitor invoked an action.
         /// </summary>
-        /// <param name="monitor">The monitor that triggered the notification.</param>
-        /// <param name="action">Action</param>
-        /// <param name="receivedEvent">Event</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal virtual void NotifyInvokedAction(Monitor monitor, MethodInfo action, Event receivedEvent)
         {
@@ -591,8 +436,6 @@ namespace Microsoft.PSharp
         /// <summary>
         /// Notifies that a machine raised an <see cref="Event"/>.
         /// </summary>
-        /// <param name="machine">The machine that triggered the notification.</param>
-        /// <param name="eventInfo">EventInfo</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal virtual void NotifyRaisedEvent(Machine machine, EventInfo eventInfo)
         {
@@ -602,8 +445,6 @@ namespace Microsoft.PSharp
         /// <summary>
         /// Notifies that a monitor raised an <see cref="Event"/>.
         /// </summary>
-        /// <param name="monitor">The monitor that triggered the notification.</param>
-        /// <param name="eventInfo">EventInfo</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal virtual void NotifyRaisedEvent(Monitor monitor, EventInfo eventInfo)
         {
@@ -613,8 +454,6 @@ namespace Microsoft.PSharp
         /// <summary>
         /// Notifies that a machine dequeued an <see cref="Event"/>.
         /// </summary>
-        /// <param name="machine">The machine that triggered the notification.</param>
-        /// <param name="eventInfo">EventInfo</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal virtual void NotifyDequeuedEvent(Machine machine, EventInfo eventInfo)
         {
@@ -624,7 +463,6 @@ namespace Microsoft.PSharp
         /// <summary>
         /// Notifies that a machine invoked pop.
         /// </summary>
-        /// <param name="machine">The machine that triggered the notification.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal virtual void NotifyPop(Machine machine)
         {
@@ -634,7 +472,6 @@ namespace Microsoft.PSharp
         /// <summary>
         /// Notifies that a machine called Receive.
         /// </summary>
-        /// <param name="machine">The machine that triggered the notification.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal virtual void NotifyReceiveCalled(Machine machine)
         {
@@ -644,8 +481,6 @@ namespace Microsoft.PSharp
         /// <summary>
         /// Notifies that a machine is handling a raised <see cref="Event"/>.
         /// </summary>
-        /// <param name="machine">The machine that triggered the notification.</param>
-        /// <param name="eventInfo">EventInfo</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal virtual void NotifyHandleRaisedEvent(Machine machine, EventInfo eventInfo)
         {
@@ -655,8 +490,6 @@ namespace Microsoft.PSharp
         /// <summary>
         /// Notifies that a machine is waiting to receive one or more events.
         /// </summary>
-        /// <param name="machine">The machine that triggered the notification.</param>
-        /// <param name="eventInfoInInbox">The event info if it is in the inbox, else null</param>
         internal virtual void NotifyWaitEvents(Machine machine, EventInfo eventInfoInInbox)
         {
             // Override to implement the notification.
@@ -665,8 +498,6 @@ namespace Microsoft.PSharp
         /// <summary>
         /// Notifies that a machine received an <see cref="Event"/> that it was waiting for.
         /// </summary>
-        /// <param name="machine">The machine that triggered the notification.</param>
-        /// <param name="eventInfo">EventInfo</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal virtual void NotifyReceivedEvent(Machine machine, EventInfo eventInfo)
         {
@@ -676,8 +507,6 @@ namespace Microsoft.PSharp
         /// <summary>
         /// Notifies that a machine has halted.
         /// </summary>
-        /// <param name="machine">The machine that triggered the notification.</param>
-        /// <param name="inbox">Machine inbox.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal virtual void NotifyHalted(Machine machine, LinkedList<EventInfo> inbox)
         {
@@ -688,7 +517,6 @@ namespace Microsoft.PSharp
         /// Notifies that the inbox of the specified machine is about to be
         /// checked to see if the default event handler should fire.
         /// </summary>
-        /// <param name="machine">The machine that triggered the notification.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal virtual void NotifyDefaultEventHandlerCheck(Machine machine)
         {
@@ -698,7 +526,6 @@ namespace Microsoft.PSharp
         /// <summary>
         /// Notifies that the default handler of the specified machine has been fired.
         /// </summary>
-        /// <param name="machine">The machine that triggered the notification.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal virtual void NotifyDefaultHandlerFired(Machine machine)
         {
@@ -708,8 +535,6 @@ namespace Microsoft.PSharp
         /// <summary>
         /// Logs the specified text.
         /// </summary>
-        /// <param name="format">Text</param>
-        /// <param name="args">Arguments</param>
         protected internal virtual void Log(string format, params object[] args)
         {
             if (this.Configuration.Verbose > 1)
@@ -721,7 +546,6 @@ namespace Microsoft.PSharp
         /// <summary>
         /// Installs the specified <see cref="ILogger"/>.
         /// </summary>
-        /// <param name="logger">ILogger</param>
         public void SetLogger(ILogger logger)
         {
             this.Logger = logger ?? throw new InvalidOperationException("Cannot install a null logger.");
@@ -729,20 +553,8 @@ namespace Microsoft.PSharp
         }
 
         /// <summary>
-        /// Removes the currently installed <see cref="ILogger"/>, and replaces
-        /// it with the default <see cref="ILogger"/>.
-        /// </summary>
-        public void RemoveLogger()
-        {
-            this.Logger = new ConsoleLogger();
-        }
-
-        /// <summary>
         /// Gets the new operation group id to propagate.
         /// </summary>
-        /// <param name="sender">Sender machine</param>
-        /// <param name="operationGroupId">Operation group id</param>
-        /// <returns>Operation group Id</returns>
         internal Guid GetNewOperationGroupId(BaseMachine sender, Guid? operationGroupId)
         {
             if (operationGroupId.HasValue)
@@ -762,9 +574,6 @@ namespace Microsoft.PSharp
         /// <summary>
         /// Sets the operation group id for the specified machine.
         /// </summary>
-        /// <param name="created">Machine created</param>
-        /// <param name="sender">Sender machine</param>
-        /// <param name="operationGroupId">Operation group id</param>
         internal void SetOperationGroupIdForMachine(Machine created, BaseMachine sender, Guid? operationGroupId)
         {
             if (operationGroupId.HasValue)
@@ -782,34 +591,8 @@ namespace Microsoft.PSharp
         }
 
         /// <summary>
-        /// Installs the specified <see cref="INetworkProvider"/>.
-        /// </summary>
-        /// <param name="networkProvider">INetworkProvider</param>
-        public void SetNetworkProvider(INetworkProvider networkProvider)
-        {
-            if (networkProvider == null)
-            {
-                throw new InvalidOperationException("Cannot install a null network provider.");
-            }
-
-            this.NetworkProvider.Dispose();
-            this.NetworkProvider = networkProvider;
-        }
-
-        /// <summary>
-        /// Replaces the currently installed <see cref="INetworkProvider"/>
-        /// with the default <see cref="INetworkProvider"/>.
-        /// </summary>
-        public void RemoveNetworkProvider()
-        {
-            this.NetworkProvider.Dispose();
-            this.NetworkProvider = new LocalNetworkProvider(this);
-        }
-
-        /// <summary>
         /// Raises the <see cref="OnFailure"/> event with the specified <see cref="Exception"/>.
         /// </summary>
-        /// <param name="exception">Exception</param>
         protected internal void RaiseOnFailureEvent(Exception exception)
         {
             if (this.Configuration.AttachDebugger && exception is MachineActionExceptionFilterException &&
@@ -825,14 +608,11 @@ namespace Microsoft.PSharp
         /// <summary>
         /// Checks if an <see cref="OnEventDropped"/> handler has been registered by the user.
         /// </summary>
-        /// <returns>True if an <see cref="OnEventDropped"/> handler is registered.</returns>
         protected internal bool IsOnEventDroppedHandlerRegistered() => this.OnEventDropped != null;
 
         /// <summary>
         /// Tries to handle the specified dropped <see cref="Event"/>.
         /// </summary>
-        /// <param name="e">Event being dropped.</param>
-        /// <param name="mid">Target machine id.</param>
         protected internal void TryHandleDroppedEvent(Event e, MachineId mid)
         {
             this.OnEventDropped?.Invoke(e, mid);
@@ -842,9 +622,6 @@ namespace Microsoft.PSharp
         /// Throws an <see cref="AssertionFailureException"/> exception
         /// containing the specified exception.
         /// </summary>
-        /// <param name="exception">Exception</param>
-        /// <param name="s">Message</param>
-        /// <param name="args">Message arguments</param>
         internal virtual void WrapAndThrowException(Exception exception, string s, params object[] args)
         {
             throw (exception is AssertionFailureException)
@@ -860,7 +637,6 @@ namespace Microsoft.PSharp
             if (disposing)
             {
                 this.MachineIdCounter = 0;
-                this.NetworkProvider.Dispose();
             }
         }
 

--- a/Source/Core/Runtime/Exceptions/OnEventDroppedHandler.cs
+++ b/Source/Core/Runtime/Exceptions/OnEventDroppedHandler.cs
@@ -6,7 +6,7 @@
 namespace Microsoft.PSharp.Runtime
 {
     /// <summary>
-    /// Handles the <see cref="PSharpRuntime.OnEventDropped"/> event.
+    /// Handles the <see cref="IMachineRuntime.OnEventDropped"/> event.
     /// </summary>
     public delegate void OnEventDroppedHandler(Event e, MachineId target);
 }

--- a/Source/Core/Runtime/Exceptions/OnFailureHandler.cs
+++ b/Source/Core/Runtime/Exceptions/OnFailureHandler.cs
@@ -8,7 +8,7 @@ using System;
 namespace Microsoft.PSharp.Runtime
 {
     /// <summary>
-    /// Handles the <see cref="PSharpRuntime.OnFailure"/> event.
+    /// Handles the <see cref="IMachineRuntime.OnFailure"/> event.
     /// </summary>
     public delegate void OnFailureHandler(Exception ex);
 }

--- a/Source/Core/Runtime/Machines/BaseMachine.cs
+++ b/Source/Core/Runtime/Machines/BaseMachine.cs
@@ -19,7 +19,7 @@ namespace Microsoft.PSharp.Runtime
         /// <summary>
         /// The runtime that executes this machine.
         /// </summary>
-        internal PSharpRuntime Runtime { get; private set; }
+        internal BaseRuntime Runtime { get; private set; }
 
         /// <summary>
         /// The unique machine id.
@@ -35,10 +35,7 @@ namespace Microsoft.PSharp.Runtime
         /// <summary>
         /// Initializes this machine.
         /// </summary>
-        /// <param name="runtime">PSharpRuntime</param>
-        /// <param name="mid">MachineId</param>
-        /// <param name="info">MachineInfo</param>
-        internal void Initialize(PSharpRuntime runtime, MachineId mid, MachineInfo info)
+        internal void Initialize(BaseRuntime runtime, MachineId mid, MachineInfo info)
         {
             this.Runtime = runtime;
             this.Id = mid;
@@ -46,32 +43,22 @@ namespace Microsoft.PSharp.Runtime
         }
 
         /// <summary>
-        /// Determines whether the specified System.Object is equal
-        /// to the current System.Object.
+        /// Determines whether the specified object is equal to the current object.
         /// </summary>
-        /// <param name="obj">Object</param>
-        /// <returns>Boolean</returns>
         public override bool Equals(object obj)
         {
-            if (obj == null)
+            if (obj is BaseMachine m &&
+                this.GetType() == m.GetType())
             {
-                return false;
+                return this.Id.Value == m.Id.Value;
             }
 
-            BaseMachine m = obj as BaseMachine;
-            if (m == null ||
-                this.GetType() != m.GetType())
-            {
-                return false;
-            }
-
-            return this.Id.Value == m.Id.Value;
+            return false;
         }
 
         /// <summary>
         /// Returns the hash code for this instance.
         /// </summary>
-        /// <returns>int</returns>
         public override int GetHashCode()
         {
             return this.Id.Value.GetHashCode();
@@ -80,7 +67,6 @@ namespace Microsoft.PSharp.Runtime
         /// <summary>
         /// Returns a string that represents the current machine.
         /// </summary>
-        /// <returns>string</returns>
         public override string ToString()
         {
             return this.Id.Name;
@@ -90,7 +76,6 @@ namespace Microsoft.PSharp.Runtime
         /// Returns the set of all states in the machine
         /// (for code coverage).
         /// </summary>
-        /// <returns>Set of all states in the machine</returns>
         internal virtual HashSet<string> GetAllStates()
         {
             return new HashSet<string>();
@@ -100,7 +85,6 @@ namespace Microsoft.PSharp.Runtime
         /// Returns the set of all (states, registered event) pairs in the machine
         /// (for code coverage).
         /// </summary>
-        /// <returns>Set of all (states, registered event) pairs in the machine</returns>
         internal virtual HashSet<Tuple<string, string>> GetAllStateEventPairs()
         {
             return new HashSet<Tuple<string, string>>();

--- a/Source/Core/Runtime/Machines/Machine.cs
+++ b/Source/Core/Runtime/Machines/Machine.cs
@@ -262,37 +262,7 @@ namespace Microsoft.PSharp
         }
 
         /// <summary>
-        /// Creates a new remote machine of the specified type and with the specified
-        /// optional <see cref="Event"/>. This <see cref="Event"/> can only be used
-        /// to access its payload, and cannot be handled.
-        /// </summary>
-        /// <param name="type">Type of the machine</param>
-        /// <param name="endpoint">Endpoint</param>
-        /// <param name="e">Event</param>
-        /// <returns>MachineId</returns>
-        protected MachineId CreateRemoteMachine(Type type, string endpoint, Event e = null)
-        {
-            return this.Runtime.CreateRemoteMachine(type, null, endpoint, e, this, null);
-        }
-
-        /// <summary>
-        /// Creates a new remote machine of the specified type and name, and with the
-        /// specified optional <see cref="Event"/>. This <see cref="Event"/> can only
-        /// be used to access its payload, and cannot be handled.
-        /// </summary>
-        /// <param name="type">Type of the machine</param>
-        /// <param name="friendlyName">Friendly machine name used for logging</param>
-        /// <param name="endpoint">Endpoint</param>
-        /// <param name="e">Event</param>
-        /// <returns>MachineId</returns>
-        protected MachineId CreateRemoteMachine(Type type, string friendlyName,
-            string endpoint, Event e = null)
-        {
-            return this.Runtime.CreateRemoteMachine(type, friendlyName, endpoint, e, this, null);
-        }
-
-        /// <summary>
-        /// Sends an asynchronous <see cref="Event"/> to the specified machine.
+        /// Sends an asynchronous <see cref="Event"/> to a machine.
         /// </summary>
         /// <param name="mid">The id of the target machine.</param>
         /// <param name="e">The event to send.</param>
@@ -305,22 +275,6 @@ namespace Microsoft.PSharp
             // If the event is null, then report an error and exit.
             this.Assert(e != null, $"Machine '{this.Id}' is sending a null event.");
             this.Runtime.SendEvent(mid, e, this, options);
-        }
-
-        /// <summary>
-        /// Sends an asynchronous <see cref="Event"/> to a remote machine.
-        /// </summary>
-        /// <param name="mid">MachineId</param>
-        /// <param name="e">Event</param>
-        /// <param name="options">Optional parameters</param>
-        protected void RemoteSend(MachineId mid, Event e, SendOptions options = null)
-        {
-            // If the target machine is null, then report an error and exit.
-            this.Assert(mid != null, $"Machine '{this.Id}' is sending to a null machine.");
-
-            // If the event is null, then report an error and exit.
-            this.Assert(e != null, $"Machine '{this.Id}' is sending a null event.");
-            this.Runtime.SendEventRemotely(mid, e, this, options);
         }
 
         /// <summary>
@@ -369,8 +323,7 @@ namespace Microsoft.PSharp
             this.Assert(!this.Info.IsHalted, $"Machine '{this.Id}' invoked Goto while halted.");
 
             // If the state is not a state of the machine, then report an error and exit.
-            this.Assert(
-                StateTypeMap[this.GetType()].Any(val => val.DeclaringType.Equals(s.DeclaringType) && val.Name.Equals(s.Name)),
+            this.Assert(StateTypeMap[this.GetType()].Any(val => val.DeclaringType.Equals(s.DeclaringType) && val.Name.Equals(s.Name)),
                 $"Machine '{this.Id}' is trying to transition to non-existing state '{s.Name}'.");
             this.Raise(new GotoStateEvent(s));
         }
@@ -399,8 +352,7 @@ namespace Microsoft.PSharp
             this.Assert(!this.Info.IsHalted, $"Machine '{this.Id}' invoked Push while halted.");
 
             // If the state is not a state of the machine, then report an error and exit.
-            this.Assert(
-                StateTypeMap[this.GetType()].Any(val => val.DeclaringType.Equals(s.DeclaringType) && val.Name.Equals(s.Name)),
+            this.Assert(StateTypeMap[this.GetType()].Any(val => val.DeclaringType.Equals(s.DeclaringType) && val.Name.Equals(s.Name)),
                 $"Machine '{this.Id}' is trying to transition to non-existing state '{s.Name}'.");
             this.Raise(new PushStateEvent(s));
         }
@@ -640,16 +592,14 @@ namespace Microsoft.PSharp
                 if (eventInfo.Event.Assert >= 0)
                 {
                     var eventCount = this.Inbox.Count(val => val.EventType.Equals(eventInfo.EventType));
-                    this.Assert(
-                        eventCount <= eventInfo.Event.Assert,
+                    this.Assert(eventCount <= eventInfo.Event.Assert,
                         $"There are more than {eventInfo.Event.Assert} instances of '{eventInfo.EventName}' in the input queue of machine '{this}'");
                 }
 
                 if (eventInfo.Event.Assume >= 0)
                 {
                     var eventCount = this.Inbox.Count(val => val.EventType.Equals(eventInfo.EventType));
-                    this.Assert(
-                        eventCount <= eventInfo.Event.Assume,
+                    this.Assert(eventCount <= eventInfo.Event.Assume,
                         $"There are more than {eventInfo.Event.Assume} instances of '{eventInfo.EventName}' in the input queue of machine '{this}'");
                 }
 
@@ -1688,9 +1638,8 @@ namespace Microsoft.PSharp
                         BindingFlags.NonPublic | BindingFlags.Public |
                         BindingFlags.DeclaredOnly))
                     {
-                        this.Assert(
-                            t.IsSubclassOf(typeof(StateGroup)) ||
-                            t.IsSubclassOf(typeof(MachineState)), $"'{t.Name}' is neither a group of states nor a state.");
+                        this.Assert(t.IsSubclassOf(typeof(StateGroup)) || t.IsSubclassOf(typeof(MachineState)),
+                            $"'{t.Name}' is neither a group of states nor a state.");
                         stack.Push(t);
                     }
                 }
@@ -1744,8 +1693,7 @@ namespace Microsoft.PSharp
         /// </summary>
         internal override HashSet<string> GetAllStates()
         {
-            this.Assert(
-                StateMap.ContainsKey(this.GetType()),
+            this.Assert(StateMap.ContainsKey(this.GetType()),
                 $"Machine '{this.Id}' hasn't populated its states yet.");
 
             var allStates = new HashSet<string>();
@@ -1762,8 +1710,7 @@ namespace Microsoft.PSharp
         /// </summary>
         internal override HashSet<Tuple<string, string>> GetAllStateEventPairs()
         {
-            this.Assert(
-                StateMap.ContainsKey(this.GetType()),
+            this.Assert(StateMap.ContainsKey(this.GetType()),
                 $"Machine '{this.Id}' hasn't populated its states yet.");
 
             var pairs = new HashSet<Tuple<string, string>>();

--- a/Source/Core/Runtime/Monitors/Monitor.cs
+++ b/Source/Core/Runtime/Monitors/Monitor.cs
@@ -46,7 +46,7 @@ namespace Microsoft.PSharp
         /// <summary>
         /// The runtime that executes this monitor.
         /// </summary>
-        private PSharpRuntime Runtime;
+        private BaseRuntime Runtime;
 
         /// <summary>
         /// The monitor state.
@@ -177,11 +177,12 @@ namespace Microsoft.PSharp
         /// <summary>
         /// Initializes this monitor.
         /// </summary>
+        /// <param name="runtime">The runtime that executes this monitor.</param>
         /// <param name="mid">The monitor id.</param>
-        internal void Initialize(MachineId mid)
+        internal void Initialize(BaseRuntime runtime, MachineId mid)
         {
             this.Id = mid;
-            this.Runtime = mid.Runtime;
+            this.Runtime = runtime;
             this.IsInsideOnExit = false;
             this.CurrentActionCalledTransitionStatement = false;
         }

--- a/Source/Core/Runtime/ProductionRuntime.cs
+++ b/Source/Core/Runtime/ProductionRuntime.cs
@@ -15,9 +15,9 @@ using Microsoft.PSharp.Timers;
 namespace Microsoft.PSharp.Runtime
 {
     /// <summary>
-    /// Runtime for executing state-machines in production.
+    /// Runtime for executing machines in production.
     /// </summary>
-    internal sealed class ProductionRuntime : PSharpRuntime
+    internal sealed class ProductionRuntime : BaseRuntime
     {
         /// <summary>
         /// List of monitors in the program.
@@ -27,7 +27,14 @@ namespace Microsoft.PSharp.Runtime
         /// <summary>
         /// Initializes a new instance of the <see cref="ProductionRuntime"/> class.
         /// </summary>
-        /// <param name="configuration">Configuration</param>
+        internal ProductionRuntime()
+            : this(Configuration.Create())
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProductionRuntime"/> class.
+        /// </summary>
         internal ProductionRuntime(Configuration configuration)
             : base(configuration)
         {
@@ -40,37 +47,31 @@ namespace Microsoft.PSharp.Runtime
         /// or it can be bound to a previously created machine. In the second case, this
         /// machine id can be directly used to communicate with the corresponding machine.
         /// </summary>
-        public override MachineId CreateMachineIdFromName(Type type, string uniqueName) => new MachineId(type, uniqueName, this, true);
+        public override MachineId CreateMachineIdFromName(Type type, string machineName) => new MachineId(type, machineName, this, true);
 
         /// <summary>
         /// Creates a new machine of the specified <see cref="Type"/> and with
         /// the specified optional <see cref="Event"/>. This event can only be
         /// used to access its payload, and cannot be handled.
         /// </summary>
-        public override MachineId CreateMachine(Type type, Event e = null, Guid? operationGroupId = null)
-        {
-            return this.CreateMachine(null, type, null, e, null, operationGroupId);
-        }
-
-        /// <summary>
-        /// Creates a new machine of the specified <see cref="Type"/>, using the specified
-        /// unbound machine id, and passes the specified optional <see cref="Event"/>. This
-        /// event can only be used to access its payload, and cannot be handled.
-        /// </summary>
-        public override void CreateMachine(MachineId mid, Type type, Event e = null, Guid? operationGroupId = null)
-        {
-            this.CreateMachine(mid, type, null, e, null, operationGroupId);
-        }
+        public override MachineId CreateMachine(Type type, Event e = null, Guid? operationGroupId = null) =>
+            this.CreateMachine(null, type, null, e, null, operationGroupId);
 
         /// <summary>
         /// Creates a new machine of the specified <see cref="Type"/> and name, and
         /// with the specified optional <see cref="Event"/>. This event can only be
         /// used to access its payload, and cannot be handled.
         /// </summary>
-        public override MachineId CreateMachine(Type type, string friendlyName, Event e = null, Guid? operationGroupId = null)
-        {
-            return this.CreateMachine(null, type, friendlyName, e, null, operationGroupId);
-        }
+        public override MachineId CreateMachine(Type type, string machineName, Event e = null, Guid? operationGroupId = null) =>
+            this.CreateMachine(null, type, machineName, e, null, operationGroupId);
+
+        /// <summary>
+        /// Creates a new machine of the specified type, using the specified <see cref="MachineId"/>.
+        /// This method optionally passes an <see cref="Event"/> to the new machine, which can only
+        /// be used to access its payload, and cannot be handled.
+        /// </summary>
+        public override MachineId CreateMachine(MachineId mid, Type type, Event e = null, Guid? operationGroupId = null) =>
+            this.CreateMachine(mid, type, null, e, null, operationGroupId);
 
         /// <summary>
         /// Creates a new machine of the specified <see cref="Type"/> and with the
@@ -78,10 +79,17 @@ namespace Microsoft.PSharp.Runtime
         /// access its payload, and cannot be handled. The method returns only when
         /// the machine is initialized and the <see cref="Event"/> (if any) is handled.
         /// </summary>
-        public override Task<MachineId> CreateMachineAndExecute(Type type, Event e = null, Guid? operationGroupId = null)
-        {
-            return this.CreateMachineAndExecute(null, type, null, e, null, operationGroupId);
-        }
+        public override Task<MachineId> CreateMachineAndExecuteAsync(Type type, Event e = null, Guid? operationGroupId = null) =>
+            this.CreateMachineAndExecute(null, type, null, e, null, operationGroupId);
+
+        /// <summary>
+        /// Creates a new machine of the specified <see cref="Type"/> and name, and with
+        /// the specified optional <see cref="Event"/>. This event can only be used to
+        /// access its payload, and cannot be handled. The method returns only when the
+        /// machine is initialized and the <see cref="Event"/> (if any) is handled.
+        /// </summary>
+        public override Task<MachineId> CreateMachineAndExecuteAsync(Type type, string machineName, Event e = null, Guid? operationGroupId = null) =>
+            this.CreateMachineAndExecute(null, type, machineName, e, null, operationGroupId);
 
         /// <summary>
         /// Creates a new machine of the specified <see cref="Type"/>, using the specified
@@ -90,10 +98,17 @@ namespace Microsoft.PSharp.Runtime
         /// returns only when the machine is initialized and the <see cref="Event"/> (if any)
         /// is handled.
         /// </summary>
-        public override async Task CreateMachineAndExecute(MachineId mid, Type type, Event e = null, Guid? operationGroupId = null)
-        {
-            await this.CreateMachineAndExecute(mid, type, null, e, null, operationGroupId);
-        }
+        public override Task<MachineId> CreateMachineAndExecuteAsync(MachineId mid, Type type, Event e = null, Guid? operationGroupId = null) =>
+            this.CreateMachineAndExecute(mid, type, null, e, null, operationGroupId);
+
+        /// <summary>
+        /// Creates a new machine of the specified <see cref="Type"/> and with the
+        /// specified optional <see cref="Event"/>. This event can only be used to
+        /// access its payload, and cannot be handled. The method returns only when
+        /// the machine is initialized and the <see cref="Event"/> (if any) is handled.
+        /// </summary>
+        public override Task<MachineId> CreateMachineAndExecute(Type type, Event e = null, Guid? operationGroupId = null) =>
+            this.CreateMachineAndExecute(null, type, null, e, null, operationGroupId);
 
         /// <summary>
         /// Creates a new machine of the specified <see cref="Type"/> and name, and with
@@ -101,31 +116,18 @@ namespace Microsoft.PSharp.Runtime
         /// access its payload, and cannot be handled. The method returns only when the
         /// machine is initialized and the <see cref="Event"/> (if any) is handled.
         /// </summary>
-        public override Task<MachineId> CreateMachineAndExecute(Type type, string friendlyName, Event e = null, Guid? operationGroupId = null)
-        {
-            return this.CreateMachineAndExecute(null, type, friendlyName, e, null, operationGroupId);
-        }
+        public override Task<MachineId> CreateMachineAndExecute(Type type, string machineName, Event e = null, Guid? operationGroupId = null) =>
+            this.CreateMachineAndExecute(null, type, machineName, e, null, operationGroupId);
 
         /// <summary>
-        /// Creates a new remote machine of the specified <see cref="Type"/> and with
-        /// the specified optional <see cref="Event"/>. This event can only be used
-        /// to access its payload, and cannot be handled.
+        /// Creates a new machine of the specified <see cref="Type"/>, using the specified
+        /// unbound machine id, and passes the specified optional <see cref="Event"/>. This
+        /// event can only be used to access its payload, and cannot be handled. The method
+        /// returns only when the machine is initialized and the <see cref="Event"/> (if any)
+        /// is handled.
         /// </summary>
-        public override MachineId RemoteCreateMachine(Type type, string endpoint, Event e = null, Guid? operationGroupId = null)
-        {
-            return this.CreateRemoteMachine(type, null, endpoint, e, null, operationGroupId);
-        }
-
-        /// <summary>
-        /// Creates a new remote machine of the specified <see cref="Type"/> and name, and
-        /// with the specified optional <see cref="Event"/>. This event can only be used
-        /// to access its payload, and cannot be handled.
-        /// </summary>
-        public override MachineId RemoteCreateMachine(Type type, string friendlyName,
-            string endpoint, Event e = null, Guid? operationGroupId = null)
-        {
-            return this.CreateRemoteMachine(type, friendlyName, endpoint, e, null, operationGroupId);
-        }
+        public override Task<MachineId> CreateMachineAndExecute(MachineId mid, Type type, Event e = null, Guid? operationGroupId = null) =>
+            this.CreateMachineAndExecute(mid, type, null, e, null, operationGroupId);
 
         /// <summary>
         /// Sends an asynchronous <see cref="Event"/> to a machine.
@@ -141,11 +143,10 @@ namespace Microsoft.PSharp.Runtime
         }
 
         /// <summary>
-        /// Sends an <see cref="Event"/> to a machine. Returns immediately
-        /// if the target machine was already running. Otherwise blocks until the machine handles
-        /// the event and reaches quiescense again.
+        /// Sends an <see cref="Event"/> to a machine. Returns immediately if the target machine was already
+        /// running. Otherwise blocks until the machine handles the event and reaches quiescense again.
         /// </summary>
-        public override Task<bool> SendEventAndExecute(MachineId target, Event e, SendOptions options = null)
+        public override Task<bool> SendEventAndExecuteAsync(MachineId target, Event e, SendOptions options = null)
         {
             // If the target machine is null then report an error and exit.
             this.Assert(target != null, "Cannot send to a null machine.");
@@ -156,43 +157,11 @@ namespace Microsoft.PSharp.Runtime
         }
 
         /// <summary>
-        /// Sends an asynchronous <see cref="Event"/> to a remote machine.
+        /// Sends an <see cref="Event"/> to a machine. Returns immediately if the target machine was already
+        /// running. Otherwise blocks until the machine handles the event and reaches quiescense again.
         /// </summary>
-        public override void RemoteSendEvent(MachineId target, Event e, SendOptions options = null)
-        {
-            // If the target machine is null then report an error and exit.
-            this.Assert(target != null, "Cannot send to a null machine.");
-
-            // If the event is null then report an error and exit.
-            this.Assert(e != null, "Cannot send a null event.");
-            this.SendEventRemotely(target, e, null, options);
-        }
-
-        /// <summary>
-        /// Registers a new specification monitor of the specified <see cref="Type"/>.
-        /// </summary>
-        public override void RegisterMonitor(Type type)
-        {
-            this.TryCreateMonitor(type);
-        }
-
-        /// <summary>
-        /// Invokes the specified monitor with the specified <see cref="Event"/>.
-        /// </summary>
-        public override void InvokeMonitor<T>(Event e)
-        {
-            this.InvokeMonitor(typeof(T), e);
-        }
-
-        /// <summary>
-        /// Invokes the specified monitor with the specified <see cref="Event"/>.
-        /// </summary>
-        public override void InvokeMonitor(Type type, Event e)
-        {
-            // If the event is null then report an error and exit.
-            this.Assert(e != null, "Cannot monitor a null event.");
-            this.Monitor(type, null, e);
-        }
+        public override Task<bool> SendEventAndExecute(MachineId target, Event e, SendOptions options = null) =>
+            this.SendEventAndExecuteAsync(target, e, options);
 
         /// <summary>
         /// Returns the operation group id of the specified machine. Returns <see cref="Guid.Empty"/>
@@ -210,21 +179,11 @@ namespace Microsoft.PSharp.Runtime
         }
 
         /// <summary>
-        /// Notifies each active machine to halt execution to allow the runtime
-        /// to reach quiescence. This is an experimental feature, which should
-        /// be used only for testing purposes.
-        /// </summary>
-        public override void Stop()
-        {
-            this.IsRunning = false;
-        }
-
-        /// <summary>
         /// Creates a new <see cref="Machine"/> of the specified <see cref="Type"/>.
         /// </summary>
-        internal override MachineId CreateMachine(MachineId mid, Type type, string friendlyName, Event e, Machine creator, Guid? operationGroupId)
+        internal override MachineId CreateMachine(MachineId mid, Type type, string machineName, Event e, Machine creator, Guid? operationGroupId)
         {
-            Machine machine = this.CreateMachine(mid, type, friendlyName);
+            Machine machine = this.CreateMachine(mid, type, machineName);
             this.Logger.OnCreateMachine(machine.Id, creator?.Id);
             this.SetOperationGroupIdForMachine(machine, creator, operationGroupId);
             this.RunMachineEventHandler(machine, e, true);
@@ -233,12 +192,12 @@ namespace Microsoft.PSharp.Runtime
 
         /// <summary>
         /// Creates a new <see cref="Machine"/> of the specified <see cref="Type"/>. The
-        /// method returns only when the created machine reaches quiescence
+        /// method returns only when the created machine reaches quiescence.
         /// </summary>
-        internal override async Task<MachineId> CreateMachineAndExecute(MachineId mid, Type type, string friendlyName, Event e,
+        internal override async Task<MachineId> CreateMachineAndExecute(MachineId mid, Type type, string machineName, Event e,
             Machine creator, Guid? operationGroupId)
         {
-            Machine machine = this.CreateMachine(mid, type, friendlyName);
+            Machine machine = this.CreateMachine(mid, type, machineName);
             this.Logger.OnCreateMachine(machine.Id, creator?.Id);
             this.SetOperationGroupIdForMachine(machine, creator, operationGroupId);
             await this.RunMachineEventHandlerAsync(machine, e, true);
@@ -246,25 +205,15 @@ namespace Microsoft.PSharp.Runtime
         }
 
         /// <summary>
-        /// Creates a new remote <see cref="Machine"/> of the specified <see cref="System.Type"/>.
-        /// </summary>
-        internal override MachineId CreateRemoteMachine(Type type, string friendlyName, string endpoint,
-            Event e, Machine creator, Guid? operationGroupId)
-        {
-            this.Assert(type.IsSubclassOf(typeof(Machine)), $"Type '{type.Name}' is not a machine.");
-            return this.NetworkProvider.RemoteCreateMachine(type, friendlyName, endpoint, e);
-        }
-
-        /// <summary>
         /// Creates a new <see cref="Machine"/> of the specified <see cref="Type"/>.
         /// </summary>
-        private Machine CreateMachine(MachineId mid, Type type, string friendlyName)
+        private Machine CreateMachine(MachineId mid, Type type, string machineName)
         {
             this.Assert(type.IsSubclassOf(typeof(Machine)), "Type '{0}' is not a machine.", type.Name);
 
             if (mid == null)
             {
-                mid = new MachineId(type, friendlyName, this);
+                mid = new MachineId(type, machineName, this);
             }
             else
             {
@@ -293,12 +242,12 @@ namespace Microsoft.PSharp.Runtime
         /// <summary>
         /// Sends an asynchronous <see cref="Event"/> to a machine.
         /// </summary>
-        internal override void SendEvent(MachineId mid, Event e, BaseMachine sender, SendOptions options)
+        internal override void SendEvent(MachineId target, Event e, BaseMachine sender, SendOptions options)
         {
             var operationGroupId = this.GetNewOperationGroupId(sender, options?.OperationGroupId);
-            if (!this.GetTargetMachine(mid, e, sender, operationGroupId, out Machine machine))
+            if (!this.GetTargetMachine(target, e, sender, operationGroupId, out Machine machine))
             {
-                this.TryHandleDroppedEvent(e, mid);
+                this.TryHandleDroppedEvent(e, target);
                 return;
             }
 
@@ -315,12 +264,12 @@ namespace Microsoft.PSharp.Runtime
         /// if the target machine was already running. Otherwise blocks until the machine handles
         /// the event and reaches quiescense again.
         /// </summary>
-        internal override async Task<bool> SendEventAndExecute(MachineId mid, Event e, BaseMachine sender, SendOptions options)
+        internal override async Task<bool> SendEventAndExecute(MachineId target, Event e, BaseMachine sender, SendOptions options)
         {
             var operationGroupId = this.GetNewOperationGroupId(sender, options?.OperationGroupId);
-            if (!this.GetTargetMachine(mid, e, sender, operationGroupId, out Machine machine))
+            if (!this.GetTargetMachine(target, e, sender, operationGroupId, out Machine machine))
             {
-                this.TryHandleDroppedEvent(e, mid);
+                this.TryHandleDroppedEvent(e, target);
                 return true;
             }
 
@@ -333,14 +282,6 @@ namespace Microsoft.PSharp.Runtime
             }
 
             return false;
-        }
-
-        /// <summary>
-        /// Sends an asynchronous <see cref="Event"/> to a remote machine.
-        /// </summary>
-        internal override void SendEventRemotely(MachineId mid, Event e, BaseMachine sender, SendOptions options)
-        {
-            this.NetworkProvider.RemoteSend(mid, e);
         }
 
         /// <summary>
@@ -413,7 +354,10 @@ namespace Microsoft.PSharp.Runtime
         /// <summary>
         /// Returns the timer machine type.
         /// </summary>
-        internal override Type GetTimerMachineType() => typeof(ProductionTimerMachine);
+        internal override Type GetTimerMachineType()
+        {
+            return typeof(ProductionTimerMachine);
+        }
 
         /// <summary>
         /// Tries to create a new <see cref="PSharp.Monitor"/> of the specified <see cref="Type"/>.
@@ -440,7 +384,7 @@ namespace Microsoft.PSharp.Runtime
             MachineId mid = new MachineId(type, null, this);
             Monitor monitor = (Monitor)Activator.CreateInstance(type);
 
-            monitor.Initialize(mid);
+            monitor.Initialize(this, mid);
             monitor.InitializeStateInformation();
 
             lock (this.Monitors)

--- a/Source/Core/Runtime/Timers/DeprecatedTimerAPIs.cs
+++ b/Source/Core/Runtime/Timers/DeprecatedTimerAPIs.cs
@@ -80,7 +80,6 @@ namespace Microsoft.PSharp.Deprecated.Timers
     /// <summary>
     /// Timeout event sent by the timer.
     /// </summary>
-    [Obsolete("The TimedMachine class is deprecated; use the new StartTimer/StartPeriodicTimer APIs in the Machine class instead.")]
     public class TimerElapsedEvent : Event
     {
         /// <summary>
@@ -101,7 +100,6 @@ namespace Microsoft.PSharp.Deprecated.Timers
     /// <summary>
     /// Unique identifier for a timer
     /// </summary>
-    [Obsolete("The TimerId is deprecated; use the new StartTimer/StartPeriodicTimer APIs in the Machine class instead.")]
     public class TimerId
     {
         /// <summary>
@@ -224,8 +222,7 @@ namespace Microsoft.PSharp.Deprecated.Timers
     /// <summary>
     /// Wrapper class for a system timer.
     /// </summary>
-    [Obsolete("The ProductionTimerMachine class is deprecated; use the new StartTimer/StartPeriodicTimer APIs in the Machine class instead.")]
-    public class ProductionTimerMachine : Machine
+    internal class ProductionTimerMachine : Machine
     {
         /// <summary>
         /// Specified if periodic timeout events are desired.

--- a/Source/DataFlowAnalysis/Properties/codeanalysis.ruleset
+++ b/Source/DataFlowAnalysis/Properties/codeanalysis.ruleset
@@ -75,7 +75,7 @@
     <Rule Id="SA1101" Action="Error" />
     <Rule Id="SA1106" Action="Error" />
     <Rule Id="SA1108" Action="Error" />
-    <Rule Id="SA1116" Action="Error" />
+    <Rule Id="SA1116" Action="None" />
     <Rule Id="SA1117" Action="None" />
     <Rule Id="SA1118" Action="None" />
     <Rule Id="SA1119" Action="Error" />

--- a/Source/LanguageServices/Properties/codeanalysis.ruleset
+++ b/Source/LanguageServices/Properties/codeanalysis.ruleset
@@ -75,7 +75,7 @@
     <Rule Id="SA1101" Action="Error" />
     <Rule Id="SA1106" Action="Error" />
     <Rule Id="SA1108" Action="Error" />
-    <Rule Id="SA1116" Action="Error" />
+    <Rule Id="SA1116" Action="None" />
     <Rule Id="SA1117" Action="None" />
     <Rule Id="SA1118" Action="None" />
     <Rule Id="SA1119" Action="Error" />

--- a/Source/SchedulingStrategies/Properties/codeanalysis.ruleset
+++ b/Source/SchedulingStrategies/Properties/codeanalysis.ruleset
@@ -75,7 +75,7 @@
     <Rule Id="SA1101" Action="Error" />
     <Rule Id="SA1106" Action="Error" />
     <Rule Id="SA1108" Action="Error" />
-    <Rule Id="SA1116" Action="Error" />
+    <Rule Id="SA1116" Action="None" />
     <Rule Id="SA1117" Action="None" />
     <Rule Id="SA1118" Action="None" />
     <Rule Id="SA1119" Action="Error" />

--- a/Source/SharedObjects/Properties/codeanalysis.ruleset
+++ b/Source/SharedObjects/Properties/codeanalysis.ruleset
@@ -75,7 +75,7 @@
     <Rule Id="SA1101" Action="Error" />
     <Rule Id="SA1106" Action="Error" />
     <Rule Id="SA1108" Action="Error" />
-    <Rule Id="SA1116" Action="Error" />
+    <Rule Id="SA1116" Action="None" />
     <Rule Id="SA1117" Action="None" />
     <Rule Id="SA1118" Action="None" />
     <Rule Id="SA1119" Action="Error" />

--- a/Source/SharedObjects/SharedCounter/SharedCounter.cs
+++ b/Source/SharedObjects/SharedCounter/SharedCounter.cs
@@ -16,9 +16,9 @@ namespace Microsoft.PSharp.SharedObjects
         /// <summary>
         /// Creates a new shared counter.
         /// </summary>
-        /// <param name="runtime">PSharpRuntime</param>
-        /// <param name="value">Initial value</param>
-        public static ISharedCounter Create(PSharpRuntime runtime, int value = 0)
+        /// <param name="runtime">The machine runtime.</param>
+        /// <param name="value">The initial value.</param>
+        public static ISharedCounter Create(IMachineRuntime runtime, int value = 0)
         {
             if (runtime is ProductionRuntime)
             {

--- a/Source/SharedObjects/SharedDictionary/SharedDictionary.cs
+++ b/Source/SharedObjects/SharedDictionary/SharedDictionary.cs
@@ -18,8 +18,8 @@ namespace Microsoft.PSharp.SharedObjects
         /// <summary>
         /// Creates a new shared dictionary.
         /// </summary>
-        /// <param name="runtime">PSharpRuntime</param>
-        public static ISharedDictionary<TKey, TValue> Create<TKey, TValue>(PSharpRuntime runtime)
+        /// <param name="runtime">The machine runtime.</param>
+        public static ISharedDictionary<TKey, TValue> Create<TKey, TValue>(IMachineRuntime runtime)
         {
             if (runtime is ProductionRuntime)
             {
@@ -38,9 +38,9 @@ namespace Microsoft.PSharp.SharedObjects
         /// <summary>
         /// Creates a new shared dictionary.
         /// </summary>
-        /// <param name="comparer">Comparer for keys</param>
-        /// <param name="runtime">PSharp runtime</param>
-        public static ISharedDictionary<TKey, TValue> Create<TKey, TValue>(IEqualityComparer<TKey> comparer, PSharpRuntime runtime)
+        /// <param name="comparer">The key comparer.</param>
+        /// <param name="runtime">The machine runtime.</param>
+        public static ISharedDictionary<TKey, TValue> Create<TKey, TValue>(IEqualityComparer<TKey> comparer, IMachineRuntime runtime)
         {
             if (runtime is ProductionRuntime)
             {

--- a/Source/SharedObjects/SharedRegister/SharedRegister.cs
+++ b/Source/SharedObjects/SharedRegister/SharedRegister.cs
@@ -16,9 +16,9 @@ namespace Microsoft.PSharp.SharedObjects
         /// <summary>
         /// Creates a new shared register.
         /// </summary>
-        /// <param name="runtime">PSharpRuntime</param>
-        /// <param name="value">Initial value</param>
-        public static ISharedRegister<T> Create<T>(PSharpRuntime runtime, T value = default)
+        /// <param name="runtime">The machine runtime.</param>
+        /// <param name="value">The initial value.</param>
+        public static ISharedRegister<T> Create<T>(IMachineRuntime runtime, T value = default)
             where T : struct
         {
             if (runtime is ProductionRuntime)

--- a/Source/StaticAnalysis/Properties/codeanalysis.ruleset
+++ b/Source/StaticAnalysis/Properties/codeanalysis.ruleset
@@ -75,7 +75,7 @@
     <Rule Id="SA1101" Action="Error" />
     <Rule Id="SA1106" Action="Error" />
     <Rule Id="SA1108" Action="Error" />
-    <Rule Id="SA1116" Action="Error" />
+    <Rule Id="SA1116" Action="None" />
     <Rule Id="SA1117" Action="None" />
     <Rule Id="SA1118" Action="None" />
     <Rule Id="SA1119" Action="Error" />

--- a/Source/TestingServices/Engines/AbstractTestingEngine.cs
+++ b/Source/TestingServices/Engines/AbstractTestingEngine.cs
@@ -72,7 +72,7 @@ namespace Microsoft.PSharp.TestingServices
         /// <summary>
         /// A P# test action.
         /// </summary>
-        internal Action<PSharpRuntime> TestAction;
+        internal Action<IMachineRuntime> TestAction;
 
         /// <summary>
         /// Set of callbacks to invoke at the end
@@ -250,7 +250,7 @@ namespace Microsoft.PSharp.TestingServices
         /// <summary>
         /// Initializes a new instance of the <see cref="AbstractTestingEngine"/> class.
         /// </summary>
-        protected AbstractTestingEngine(Configuration configuration, Action<PSharpRuntime> action)
+        protected AbstractTestingEngine(Configuration configuration, Action<IMachineRuntime> action)
         {
             this.Initialize(configuration);
             this.TestAction = action;
@@ -538,12 +538,12 @@ namespace Microsoft.PSharp.TestingServices
                 testMethod.IsConstructor ||
                 !testMethod.IsPublic || !testMethod.IsStatic ||
                 testMethod.GetParameters().Length != 1 ||
-                testMethod.GetParameters()[0].ParameterType != typeof(PSharpRuntime))
+                testMethod.GetParameters()[0].ParameterType != typeof(IMachineRuntime))
             {
                 Error.ReportAndExit("Incorrect test method declaration. Please " +
                     "declare the test method as follows:\n" +
                     $"  [{typeof(TestAttribute).FullName}] public static void " +
-                    $"{testMethod.Name}(PSharpRuntime runtime) {{ ... }}");
+                    $"{testMethod.Name}(IMachineRuntime runtime) {{ ... }}");
             }
 
             this.TestMethod = testMethod;

--- a/Source/TestingServices/Engines/BugFindingEngine.cs
+++ b/Source/TestingServices/Engines/BugFindingEngine.cs
@@ -44,7 +44,7 @@ namespace Microsoft.PSharp.TestingServices
         /// <summary>
         /// Creates a new P# bug-finding engine.
         /// </summary>
-        public static BugFindingEngine Create(Configuration configuration, Action<PSharpRuntime> action)
+        public static BugFindingEngine Create(Configuration configuration, Action<IMachineRuntime> action)
         {
             return new BugFindingEngine(configuration, action);
         }
@@ -167,7 +167,7 @@ namespace Microsoft.PSharp.TestingServices
         /// <summary>
         /// Initializes a new instance of the <see cref="BugFindingEngine"/> class.
         /// </summary>
-        private BugFindingEngine(Configuration configuration, Action<PSharpRuntime> action)
+        private BugFindingEngine(Configuration configuration, Action<IMachineRuntime> action)
             : base(configuration, action)
         {
             if (this.Configuration.EnableDataRaceDetection)

--- a/Source/TestingServices/Engines/ReplayEngine.cs
+++ b/Source/TestingServices/Engines/ReplayEngine.cs
@@ -46,7 +46,7 @@ namespace Microsoft.PSharp.TestingServices
         /// <summary>
         /// Creates a new P# replaying engine.
         /// </summary>
-        public static ReplayEngine Create(Configuration configuration, Action<PSharpRuntime> action)
+        public static ReplayEngine Create(Configuration configuration, Action<IMachineRuntime> action)
         {
             configuration.SchedulingStrategy = SchedulingStrategy.Replay;
             return new ReplayEngine(configuration, action);
@@ -55,7 +55,7 @@ namespace Microsoft.PSharp.TestingServices
         /// <summary>
         /// Creates a new P# replaying engine.
         /// </summary>
-        public static ReplayEngine Create(Configuration configuration, Action<PSharpRuntime> action, string trace)
+        public static ReplayEngine Create(Configuration configuration, Action<IMachineRuntime> action, string trace)
         {
             configuration.SchedulingStrategy = SchedulingStrategy.Replay;
             configuration.ScheduleTrace = trace;
@@ -107,7 +107,7 @@ namespace Microsoft.PSharp.TestingServices
         /// <summary>
         /// Initializes a new instance of the <see cref="ReplayEngine"/> class.
         /// </summary>
-        private ReplayEngine(Configuration configuration, Action<PSharpRuntime> action)
+        private ReplayEngine(Configuration configuration, Action<IMachineRuntime> action)
             : base(configuration, action)
         {
         }

--- a/Source/TestingServices/Engines/TestingEngineFactory.cs
+++ b/Source/TestingServices/Engines/TestingEngineFactory.cs
@@ -16,8 +16,6 @@ namespace Microsoft.PSharp.TestingServices
         /// <summary>
         /// Creates a new P# bug-finding engine.
         /// </summary>
-        /// <param name="configuration">Configuration</param>
-        /// <returns>BugFindingEngine</returns>
         public static ITestingEngine CreateBugFindingEngine(Configuration configuration)
         {
             return BugFindingEngine.Create(configuration);
@@ -26,9 +24,6 @@ namespace Microsoft.PSharp.TestingServices
         /// <summary>
         /// Creates a new P# bug-finding engine.
         /// </summary>
-        /// <param name="configuration">Configuration</param>
-        /// <param name="assembly">Assembly</param>
-        /// <returns>BugFindingEngine</returns>
         public static ITestingEngine CreateBugFindingEngine(
             Configuration configuration, Assembly assembly)
         {
@@ -38,11 +33,8 @@ namespace Microsoft.PSharp.TestingServices
         /// <summary>
         /// Creates a new P# bug-finding engine.
         /// </summary>
-        /// <param name="configuration">Configuration</param>
-        /// <param name="action">Action</param>
-        /// <returns>BugFindingEngine</returns>
         public static ITestingEngine CreateBugFindingEngine(
-            Configuration configuration, Action<PSharpRuntime> action)
+            Configuration configuration, Action<IMachineRuntime> action)
         {
             return BugFindingEngine.Create(configuration, action);
         }
@@ -50,8 +42,6 @@ namespace Microsoft.PSharp.TestingServices
         /// <summary>
         /// Creates a new P# replay engine.
         /// </summary>
-        /// <param name="configuration">Configuration</param>
-        /// <returns>BugFindingEngine</returns>
         public static ITestingEngine CreateReplayEngine(Configuration configuration)
         {
             return ReplayEngine.Create(configuration);
@@ -60,9 +50,6 @@ namespace Microsoft.PSharp.TestingServices
         /// <summary>
         /// Creates a new P# replay engine.
         /// </summary>
-        /// <param name="configuration">Configuration</param>
-        /// <param name="assembly">Assembly</param>
-        /// <returns>BugFindingEngine</returns>
         public static ITestingEngine CreateReplayEngine(Configuration configuration, Assembly assembly)
         {
             return ReplayEngine.Create(configuration, assembly);
@@ -71,10 +58,7 @@ namespace Microsoft.PSharp.TestingServices
         /// <summary>
         /// Creates a new P# replay engine.
         /// </summary>
-        /// <param name="configuration">Configuration</param>
-        /// <param name="action">Action</param>
-        /// <returns>BugFindingEngine</returns>
-        public static ITestingEngine CreateReplayEngine(Configuration configuration, Action<PSharpRuntime> action)
+        public static ITestingEngine CreateReplayEngine(Configuration configuration, Action<IMachineRuntime> action)
         {
             return ReplayEngine.Create(configuration, action);
         }

--- a/Source/TestingServices/Properties/codeanalysis.ruleset
+++ b/Source/TestingServices/Properties/codeanalysis.ruleset
@@ -75,7 +75,7 @@
     <Rule Id="SA1101" Action="Error" />
     <Rule Id="SA1106" Action="Error" />
     <Rule Id="SA1108" Action="Error" />
-    <Rule Id="SA1116" Action="Error" />
+    <Rule Id="SA1116" Action="None" />
     <Rule Id="SA1117" Action="None" />
     <Rule Id="SA1118" Action="None" />
     <Rule Id="SA1119" Action="Error" />

--- a/Source/TestingServices/RaceDetection/IRegisterRuntimeOperation.cs
+++ b/Source/TestingServices/RaceDetection/IRegisterRuntimeOperation.cs
@@ -83,7 +83,7 @@ namespace Microsoft.PSharp.TestingServices
         /// <summary>
         /// Set the runtime an implementer should forward TryGetCurrentMachineId calls to.
         /// </summary>
-        void RegisterRuntime(PSharpRuntime runtime);
+        void RegisterRuntime(IMachineRuntime runtime);
 
         /// <summary>
         /// Return true if the runtime is currently executing a machine's action.

--- a/Source/TestingServices/RaceDetection/RaceDetectionEngine.cs
+++ b/Source/TestingServices/RaceDetection/RaceDetectionEngine.cs
@@ -127,7 +127,7 @@ namespace Microsoft.PSharp.TestingServices.RaceDetection
         /// <summary>
         /// Registers the testing runtime.
         /// </summary>
-        public void RegisterRuntime(PSharpRuntime runtime)
+        public void RegisterRuntime(IMachineRuntime runtime)
         {
             runtime.Assert(
                 (runtime as TestingRuntime) != null,

--- a/Source/TestingServices/Runtime/TestHarnessMachine.cs
+++ b/Source/TestingServices/Runtime/TestHarnessMachine.cs
@@ -24,12 +24,12 @@ namespace Microsoft.PSharp.TestingServices
         /// <summary>
         /// The test action.
         /// </summary>
-        private readonly Action<PSharpRuntime> TestAction;
+        private readonly Action<IMachineRuntime> TestAction;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TestHarnessMachine"/> class.
         /// </summary>
-        internal TestHarnessMachine(MethodInfo testMethod, Action<PSharpRuntime> testAction)
+        internal TestHarnessMachine(MethodInfo testMethod, Action<IMachineRuntime> testAction)
         {
             this.TestMethod = testMethod;
             this.TestAction = testAction;

--- a/Source/TestingServices/Runtime/Timers/DeprecatedTimerAPIs.cs
+++ b/Source/TestingServices/Runtime/Timers/DeprecatedTimerAPIs.cs
@@ -3,8 +3,6 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------------------------------------------
 
-using System;
-
 using Microsoft.PSharp.Deprecated.Timers;
 
 namespace Microsoft.PSharp.TestingServices.Deprecated.Timers
@@ -20,7 +18,6 @@ namespace Microsoft.PSharp.TestingServices.Deprecated.Timers
     /// <summary>
     /// A timer model, used for testing purposes.
     /// </summary>
-    [Obsolete("The ModelTimerMachine class is deprecated; use the new StartTimer/StartPeriodicTimer APIs in the Machine class instead.")]
     public class ModelTimerMachine : Machine
     {
         /// <summary>

--- a/Tests/Core.Tests/BaseTest.cs
+++ b/Tests/Core.Tests/BaseTest.cs
@@ -19,7 +19,7 @@ namespace Microsoft.PSharp.Core.Tests
         {
         }
 
-        protected void Run(Configuration configuration, Action<PSharpRuntime> test)
+        protected void Run(Configuration configuration, Action<IMachineRuntime> test)
         {
             var logger = new ThreadSafeInMemoryLogger();
             var outputLogger = new Common.TestOutputLogger(this.TestOutput);

--- a/Tests/Core.Tests/ExceptionPropagation/ExceptionPropagationTest.cs
+++ b/Tests/Core.Tests/ExceptionPropagation/ExceptionPropagationTest.cs
@@ -75,7 +75,7 @@ namespace Microsoft.PSharp.Core.Tests
         [Fact]
         public void TestAssertFailureNoEventHandler()
         {
-            PSharpRuntime runtime = PSharpRuntime.Create();
+            var runtime = PSharpRuntime.Create();
             var tcs = new TaskCompletionSource<bool>();
             runtime.CreateMachine(typeof(M), new Configure(tcs));
             tcs.Task.Wait();
@@ -85,7 +85,7 @@ namespace Microsoft.PSharp.Core.Tests
         public void TestAssertFailureEventHandler()
         {
             var config = GetConfiguration().WithVerbosityEnabled(2);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var tcsFail = new TaskCompletionSource<bool>();
                 int count = 0;
@@ -116,7 +116,7 @@ namespace Microsoft.PSharp.Core.Tests
         public void TestUnhandledExceptionEventHandler()
         {
             var config = GetConfiguration().WithVerbosityEnabled(2);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var tcsFail = new TaskCompletionSource<bool>();
                 int count = 0;

--- a/Tests/Core.Tests/ExceptionPropagation/OnExceptionTest.cs
+++ b/Tests/Core.Tests/ExceptionPropagation/OnExceptionTest.cs
@@ -202,7 +202,7 @@ namespace Microsoft.PSharp.Core.Tests
         public void TestOnExceptionCalledOnce1()
         {
             var config = GetConfiguration().WithVerbosityEnabled(2);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var failed = false;
                 var tcs = new TaskCompletionSource<bool>();
@@ -229,7 +229,7 @@ namespace Microsoft.PSharp.Core.Tests
         public void TestOnExceptionCalledOnce2()
         {
             var config = GetConfiguration().WithVerbosityEnabled(2);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var failed = false;
                 var tcs = new TaskCompletionSource<bool>();
@@ -254,7 +254,7 @@ namespace Microsoft.PSharp.Core.Tests
         public void TestOnExceptionCalledOnceAsync1()
         {
             var config = GetConfiguration().WithVerbosityEnabled(2);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var failed = false;
                 var tcs = new TaskCompletionSource<bool>();
@@ -281,7 +281,7 @@ namespace Microsoft.PSharp.Core.Tests
         public void TestOnExceptionCalledOnceAsync2()
         {
             var config = GetConfiguration().WithVerbosityEnabled(2);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var failed = false;
                 var tcs = new TaskCompletionSource<bool>();
@@ -306,7 +306,7 @@ namespace Microsoft.PSharp.Core.Tests
         public void TestOnExceptionCanHalt()
         {
             var config = GetConfiguration().WithVerbosityEnabled(2);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var failed = false;
                 var tcs = new TaskCompletionSource<bool>();
@@ -331,7 +331,7 @@ namespace Microsoft.PSharp.Core.Tests
         public void TestUnHandledEventCanHalt()
         {
             var config = GetConfiguration().WithVerbosityEnabled(2);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var failed = false;
                 var tcs = new TaskCompletionSource<bool>();

--- a/Tests/Core.Tests/Features/Deprecated/TimerTest.cs
+++ b/Tests/Core.Tests/Features/Deprecated/TimerTest.cs
@@ -291,7 +291,7 @@ namespace Microsoft.PSharp.Core.Tests.Deprecated
         public void BasicPeriodicTimerOperationTest()
         {
             var config = GetConfiguration().WithVerbosityEnabled(2);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var tcs = new TaskCompletionSource<bool>();
                 r.CreateMachine(typeof(T1), new Configure(tcs, true));
@@ -305,7 +305,7 @@ namespace Microsoft.PSharp.Core.Tests.Deprecated
         public void BasicSingleTimerOperationTest()
         {
             var config = GetConfiguration().WithVerbosityEnabled(2);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var tcs = new TaskCompletionSource<bool>();
                 r.CreateMachine(typeof(T1), new Configure(tcs, false));
@@ -322,7 +322,7 @@ namespace Microsoft.PSharp.Core.Tests.Deprecated
         public void InboxFlushOperationTest()
         {
             var config = GetConfiguration().WithVerbosityEnabled(2);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var tcs = new TaskCompletionSource<bool>();
                 r.CreateMachine(typeof(FlushingClient), new Configure(tcs, true));
@@ -336,7 +336,7 @@ namespace Microsoft.PSharp.Core.Tests.Deprecated
         public void IllegalTimerStoppageTest()
         {
             var config = GetConfiguration().WithVerbosityEnabled(2);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var tcs = new TaskCompletionSource<bool>();
                 r.CreateMachine(typeof(T2), new Configure(tcs, true));
@@ -350,7 +350,7 @@ namespace Microsoft.PSharp.Core.Tests.Deprecated
         public void IllegalPeriodSpecificationTest()
         {
             var config = GetConfiguration().WithVerbosityEnabled(2);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var tcs = new TaskCompletionSource<bool>();
                 r.CreateMachine(typeof(T4), new ConfigureWithPeriod(tcs, -1));

--- a/Tests/Core.Tests/Features/GetOperationGroupIdTest.cs
+++ b/Tests/Core.Tests/Features/GetOperationGroupIdTest.cs
@@ -72,7 +72,7 @@ namespace Microsoft.PSharp.Core.Tests
         private void AssertSucceeded(Type machine)
         {
             var config = GetConfiguration().WithVerbosityEnabled(2);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var failed = false;
                 var tcs = new TaskCompletionSource<bool>();

--- a/Tests/Core.Tests/Features/OnEventDroppedTest.cs
+++ b/Tests/Core.Tests/Features/OnEventDroppedTest.cs
@@ -54,7 +54,7 @@ namespace Microsoft.PSharp.Core.Tests
         public void TestOnDroppedCalled1()
         {
             var config = GetConfiguration().WithVerbosityEnabled(2);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var called = false;
                 var tcs = new TaskCompletionSource<bool>();
@@ -94,7 +94,7 @@ namespace Microsoft.PSharp.Core.Tests
         public void TestOnDroppedCalled2()
         {
             var config = GetConfiguration().WithVerbosityEnabled(2);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var called = false;
                 var tcs = new TaskCompletionSource<bool>();
@@ -118,7 +118,7 @@ namespace Microsoft.PSharp.Core.Tests
         public void TestOnDroppedParams()
         {
             var config = GetConfiguration().WithVerbosityEnabled(2);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var called = false;
                 var tcs = new TaskCompletionSource<bool>();
@@ -231,7 +231,7 @@ namespace Microsoft.PSharp.Core.Tests
             var config = GetConfiguration().WithVerbosityEnabled(2);
             config.EnableMonitorsInProduction = true;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var tcs = new TaskCompletionSource<bool>();
 

--- a/Tests/Core.Tests/Features/OnHaltTest.cs
+++ b/Tests/Core.Tests/Features/OnHaltTest.cs
@@ -158,7 +158,7 @@ namespace Microsoft.PSharp.Core.Tests
         private void AssertSucceeded(Type machine)
         {
             var config = GetConfiguration().WithVerbosityEnabled(2);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
             });
 
@@ -182,7 +182,7 @@ namespace Microsoft.PSharp.Core.Tests
         private void AssertFailed(Type machine)
         {
             var config = GetConfiguration().WithVerbosityEnabled(2);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var failed = false;
                 var tcs = new TaskCompletionSource<bool>();

--- a/Tests/Core.Tests/Features/OperationGroupingTest.cs
+++ b/Tests/Core.Tests/Features/OperationGroupingTest.cs
@@ -313,7 +313,7 @@ namespace Microsoft.PSharp.Core.Tests
         private void AssertSucceeded(Type machine)
         {
             var config = GetConfiguration().WithVerbosityEnabled(2);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var failed = false;
                 var tcs = new TaskCompletionSource<bool>();

--- a/Tests/Core.Tests/Features/TimerTest.cs
+++ b/Tests/Core.Tests/Features/TimerTest.cs
@@ -236,7 +236,7 @@ namespace Microsoft.PSharp.Core.Tests
         public void TestBasicTimerOperation()
         {
             var configuration = GetConfiguration().WithVerbosityEnabled(2);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var tcs = new TaskCompletionSource<bool>();
                 r.CreateMachine(typeof(T1), new SetupEvent(tcs));
@@ -250,7 +250,7 @@ namespace Microsoft.PSharp.Core.Tests
         public void TestBasicPeriodicTimerOperation()
         {
             var configuration = GetConfiguration().WithVerbosityEnabled(2);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var tcs = new TaskCompletionSource<bool>();
                 r.CreateMachine(typeof(T2), new SetupEvent(tcs));
@@ -264,7 +264,7 @@ namespace Microsoft.PSharp.Core.Tests
         public void TestDropTimeoutsAfterTimerDisposal()
         {
             var configuration = GetConfiguration().WithVerbosityEnabled(2);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var tcs = new TaskCompletionSource<bool>();
                 r.CreateMachine(typeof(T3), new SetupEvent(tcs));
@@ -278,7 +278,7 @@ namespace Microsoft.PSharp.Core.Tests
         public void TestIllegalDueTimeSpecification()
         {
             var configuration = GetConfiguration().WithVerbosityEnabled(2);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var tcs = new TaskCompletionSource<bool>();
                 r.CreateMachine(typeof(T4), new SetupEvent(tcs));
@@ -292,7 +292,7 @@ namespace Microsoft.PSharp.Core.Tests
         public void TestIllegalPeriodSpecification()
         {
             var configuration = GetConfiguration().WithVerbosityEnabled(2);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var tcs = new TaskCompletionSource<bool>();
                 r.CreateMachine(typeof(T5), new SetupEvent(tcs));

--- a/Tests/Core.Tests/Logging/CustomLoggerTest.cs
+++ b/Tests/Core.Tests/Logging/CustomLoggerTest.cs
@@ -134,7 +134,7 @@ namespace Microsoft.PSharp.Core.Tests
             CustomLogger logger = new CustomLogger();
 
             Configuration config = Configuration.Create().WithVerbosityEnabled(2);
-            PSharpRuntime runtime = PSharpRuntime.Create(config);
+            var runtime = PSharpRuntime.Create(config);
             runtime.SetLogger(logger);
 
             var tcs = new TaskCompletionSource<bool>();
@@ -170,7 +170,7 @@ namespace Microsoft.PSharp.Core.Tests
         {
             CustomLogger logger = new CustomLogger();
 
-            PSharpRuntime runtime = PSharpRuntime.Create();
+            var runtime = PSharpRuntime.Create();
             runtime.SetLogger(logger);
 
             var tcs = new TaskCompletionSource<bool>();
@@ -186,7 +186,7 @@ namespace Microsoft.PSharp.Core.Tests
         public void TestNullCustomLoggerFail()
         {
             var config = GetConfiguration().WithVerbosityEnabled(2);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => r.SetLogger(null));
                 Assert.Equal("Cannot install a null logger.", ex.Message);

--- a/Tests/Core.Tests/MemoryLeak/NoMemoryLeakAfterHaltTest.cs
+++ b/Tests/Core.Tests/MemoryLeak/NoMemoryLeakAfterHaltTest.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.PSharp.Runtime;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -103,12 +104,12 @@ namespace Microsoft.PSharp.Core.Tests
         public void TestNoMemoryLeakAfterHalt()
         {
             var config = GetConfiguration().WithVerbosityEnabled(2);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var tcs = new TaskCompletionSource<bool>();
                 r.CreateMachine(typeof(M), new Configure(tcs));
                 tcs.Task.Wait();
-                r.Stop();
+                (r as ProductionRuntime).Stop();
             });
 
             this.Run(config, test);

--- a/Tests/Core.Tests/MemoryLeak/NoMemoryLeakInEventSendingTest.cs
+++ b/Tests/Core.Tests/MemoryLeak/NoMemoryLeakInEventSendingTest.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.PSharp.Runtime;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -96,12 +97,12 @@ namespace Microsoft.PSharp.Core.Tests
         public void TestNoMemoryLeakInEventSending()
         {
             var config = GetConfiguration().WithVerbosityEnabled(2);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var tcs = new TaskCompletionSource<bool>();
                 r.CreateMachine(typeof(M), new Configure(tcs));
                 tcs.Task.Wait();
-                r.Stop();
+                (r as ProductionRuntime).Stop();
             });
 
             this.Run(config, test);

--- a/Tests/Core.Tests/Properties/codeanalysis.ruleset
+++ b/Tests/Core.Tests/Properties/codeanalysis.ruleset
@@ -75,7 +75,7 @@
     <Rule Id="SA1101" Action="Error" />
     <Rule Id="SA1106" Action="Error" />
     <Rule Id="SA1108" Action="Error" />
-    <Rule Id="SA1116" Action="Error" />
+    <Rule Id="SA1116" Action="None" />
     <Rule Id="SA1117" Action="None" />
     <Rule Id="SA1118" Action="None" />
     <Rule Id="SA1119" Action="Error" />

--- a/Tests/Core.Tests/RuntimeInterface/CreateMachineIdFromNameTest.cs
+++ b/Tests/Core.Tests/RuntimeInterface/CreateMachineIdFromNameTest.cs
@@ -52,7 +52,7 @@ namespace Microsoft.PSharp.Core.Tests
         public void TestCreateWithId1()
         {
             var config = GetConfiguration().WithVerbosityEnabled(2);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var failed = false;
                 var tcs = new TaskCompletionSource<bool>();
@@ -78,7 +78,7 @@ namespace Microsoft.PSharp.Core.Tests
         public void TestCreateWithId2()
         {
             var config = GetConfiguration().WithVerbosityEnabled(2);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var failed = false;
                 var tcs = new TaskCompletionSource<bool>();
@@ -121,7 +121,7 @@ namespace Microsoft.PSharp.Core.Tests
         public void TestCreateWithId4()
         {
             var config = GetConfiguration().WithVerbosityEnabled(2);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var failed = false;
                 var tcs = new TaskCompletionSource<bool>();
@@ -153,7 +153,7 @@ namespace Microsoft.PSharp.Core.Tests
         public void TestCreateWithId5()
         {
             var config = GetConfiguration().WithVerbosityEnabled(2);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var failed = false;
                 var tcs = new TaskCompletionSource<bool>();
@@ -210,7 +210,7 @@ namespace Microsoft.PSharp.Core.Tests
         public void TestCreateWithId9()
         {
             var config = GetConfiguration().WithVerbosityEnabled(2);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var m1 = r.CreateMachineIdFromName(typeof(M4), "M4");
                 var m2 = r.CreateMachineIdFromName(typeof(M4), "M4");
@@ -239,7 +239,7 @@ namespace Microsoft.PSharp.Core.Tests
         public void TestCreateWithId10()
         {
             var config = GetConfiguration().WithVerbosityEnabled(2);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var failed = false;
                 var tcs = new TaskCompletionSource<bool>();
@@ -279,7 +279,7 @@ namespace Microsoft.PSharp.Core.Tests
         public void TestCreateWithId11()
         {
             var config = GetConfiguration().WithVerbosityEnabled(2);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var failed = false;
                 var tcs = new TaskCompletionSource<bool>();

--- a/Tests/Core.Tests/RuntimeInterface/SendAndExecuteTest.cs
+++ b/Tests/Core.Tests/RuntimeInterface/SendAndExecuteTest.cs
@@ -125,7 +125,7 @@ namespace Microsoft.PSharp.Core.Tests
         public void TestSyncSendBlocks()
         {
             var config = GetConfiguration().WithVerbosityEnabled(2);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var failed = false;
                 var tcs = new TaskCompletionSource<bool>();
@@ -184,7 +184,7 @@ namespace Microsoft.PSharp.Core.Tests
         public void TestSendCycleDoesNotDeadlock()
         {
             var config = GetConfiguration().WithVerbosityEnabled(2);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var failed = false;
                 var tcs = new TaskCompletionSource<bool>();
@@ -279,7 +279,7 @@ namespace Microsoft.PSharp.Core.Tests
             var config = GetConfiguration().WithVerbosityEnabled(2);
             config.EnableMonitorsInProduction = true;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var failed = false;
                 var tcs = new TaskCompletionSource<bool>();
@@ -354,7 +354,7 @@ namespace Microsoft.PSharp.Core.Tests
         public void TestHandledExceptionOnSendExec()
         {
             var config = GetConfiguration().WithVerbosityEnabled(2);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var failed = false;
                 var tcs = new TaskCompletionSource<bool>();
@@ -377,7 +377,7 @@ namespace Microsoft.PSharp.Core.Tests
         public void TestUnHandledExceptionOnSendExec()
         {
             var config = GetConfiguration().WithVerbosityEnabled(2);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var failed = false;
                 var tcs = new TaskCompletionSource<bool>();
@@ -433,7 +433,7 @@ namespace Microsoft.PSharp.Core.Tests
         public void TestUnhandledEventOnSendExec()
         {
             var config = GetConfiguration().WithVerbosityEnabled(2);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var failed = false;
                 var tcs = new TaskCompletionSource<bool>();

--- a/Tests/LanguageServices.Tests/Properties/codeanalysis.ruleset
+++ b/Tests/LanguageServices.Tests/Properties/codeanalysis.ruleset
@@ -75,7 +75,7 @@
     <Rule Id="SA1101" Action="Error" />
     <Rule Id="SA1106" Action="Error" />
     <Rule Id="SA1108" Action="Error" />
-    <Rule Id="SA1116" Action="Error" />
+    <Rule Id="SA1116" Action="None" />
     <Rule Id="SA1117" Action="None" />
     <Rule Id="SA1118" Action="None" />
     <Rule Id="SA1119" Action="Error" />

--- a/Tests/SharedObjects.Tests/BaseTest.cs
+++ b/Tests/SharedObjects.Tests/BaseTest.cs
@@ -24,13 +24,13 @@ namespace Microsoft.PSharp.SharedObjects.Tests
         {
         }
 
-        protected void AssertSucceeded(Action<PSharpRuntime> test)
+        protected void AssertSucceeded(Action<IMachineRuntime> test)
         {
             var configuration = GetConfiguration();
             this.AssertSucceeded(configuration, test);
         }
 
-        protected void AssertSucceeded(Configuration configuration, Action<PSharpRuntime> test)
+        protected void AssertSucceeded(Configuration configuration, Action<IMachineRuntime> test)
         {
             var logger = new Common.TestOutputLogger(this.TestOutput);
 
@@ -53,35 +53,35 @@ namespace Microsoft.PSharp.SharedObjects.Tests
             }
         }
 
-        protected void AssertFailed(Action<PSharpRuntime> test, int numExpectedErrors)
+        protected void AssertFailed(Action<IMachineRuntime> test, int numExpectedErrors)
         {
             var configuration = GetConfiguration();
             this.AssertFailed(configuration, test, numExpectedErrors);
         }
 
-        protected void AssertFailed(Action<PSharpRuntime> test, string expectedOutput)
+        protected void AssertFailed(Action<IMachineRuntime> test, string expectedOutput)
         {
             var configuration = GetConfiguration();
             this.AssertFailed(configuration, test, 1, new HashSet<string> { expectedOutput });
         }
 
-        protected void AssertFailed(Action<PSharpRuntime> test, int numExpectedErrors, ISet<string> expectedOutputs)
+        protected void AssertFailed(Action<IMachineRuntime> test, int numExpectedErrors, ISet<string> expectedOutputs)
         {
             var configuration = GetConfiguration();
             this.AssertFailed(configuration, test, numExpectedErrors, expectedOutputs);
         }
 
-        protected void AssertFailed(Configuration configuration, Action<PSharpRuntime> test, int numExpectedErrors)
+        protected void AssertFailed(Configuration configuration, Action<IMachineRuntime> test, int numExpectedErrors)
         {
             this.AssertFailed(configuration, test, numExpectedErrors, new HashSet<string>());
         }
 
-        protected void AssertFailed(Configuration configuration, Action<PSharpRuntime> test, string expectedOutput)
+        protected void AssertFailed(Configuration configuration, Action<IMachineRuntime> test, string expectedOutput)
         {
             this.AssertFailed(configuration, test, 1, new HashSet<string> { expectedOutput });
         }
 
-        protected void AssertFailed(Configuration configuration, Action<PSharpRuntime> test, int numExpectedErrors, ISet<string> expectedOutputs)
+        protected void AssertFailed(Configuration configuration, Action<IMachineRuntime> test, int numExpectedErrors, ISet<string> expectedOutputs)
         {
             var logger = new Common.TestOutputLogger(this.TestOutput);
 
@@ -134,13 +134,13 @@ namespace Microsoft.PSharp.SharedObjects.Tests
             }
         }
 
-        protected void AssertFailedWithException(Action<PSharpRuntime> test, Type exceptionType)
+        protected void AssertFailedWithException(Action<IMachineRuntime> test, Type exceptionType)
         {
             var configuration = GetConfiguration();
             this.AssertFailedWithException(configuration, test, exceptionType);
         }
 
-        protected void AssertFailedWithException(Configuration configuration, Action<PSharpRuntime> test, Type exceptionType)
+        protected void AssertFailedWithException(Configuration configuration, Action<IMachineRuntime> test, Type exceptionType)
         {
             Assert.True(exceptionType.IsSubclassOf(typeof(Exception)), "Please configure the test correctly. " +
                 $"Type '{exceptionType}' is not an exception type.");

--- a/Tests/SharedObjects.Tests/Properties/codeanalysis.ruleset
+++ b/Tests/SharedObjects.Tests/Properties/codeanalysis.ruleset
@@ -75,7 +75,7 @@
     <Rule Id="SA1101" Action="Error" />
     <Rule Id="SA1106" Action="Error" />
     <Rule Id="SA1108" Action="Error" />
-    <Rule Id="SA1116" Action="Error" />
+    <Rule Id="SA1116" Action="None" />
     <Rule Id="SA1117" Action="None" />
     <Rule Id="SA1118" Action="None" />
     <Rule Id="SA1119" Action="Error" />

--- a/Tests/SharedObjects.Tests/SharedCounter/MockSharedCounterTest.cs
+++ b/Tests/SharedObjects.Tests/SharedCounter/MockSharedCounterTest.cs
@@ -78,8 +78,7 @@ namespace Microsoft.PSharp.SharedObjects.Tests
         public void TestMockSharedCounter1()
         {
             var config = Configuration.Create().WithNumberOfIterations(50);
-
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M1));
             });
@@ -207,7 +206,7 @@ namespace Microsoft.PSharp.SharedObjects.Tests
         public void TestMockSharedCounter2()
         {
             var config = Configuration.Create().WithNumberOfIterations(100);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M2), new Config(0));
             });
@@ -219,7 +218,7 @@ namespace Microsoft.PSharp.SharedObjects.Tests
         public void TestMockSharedCounter3()
         {
             var config = Configuration.Create().WithNumberOfIterations(100);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M2), new Config(1));
             });
@@ -231,7 +230,7 @@ namespace Microsoft.PSharp.SharedObjects.Tests
         public void TestMockSharedCounter4()
         {
             var config = Configuration.Create().WithNumberOfIterations(100);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M2), new Config(2));
             });
@@ -243,7 +242,7 @@ namespace Microsoft.PSharp.SharedObjects.Tests
         public void TestMockSharedCounter5()
         {
             var config = Configuration.Create().WithNumberOfIterations(100);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M2), new Config(3));
             });
@@ -255,8 +254,7 @@ namespace Microsoft.PSharp.SharedObjects.Tests
         public void TestMockSharedCounter6()
         {
             var config = Configuration.Create().WithNumberOfIterations(50);
-
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M3));
             });

--- a/Tests/SharedObjects.Tests/SharedDictionary/MockSharedDictionaryTest.cs
+++ b/Tests/SharedObjects.Tests/SharedDictionary/MockSharedDictionaryTest.cs
@@ -261,7 +261,7 @@ namespace Microsoft.PSharp.SharedObjects.Tests
         public void TestMockSharedDictionary1()
         {
             var config = Configuration.Create().WithNumberOfIterations(50);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M1));
             });
@@ -273,7 +273,7 @@ namespace Microsoft.PSharp.SharedObjects.Tests
         public void TestMockSharedDictionary2()
         {
             var config = Configuration.Create().WithNumberOfIterations(50);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M2));
             });
@@ -285,7 +285,7 @@ namespace Microsoft.PSharp.SharedObjects.Tests
         public void TestMockSharedDictionary3()
         {
             var config = Configuration.Create().WithNumberOfIterations(50);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M3));
             });
@@ -297,7 +297,7 @@ namespace Microsoft.PSharp.SharedObjects.Tests
         public void TestMockSharedDictionary4()
         {
             var config = Configuration.Create().WithNumberOfIterations(50);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M4));
             });
@@ -309,7 +309,7 @@ namespace Microsoft.PSharp.SharedObjects.Tests
         public void TestMockSharedDictionary5()
         {
             var config = Configuration.Create().WithNumberOfIterations(50);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var counter = SharedDictionary.Create<int, string>(r);
                 r.CreateMachine(typeof(M5), new E2(counter, true));
@@ -322,7 +322,7 @@ namespace Microsoft.PSharp.SharedObjects.Tests
         public void TestMockSharedDictionary6()
         {
             var config = Configuration.Create().WithNumberOfIterations(50);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var counter = SharedDictionary.Create<int, string>(r);
                 r.CreateMachine(typeof(M5), new E2(counter, false));
@@ -335,7 +335,7 @@ namespace Microsoft.PSharp.SharedObjects.Tests
         public void TestMockSharedDictionary7()
         {
             var config = Configuration.Create().WithNumberOfIterations(50);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var counter = SharedDictionary.Create<int, string>(r);
                 r.CreateMachine(typeof(M6), new E1(counter));

--- a/Tests/SharedObjects.Tests/SharedRegister/MockSharedRegisterTest.cs
+++ b/Tests/SharedObjects.Tests/SharedRegister/MockSharedRegisterTest.cs
@@ -164,7 +164,7 @@ namespace Microsoft.PSharp.SharedObjects.Tests
         public void TestMockSharedRegister1()
         {
             var config = Configuration.Create().WithNumberOfIterations(100);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M1), new Setup(true));
             });
@@ -176,7 +176,7 @@ namespace Microsoft.PSharp.SharedObjects.Tests
         public void TestMockSharedRegister2()
         {
             var config = Configuration.Create().WithNumberOfIterations(100);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M1), new Setup(false));
             });
@@ -188,7 +188,7 @@ namespace Microsoft.PSharp.SharedObjects.Tests
         public void TestMockSharedRegister3()
         {
             var config = Configuration.Create().WithNumberOfIterations(100);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M2), new Setup(true));
             });
@@ -200,7 +200,7 @@ namespace Microsoft.PSharp.SharedObjects.Tests
         public void TestMockSharedRegister4()
         {
             var config = Configuration.Create().WithNumberOfIterations(100);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M2), new Setup(false));
             });

--- a/Tests/StaticAnalysis.Tests/Properties/codeanalysis.ruleset
+++ b/Tests/StaticAnalysis.Tests/Properties/codeanalysis.ruleset
@@ -75,7 +75,7 @@
     <Rule Id="SA1101" Action="Error" />
     <Rule Id="SA1106" Action="Error" />
     <Rule Id="SA1108" Action="Error" />
-    <Rule Id="SA1116" Action="Error" />
+    <Rule Id="SA1116" Action="None" />
     <Rule Id="SA1117" Action="None" />
     <Rule Id="SA1118" Action="None" />
     <Rule Id="SA1119" Action="Error" />

--- a/Tests/TestingServices.Tests/Algorithms/BubbleSortAlgorithmTest.cs
+++ b/Tests/TestingServices.Tests/Algorithms/BubbleSortAlgorithmTest.cs
@@ -115,7 +115,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestBubbleSortAlgorithm()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(BubbleSortMachine));
             });

--- a/Tests/TestingServices.Tests/Asynchrony/AsyncAwaitTest.cs
+++ b/Tests/TestingServices.Tests/Asynchrony/AsyncAwaitTest.cs
@@ -58,7 +58,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestAsyncDelay()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M));
             });
@@ -69,7 +69,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestAsyncDelayWithOtherSynchronizationContext()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(N));
             });

--- a/Tests/TestingServices.Tests/Asynchrony/ReceiveTest.cs
+++ b/Tests/TestingServices.Tests/Asynchrony/ReceiveTest.cs
@@ -40,7 +40,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestAsyncReceiveEvent()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M));
             });

--- a/Tests/TestingServices.Tests/Asynchrony/ReceiveWaitTest.cs
+++ b/Tests/TestingServices.Tests/Asynchrony/ReceiveWaitTest.cs
@@ -39,7 +39,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestAsyncReceiveEvent()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M));
             });

--- a/Tests/TestingServices.Tests/BaseTest.cs
+++ b/Tests/TestingServices.Tests/BaseTest.cs
@@ -22,13 +22,13 @@ namespace Microsoft.PSharp.TestingServices.Tests
         {
         }
 
-        protected void AssertSucceeded(Action<PSharpRuntime> test)
+        protected void AssertSucceeded(Action<IMachineRuntime> test)
         {
             var configuration = GetConfiguration();
             this.AssertSucceeded(configuration, test);
         }
 
-        protected ITestingEngine AssertSucceeded(Configuration configuration, Action<PSharpRuntime> test)
+        protected ITestingEngine AssertSucceeded(Configuration configuration, Action<IMachineRuntime> test)
         {
             BugFindingEngine engine = null;
             var logger = new Common.TestOutputLogger(this.TestOutput);
@@ -54,35 +54,35 @@ namespace Microsoft.PSharp.TestingServices.Tests
             return engine;
         }
 
-        protected void AssertFailed(Action<PSharpRuntime> test, int numExpectedErrors, bool replay)
+        protected void AssertFailed(Action<IMachineRuntime> test, int numExpectedErrors, bool replay)
         {
             var configuration = GetConfiguration();
             this.AssertFailed(configuration, test, numExpectedErrors, replay);
         }
 
-        protected void AssertFailed(Action<PSharpRuntime> test, string expectedOutput, bool replay)
+        protected void AssertFailed(Action<IMachineRuntime> test, string expectedOutput, bool replay)
         {
             var configuration = GetConfiguration();
             this.AssertFailed(configuration, test, 1, new HashSet<string> { expectedOutput }, replay);
         }
 
-        protected void AssertFailed(Action<PSharpRuntime> test, int numExpectedErrors, ISet<string> expectedOutputs, bool replay)
+        protected void AssertFailed(Action<IMachineRuntime> test, int numExpectedErrors, ISet<string> expectedOutputs, bool replay)
         {
             var configuration = GetConfiguration();
             this.AssertFailed(configuration, test, numExpectedErrors, expectedOutputs, replay);
         }
 
-        protected void AssertFailed(Configuration configuration, Action<PSharpRuntime> test, int numExpectedErrors, bool replay)
+        protected void AssertFailed(Configuration configuration, Action<IMachineRuntime> test, int numExpectedErrors, bool replay)
         {
             this.AssertFailed(configuration, test, numExpectedErrors, new HashSet<string>(), replay);
         }
 
-        protected void AssertFailed(Configuration configuration, Action<PSharpRuntime> test, string expectedOutput, bool replay)
+        protected void AssertFailed(Configuration configuration, Action<IMachineRuntime> test, string expectedOutput, bool replay)
         {
             this.AssertFailed(configuration, test, 1, new HashSet<string> { expectedOutput }, replay);
         }
 
-        protected void AssertFailed(Configuration configuration, Action<PSharpRuntime> test, int numExpectedErrors,
+        protected void AssertFailed(Configuration configuration, Action<IMachineRuntime> test, int numExpectedErrors,
             ISet<string> expectedOutputs, bool replay)
         {
             this.AssertFailed(configuration, test, numExpectedErrors, bugReports =>
@@ -99,7 +99,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             }, replay);
         }
 
-        protected void AssertFailed(Configuration configuration, Action<PSharpRuntime> test, int numExpectedErrors,
+        protected void AssertFailed(Configuration configuration, Action<IMachineRuntime> test, int numExpectedErrors,
             Func<HashSet<string>, bool> expectedOutputFunc, bool replay)
         {
             var logger = new Common.TestOutputLogger(this.TestOutput);
@@ -132,13 +132,13 @@ namespace Microsoft.PSharp.TestingServices.Tests
             }
         }
 
-        protected void AssertFailedWithException(Action<PSharpRuntime> test, Type exceptionType, bool replay)
+        protected void AssertFailedWithException(Action<IMachineRuntime> test, Type exceptionType, bool replay)
         {
             var configuration = GetConfiguration();
             this.AssertFailedWithException(configuration, test, exceptionType, replay);
         }
 
-        protected void AssertFailedWithException(Configuration configuration, Action<PSharpRuntime> test, Type exceptionType, bool replay)
+        protected void AssertFailedWithException(Configuration configuration, Action<IMachineRuntime> test, Type exceptionType, bool replay)
         {
             Assert.True(exceptionType.IsSubclassOf(typeof(Exception)), "Please configure the test correctly. " +
                 $"Type '{exceptionType}' is not an exception type.");

--- a/Tests/TestingServices.Tests/Concurrency/ExternalConcurrencyTest.cs
+++ b/Tests/TestingServices.Tests/Concurrency/ExternalConcurrencyTest.cs
@@ -60,7 +60,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestExternalTaskSendingEvent()
         {
-            var test = new Action<PSharpRuntime>((r) => { r.CreateMachine(typeof(M)); });
+            var test = new Action<IMachineRuntime>((r) => { r.CreateMachine(typeof(M)); });
             string bugReport = @"Detected task with id '' that is not controlled by the P# runtime.";
             this.AssertFailed(test, bugReport, true);
         }
@@ -68,7 +68,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestExternalTaskInvokingRandom()
         {
-            var test = new Action<PSharpRuntime>((r) => { r.CreateMachine(typeof(N)); });
+            var test = new Action<IMachineRuntime>((r) => { r.CreateMachine(typeof(N)); });
             string bugReport = @"Detected task with id '' that is not controlled by the P# runtime.";
             this.AssertFailed(test, bugReport, true);
         }

--- a/Tests/TestingServices.Tests/EntryPoint/EntryPointEventSendingTest.cs
+++ b/Tests/TestingServices.Tests/EntryPoint/EntryPointEventSendingTest.cs
@@ -44,7 +44,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestEntryPointEventSending()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 MachineId m = r.CreateMachine(typeof(M));
                 r.SendEvent(m, new Transfer(0));

--- a/Tests/TestingServices.Tests/EntryPoint/EntryPointMachineCreationTest.cs
+++ b/Tests/TestingServices.Tests/EntryPoint/EntryPointMachineCreationTest.cs
@@ -35,7 +35,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestEntryPointMachineCreation()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 MachineId m = r.CreateMachine(typeof(M));
                 MachineId n = r.CreateMachine(typeof(N));

--- a/Tests/TestingServices.Tests/EntryPoint/EntryPointMachineExecutionTest.cs
+++ b/Tests/TestingServices.Tests/EntryPoint/EntryPointMachineExecutionTest.cs
@@ -41,7 +41,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestEntryPointMachineExecution()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 MachineId m = r.CreateMachine(typeof(M));
                 MachineId n = r.CreateMachine(typeof(N));

--- a/Tests/TestingServices.Tests/EntryPoint/EntryPointRandomChoiceTest.cs
+++ b/Tests/TestingServices.Tests/EntryPoint/EntryPointRandomChoiceTest.cs
@@ -27,7 +27,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestEntryPointRandomChoice()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 if (r.Random())
                 {

--- a/Tests/TestingServices.Tests/EntryPoint/EntryPointThrowExceptionTest.cs
+++ b/Tests/TestingServices.Tests/EntryPoint/EntryPointThrowExceptionTest.cs
@@ -27,7 +27,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestEntryPointThrowException()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 MachineId m = r.CreateMachine(typeof(M));
                 throw new InvalidOperationException();
@@ -39,7 +39,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestEntryPointNoMachinesThrowException()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 throw new InvalidOperationException();
             });

--- a/Tests/TestingServices.Tests/EventHandling/Actions1FailTest.cs
+++ b/Tests/TestingServices.Tests/EventHandling/Actions1FailTest.cs
@@ -165,7 +165,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         {
             var configuration = GetConfiguration();
             configuration.SchedulingStrategy = SchedulingStrategy.DFS;
-            var test = new Action<PSharpRuntime>((r) => { r.CreateMachine(typeof(Real)); });
+            var test = new Action<IMachineRuntime>((r) => { r.CreateMachine(typeof(Real)); });
             this.AssertFailed(configuration, test, 1, true);
         }
     }

--- a/Tests/TestingServices.Tests/EventHandling/Actions5FailTest.cs
+++ b/Tests/TestingServices.Tests/EventHandling/Actions5FailTest.cs
@@ -169,7 +169,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         {
             var configuration = GetConfiguration();
             configuration.SchedulingStrategy = SchedulingStrategy.DFS;
-            var test = new Action<PSharpRuntime>((r) => { r.CreateMachine(typeof(Real)); });
+            var test = new Action<IMachineRuntime>((r) => { r.CreateMachine(typeof(Real)); });
             this.AssertFailed(configuration, test, 1, true);
         }
     }

--- a/Tests/TestingServices.Tests/EventHandling/Actions6FailTest.cs
+++ b/Tests/TestingServices.Tests/EventHandling/Actions6FailTest.cs
@@ -164,7 +164,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         {
             var configuration = GetConfiguration();
             configuration.SchedulingStrategy = SchedulingStrategy.DFS;
-            var test = new Action<PSharpRuntime>((r) => { r.CreateMachine(typeof(Real)); });
+            var test = new Action<IMachineRuntime>((r) => { r.CreateMachine(typeof(Real)); });
             this.AssertFailed(configuration, test, 1, true);
         }
     }

--- a/Tests/TestingServices.Tests/EventHandling/IgnoreEvent/IgnoreRaisedTest.cs
+++ b/Tests/TestingServices.Tests/EventHandling/IgnoreEvent/IgnoreRaisedTest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         {
             var configuration = GetConfiguration();
             configuration.SchedulingIterations = 5;
-            var test = new Action<PSharpRuntime>((r) => { r.CreateMachine(typeof(Harness)); });
+            var test = new Action<IMachineRuntime>((r) => { r.CreateMachine(typeof(Harness)); });
             this.AssertSucceeded(configuration, test);
         }
     }

--- a/Tests/TestingServices.Tests/EventHandling/MaxInstances1FailTest.cs
+++ b/Tests/TestingServices.Tests/EventHandling/MaxInstances1FailTest.cs
@@ -177,7 +177,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             configuration.ReductionStrategy = ReductionStrategy.None;
             configuration.SchedulingStrategy = SchedulingStrategy.DFS;
             configuration.MaxSchedulingSteps = 6;
-            var test = new Action<PSharpRuntime>((r) => { r.CreateMachine(typeof(RealMachine)); });
+            var test = new Action<IMachineRuntime>((r) => { r.CreateMachine(typeof(RealMachine)); });
             this.AssertFailed(configuration, test, 1, true);
         }
     }

--- a/Tests/TestingServices.Tests/EventHandling/ReceiveEvent/ReceiveEventFailTest.cs
+++ b/Tests/TestingServices.Tests/EventHandling/ReceiveEvent/ReceiveEventFailTest.cs
@@ -118,7 +118,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         {
             var configuration = GetConfiguration();
             configuration.SchedulingStrategy = SchedulingStrategy.DFS;
-            var test = new Action<PSharpRuntime>((r) => { r.CreateMachine(typeof(Server)); });
+            var test = new Action<IMachineRuntime>((r) => { r.CreateMachine(typeof(Server)); });
             var bugReport = "Livelock detected. 'Client()' is waiting for an event, but no other schedulable choices are enabled.";
             this.AssertFailed(configuration, test, bugReport, true);
         }
@@ -128,7 +128,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         {
             var configuration = GetConfiguration();
             configuration.SchedulingStrategy = SchedulingStrategy.DFS;
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(Server));
                 r.CreateMachine(typeof(Server));
@@ -143,7 +143,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         {
             var configuration = GetConfiguration();
             configuration.SchedulingStrategy = SchedulingStrategy.DFS;
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(Server));
                 r.CreateMachine(typeof(Server));

--- a/Tests/TestingServices.Tests/EventHandling/ReceiveEvent/ReceiveEventTest.cs
+++ b/Tests/TestingServices.Tests/EventHandling/ReceiveEvent/ReceiveEventTest.cs
@@ -126,7 +126,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         {
             var configuration = GetConfiguration();
             configuration.SchedulingStrategy = SchedulingStrategy.DFS;
-            var test = new Action<PSharpRuntime>((r) => { r.CreateMachine(typeof(Server)); });
+            var test = new Action<IMachineRuntime>((r) => { r.CreateMachine(typeof(Server)); });
             this.AssertSucceeded(configuration, test);
         }
     }

--- a/Tests/TestingServices.Tests/EventHandling/Wildcard/WildCardEventTest.cs
+++ b/Tests/TestingServices.Tests/EventHandling/Wildcard/WildCardEventTest.cs
@@ -72,7 +72,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestWildCardEvent()
         {
-            var test = new Action<PSharpRuntime>((r) => { r.CreateMachine(typeof(B)); });
+            var test = new Action<IMachineRuntime>((r) => { r.CreateMachine(typeof(B)); });
             this.AssertSucceeded(test);
         }
     }

--- a/Tests/TestingServices.Tests/Features/CompletenessTest.cs
+++ b/Tests/TestingServices.Tests/Features/CompletenessTest.cs
@@ -77,7 +77,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestCompleteness1()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(P));
                 r.CreateMachine(typeof(M2));
@@ -92,7 +92,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestCompleteness2()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(P));
                 r.CreateMachine(typeof(M1));

--- a/Tests/TestingServices.Tests/Features/GetOperationGroupIdTest.cs
+++ b/Tests/TestingServices.Tests/Features/GetOperationGroupIdTest.cs
@@ -94,7 +94,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestGetOperationGroupIdNotSet()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M1));
             });
@@ -105,7 +105,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestGetOperationGroupIdSet()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M2));
             });
@@ -116,7 +116,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestGetOperationGroupIdOfNotCurrentMachine()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M3));
             });

--- a/Tests/TestingServices.Tests/Features/MustHandleEventTest.cs
+++ b/Tests/TestingServices.Tests/Features/MustHandleEventTest.cs
@@ -116,7 +116,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestMustHandleFail1()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var m = r.CreateMachine(typeof(M1));
                 r.SendEvent(m, new E(), new SendOptions { MustHandle = true });
@@ -144,7 +144,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestMustHandleFail2()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var m = r.CreateMachine(typeof(M2));
                 r.SendEvent(m, new E());
@@ -173,7 +173,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestMustHandleFail3()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var m = r.CreateMachine(typeof(M5));
                 r.SendEvent(m, new Halt());
@@ -191,7 +191,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestMustHandleSuccess()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var m = r.CreateMachine(typeof(M3));
                 r.SendEvent(m, new E(), new SendOptions { MustHandle = true });
@@ -205,7 +205,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestMustHandleDeferFail()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var m = r.CreateMachine(typeof(M4));
                 r.SendEvent(m, new E(), new SendOptions { MustHandle = true });

--- a/Tests/TestingServices.Tests/Features/OnEventDequeueOrHandledTest.cs
+++ b/Tests/TestingServices.Tests/Features/OnEventDequeueOrHandledTest.cs
@@ -141,7 +141,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestOnProcessingCalled()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(Spec1));
                 var m = r.CreateMachine(typeof(M1), new E());
@@ -217,7 +217,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestOnProcessingNotCalledOnHalt()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(Spec2));
                 var m = r.CreateMachine(typeof(M2));
@@ -281,7 +281,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestOnProcessingCanGoto()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(Spec3));
                 var m = r.CreateMachine(typeof(M3));
@@ -333,7 +333,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestOnProcessingCanHalt()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(Spec4));
                 var m = r.CreateMachine(typeof(M4));

--- a/Tests/TestingServices.Tests/Features/OnEventDroppedTest.cs
+++ b/Tests/TestingServices.Tests/Features/OnEventDroppedTest.cs
@@ -46,7 +46,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestOnDroppedCalled1()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.OnEventDropped += (e, target) =>
                 {
@@ -78,7 +78,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestOnDroppedCalled2()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.OnEventDropped += (e, target) =>
                 {
@@ -94,7 +94,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestOnDroppedParams()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var m = r.CreateMachine(typeof(M1));
 
@@ -179,7 +179,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestProcessedOrDropped()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(Monitor3));
                 r.OnEventDropped += (e, target) =>

--- a/Tests/TestingServices.Tests/Features/OnExceptionTest.cs
+++ b/Tests/TestingServices.Tests/Features/OnExceptionTest.cs
@@ -344,7 +344,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestExceptionSuppressed1()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M1a));
             });
@@ -355,7 +355,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestExceptionSuppressed2()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M1b));
             });
@@ -366,7 +366,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestExceptionSuppressed3()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M1c));
             });
@@ -377,7 +377,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestExceptionSuppressed4()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M1c));
             });
@@ -388,7 +388,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestExceptionNotSuppressed()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M2));
             });
@@ -399,7 +399,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestRaiseOnException()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M3a));
             });
@@ -410,7 +410,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestSendOnException()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M3b));
             });
@@ -421,7 +421,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestMachineHalt1()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(GetsDone));
                 r.CreateMachine(typeof(M4));
@@ -433,7 +433,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestMachineHalt2()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(GetsDone));
                 var m = r.CreateMachine(typeof(M5));
@@ -446,7 +446,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestSendOnUnhandledEventException()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var m = r.CreateMachine(typeof(M6));
                 r.SendEvent(m, new E());

--- a/Tests/TestingServices.Tests/Features/OnHaltTest.cs
+++ b/Tests/TestingServices.Tests/Features/OnHaltTest.cs
@@ -158,7 +158,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestHaltCalled()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M1));
             });
@@ -169,7 +169,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestReceiveOnHalt()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M2a));
             });
@@ -181,7 +181,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestRaiseOnHalt()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M2b));
             });
@@ -193,7 +193,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestGotoOnHalt()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M2c));
             });
@@ -205,7 +205,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestAPIsOnHalt()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var m = r.CreateMachine(typeof(M4));
                 r.CreateMachine(typeof(M3), new E(m));

--- a/Tests/TestingServices.Tests/Features/OperationGroupingTest.cs
+++ b/Tests/TestingServices.Tests/Features/OperationGroupingTest.cs
@@ -313,7 +313,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestOperationGroupingSingleMachineNoSend()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M1));
             });
@@ -324,7 +324,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestOperationGroupingSingleMachineSend()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M2));
             });
@@ -335,7 +335,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestOperationGroupingSingleMachineSendStarter()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M2S));
             });
@@ -346,7 +346,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestOperationGroupingTwoMachinesCreate()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M3));
             });
@@ -357,7 +357,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestOperationGroupingTwoMachinesSend()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M5));
             });
@@ -368,7 +368,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestOperationGroupingTwoMachinesSendStarter()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M5S));
             });
@@ -379,7 +379,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestOperationGroupingTwoMachinesSendBack()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M7));
             });
@@ -390,7 +390,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestOperationGroupingTwoMachinesSendBackStarter()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M7S));
             });
@@ -401,7 +401,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestOperationGroupingThreeMachinesSendStarter()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M9S));
             });

--- a/Tests/TestingServices.Tests/Features/SingleStateMachineTest.cs
+++ b/Tests/TestingServices.Tests/Features/SingleStateMachineTest.cs
@@ -80,7 +80,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestSingleStateMachine()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(Harness));
             });

--- a/Tests/TestingServices.Tests/Generics/GenericMachineTest.cs
+++ b/Tests/TestingServices.Tests/Generics/GenericMachineTest.cs
@@ -50,14 +50,14 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestGenericMachine1()
         {
-            var test = new Action<PSharpRuntime>((r) => { r.CreateMachine(typeof(M<int>)); });
+            var test = new Action<IMachineRuntime>((r) => { r.CreateMachine(typeof(M<int>)); });
             this.AssertSucceeded(test);
         }
 
         [Fact]
         public void TestGenericMachine2()
         {
-            var test = new Action<PSharpRuntime>((r) => { r.CreateMachine(typeof(N)); });
+            var test = new Action<IMachineRuntime>((r) => { r.CreateMachine(typeof(N)); });
             this.AssertSucceeded(test);
         }
     }

--- a/Tests/TestingServices.Tests/Generics/GenericMonitorTest.cs
+++ b/Tests/TestingServices.Tests/Generics/GenericMonitorTest.cs
@@ -68,7 +68,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestGenericMonitor()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(M<int>));
                 r.CreateMachine(typeof(Program<int>));

--- a/Tests/TestingServices.Tests/Interleavings/SendInterleavingsTest.cs
+++ b/Tests/TestingServices.Tests/Interleavings/SendInterleavingsTest.cs
@@ -105,7 +105,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             configuration.SchedulingStrategy = SchedulingStrategy.DFS;
             configuration.SchedulingIterations = 600;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(Receiver));
             });

--- a/Tests/TestingServices.Tests/Liveness/CycleDetection/CycleDetectionBasicTest.cs
+++ b/Tests/TestingServices.Tests/Liveness/CycleDetection/CycleDetectionBasicTest.cs
@@ -85,7 +85,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             configuration.SchedulingIterations = 10;
             configuration.MaxSchedulingSteps = 200;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(WatchDog));
                 r.CreateMachine(typeof(EventHandler), new Configure(true));
@@ -101,7 +101,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             configuration.EnableCycleDetection = true;
             configuration.MaxSchedulingSteps = 200;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(WatchDog));
                 r.CreateMachine(typeof(EventHandler), new Configure(false));

--- a/Tests/TestingServices.Tests/Liveness/CycleDetection/CycleDetectionCounterTest.cs
+++ b/Tests/TestingServices.Tests/Liveness/CycleDetection/CycleDetectionCounterTest.cs
@@ -99,7 +99,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             configuration.SchedulingIterations = 10;
             configuration.MaxSchedulingSteps = 200;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(WatchDog));
                 r.CreateMachine(typeof(EventHandler), new Configure(true, false));
@@ -116,7 +116,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             configuration.EnableUserDefinedStateHashing = true;
             configuration.MaxSchedulingSteps = 200;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(WatchDog));
                 r.CreateMachine(typeof(EventHandler), new Configure(false, false));
@@ -134,7 +134,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             configuration.EnableUserDefinedStateHashing = true;
             configuration.MaxSchedulingSteps = 200;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(WatchDog));
                 r.CreateMachine(typeof(EventHandler), new Configure(true, true));

--- a/Tests/TestingServices.Tests/Liveness/CycleDetection/CycleDetectionDefaultHandlerTest.cs
+++ b/Tests/TestingServices.Tests/Liveness/CycleDetection/CycleDetectionDefaultHandlerTest.cs
@@ -83,7 +83,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             configuration.SchedulingIterations = 10;
             configuration.MaxSchedulingSteps = 200;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(WatchDog));
                 r.CreateMachine(typeof(EventHandler), new Configure(true));
@@ -99,7 +99,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             configuration.EnableCycleDetection = true;
             configuration.MaxSchedulingSteps = 200;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(WatchDog));
                 r.CreateMachine(typeof(EventHandler), new Configure(false));

--- a/Tests/TestingServices.Tests/Liveness/CycleDetection/CycleDetectionRandomChoiceTest.cs
+++ b/Tests/TestingServices.Tests/Liveness/CycleDetection/CycleDetectionRandomChoiceTest.cs
@@ -104,7 +104,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             configuration.SchedulingIterations = 7;
             configuration.MaxSchedulingSteps = 200;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(WatchDog));
                 r.CreateMachine(typeof(EventHandler), new Configure(true));
@@ -122,7 +122,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             configuration.SchedulingIterations = 10;
             configuration.MaxSchedulingSteps = 200;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(WatchDog));
                 r.CreateMachine(typeof(EventHandler), new Configure(false));

--- a/Tests/TestingServices.Tests/Liveness/CycleDetection/CycleDetectionRingOfNodesTest.cs
+++ b/Tests/TestingServices.Tests/Liveness/CycleDetection/CycleDetectionRingOfNodesTest.cs
@@ -124,7 +124,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             configuration.SchedulingIterations = 10;
             configuration.MaxSchedulingSteps = 200;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(WatchDog));
                 r.CreateMachine(typeof(Environment), new Configure(true));
@@ -140,7 +140,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             configuration.EnableCycleDetection = true;
             configuration.MaxSchedulingSteps = 200;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(WatchDog));
                 r.CreateMachine(typeof(Environment), new Configure(false));

--- a/Tests/TestingServices.Tests/Liveness/CycleDetection/FairNondet1Test.cs
+++ b/Tests/TestingServices.Tests/Liveness/CycleDetection/FairNondet1Test.cs
@@ -115,7 +115,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             configuration.SchedulingStrategy = SchedulingStrategy.DFS;
             configuration.MaxSchedulingSteps = 300;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(WatchDog));
                 r.CreateMachine(typeof(EventHandler));

--- a/Tests/TestingServices.Tests/Liveness/CycleDetection/Liveness2Test.cs
+++ b/Tests/TestingServices.Tests/Liveness/CycleDetection/Liveness2Test.cs
@@ -101,7 +101,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             configuration.EnableCycleDetection = true;
             configuration.SchedulingStrategy = SchedulingStrategy.DFS;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(WatchDog));
                 r.CreateMachine(typeof(EventHandler));

--- a/Tests/TestingServices.Tests/Liveness/CycleDetection/Liveness3Test.cs
+++ b/Tests/TestingServices.Tests/Liveness/CycleDetection/Liveness3Test.cs
@@ -115,7 +115,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             configuration.EnableCycleDetection = true;
             configuration.SchedulingIterations = 100;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(WatchDog));
                 r.CreateMachine(typeof(EventHandler));

--- a/Tests/TestingServices.Tests/Liveness/CycleDetection/Nondet1Test.cs
+++ b/Tests/TestingServices.Tests/Liveness/CycleDetection/Nondet1Test.cs
@@ -114,7 +114,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             configuration.SchedulingStrategy = SchedulingStrategy.DFS;
             configuration.RandomSchedulingSeed = 96;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(WatchDog));
                 r.CreateMachine(typeof(EventHandler));

--- a/Tests/TestingServices.Tests/Liveness/CycleDetection/WarmStateBugTest.cs
+++ b/Tests/TestingServices.Tests/Liveness/CycleDetection/WarmStateBugTest.cs
@@ -100,7 +100,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             configuration.EnableCycleDetection = true;
             configuration.SchedulingStrategy = SchedulingStrategy.DFS;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(WatchDog));
                 r.CreateMachine(typeof(EventHandler));

--- a/Tests/TestingServices.Tests/Liveness/HotStateTest.cs
+++ b/Tests/TestingServices.Tests/Liveness/HotStateTest.cs
@@ -181,7 +181,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             configuration.EnableCycleDetection = true;
             configuration.SchedulingStrategy = SchedulingStrategy.DFS;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(M));
                 r.CreateMachine(typeof(Master));

--- a/Tests/TestingServices.Tests/Liveness/Liveness1Test.cs
+++ b/Tests/TestingServices.Tests/Liveness/Liveness1Test.cs
@@ -101,7 +101,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             configuration.SchedulingStrategy = SchedulingStrategy.DFS;
             configuration.MaxSchedulingSteps = 300;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(WatchDog));
                 r.CreateMachine(typeof(EventHandler));

--- a/Tests/TestingServices.Tests/Liveness/Liveness2BugFoundTest.cs
+++ b/Tests/TestingServices.Tests/Liveness/Liveness2BugFoundTest.cs
@@ -100,7 +100,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             configuration.EnableCycleDetection = true;
             configuration.SchedulingStrategy = SchedulingStrategy.DFS;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(WatchDog));
                 r.CreateMachine(typeof(EventHandler));

--- a/Tests/TestingServices.Tests/Liveness/Liveness2LoopMachineTest.cs
+++ b/Tests/TestingServices.Tests/Liveness/Liveness2LoopMachineTest.cs
@@ -114,7 +114,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             configuration.LivenessTemperatureThreshold = 200;
             configuration.SchedulingIterations = 1;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(LivenessMonitor));
                 r.CreateMachine(typeof(EventHandler));

--- a/Tests/TestingServices.Tests/Liveness/UnfairExecutionTest.cs
+++ b/Tests/TestingServices.Tests/Liveness/UnfairExecutionTest.cs
@@ -110,7 +110,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             configuration.SchedulingStrategy = SchedulingStrategy.PCT;
             configuration.MaxSchedulingSteps = 300;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(LivenessMonitor));
                 r.CreateMachine(typeof(M));

--- a/Tests/TestingServices.Tests/Liveness/WarmStateTest.cs
+++ b/Tests/TestingServices.Tests/Liveness/WarmStateTest.cs
@@ -96,7 +96,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             var configuration = GetConfiguration();
             configuration.SchedulingStrategy = SchedulingStrategy.DFS;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(WatchDog));
                 r.CreateMachine(typeof(EventHandler));

--- a/Tests/TestingServices.Tests/Machines/Declarations/AmbiguousEventHandlerTest.cs
+++ b/Tests/TestingServices.Tests/Machines/Declarations/AmbiguousEventHandlerTest.cs
@@ -73,7 +73,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestAmbiguousMachineEventHandler()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(Program));
             });
@@ -84,7 +84,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestAmbiguousMonitorEventHandler()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(Safety));
             });

--- a/Tests/TestingServices.Tests/Machines/Declarations/DuplicateEventHandlersTest.cs
+++ b/Tests/TestingServices.Tests/Machines/Declarations/DuplicateEventHandlersTest.cs
@@ -166,7 +166,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestMachineDuplicateEventHandlerDo()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M1));
             });
@@ -178,7 +178,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestMachineDuplicateEventHandlerGoto()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M2));
             });
@@ -190,7 +190,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestMachineDuplicateEventHandlerPush()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M3));
             });
@@ -202,7 +202,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestMachineDuplicateEventHandlerInheritanceDo()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M4));
             });
@@ -215,7 +215,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestMachineDuplicateEventHandlerInheritanceGoto()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M5));
             });
@@ -228,7 +228,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestMachineDuplicateEventHandlerInheritancePush()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M6));
             });
@@ -241,7 +241,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestMachineDuplicateEventHandlerMixed()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M7));
             });

--- a/Tests/TestingServices.Tests/Machines/Declarations/GroupStateTest.cs
+++ b/Tests/TestingServices.Tests/Machines/Declarations/GroupStateTest.cs
@@ -123,7 +123,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestGroupState()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(M));
                 r.CreateMachine(typeof(Program));

--- a/Tests/TestingServices.Tests/Machines/Declarations/MachineStateInheritanceTest.cs
+++ b/Tests/TestingServices.Tests/Machines/Declarations/MachineStateInheritanceTest.cs
@@ -542,7 +542,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestMachineStateInheritingAbstractState()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M1));
             });
@@ -554,7 +554,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestMachineStateInheritingStateDuplicateStart()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M2));
             });
@@ -566,7 +566,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestMachineStateInheritingStateOnEntry()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M3));
             });
@@ -578,7 +578,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestMachineStateOverridingStateOnEntry()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M4));
             });
@@ -589,7 +589,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestMachineStateInheritingStateOnEventDoAction()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M5));
             });
@@ -601,7 +601,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestMachineStateOverridingStateOnEventDoAction()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M6));
             });
@@ -612,7 +612,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestMachineStateOverridingTwoStatesOnEventDoAction()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M7));
             });
@@ -623,7 +623,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestMachineStateOverridingDeepStateOnEventDoAction()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M8));
             });
@@ -634,7 +634,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestMachineStateInheritingStateOnEventGotoState()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M9));
             });
@@ -646,7 +646,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestMachineStateOverridingStateOnEventGotoState()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M10));
             });
@@ -658,7 +658,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestMachineStateOverridingTwoStatesOnEventGotoState()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M11));
             });
@@ -670,7 +670,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestMachineStateOverridingDeepStateOnEventGotoState()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M12));
             });
@@ -682,7 +682,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestMachineStateInheritingStateOnEventPushState()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M13));
             });
@@ -694,7 +694,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestMachineStateOverridingStateOnEventPushState()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M14));
             });
@@ -706,7 +706,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestMachineStateOverridingTwoStatesOnEventPushState()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M15));
             });
@@ -718,7 +718,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestMachineStateOverridingDeepStateOnEventPushState()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M16));
             });

--- a/Tests/TestingServices.Tests/Machines/Declarations/NameofTest.cs
+++ b/Tests/TestingServices.Tests/Machines/Declarations/NameofTest.cs
@@ -118,7 +118,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestAllNameofWithNameof()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M_With_nameof));
             });
@@ -130,7 +130,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestAllNameofWithoutNameof()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M_Without_nameof));
             });

--- a/Tests/TestingServices.Tests/Machines/OneMachineIntegrationTests.cs
+++ b/Tests/TestingServices.Tests/Machines/OneMachineIntegrationTests.cs
@@ -760,7 +760,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestOneMachineIntegration1()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M1));
             });
@@ -771,7 +771,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestOneMachineIntegration2()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M2));
             });
@@ -782,7 +782,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestOneMachineIntegration3()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M3));
             });
@@ -793,7 +793,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestOneMachineIntegration4()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M4));
             });
@@ -804,7 +804,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestOneMachineIntegration5()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M5));
             });
@@ -815,7 +815,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestOneMachineIntegration6()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M6));
             });
@@ -826,7 +826,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestOneMachineIntegration7()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M7));
             });
@@ -837,7 +837,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestOneMachineIntegration8()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M8));
             });
@@ -848,7 +848,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestOneMachineIntegration9()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M9));
             });
@@ -859,7 +859,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestOneMachineIntegration10()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M10));
             });
@@ -870,7 +870,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestOneMachineIntegration11()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M11));
             });
@@ -881,7 +881,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestOneMachineIntegration12()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M12));
             });
@@ -892,7 +892,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestOneMachineIntegration13()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M13));
             });
@@ -903,7 +903,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestOneMachineIntegration14()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M14));
             });
@@ -914,7 +914,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestOneMachineIntegration15()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M15));
             });
@@ -925,7 +925,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestOneMachineIntegration16()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M16));
             });
@@ -936,7 +936,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestOneMachineIntegration17()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M17));
             });
@@ -947,7 +947,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestOneMachineIntegration18()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M18));
             });
@@ -958,7 +958,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestOneMachineIntegration19()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M19));
             });
@@ -969,7 +969,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestOneMachineIntegration20()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M20));
             });

--- a/Tests/TestingServices.Tests/Machines/Statements/CurrentStateTest.cs
+++ b/Tests/TestingServices.Tests/Machines/Statements/CurrentStateTest.cs
@@ -56,7 +56,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             var configuration = GetConfiguration();
             configuration.SchedulingStrategy = SchedulingStrategy.DFS;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(Server));
             });

--- a/Tests/TestingServices.Tests/Machines/Statements/MethodCallTest.cs
+++ b/Tests/TestingServices.Tests/Machines/Statements/MethodCallTest.cs
@@ -44,7 +44,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestMethodCall()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(Program));
             });

--- a/Tests/TestingServices.Tests/Machines/Statements/PopTest.cs
+++ b/Tests/TestingServices.Tests/Machines/Statements/PopTest.cs
@@ -57,7 +57,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestUnbalancedPop()
         {
-            var test = new Action<PSharpRuntime>((r) => { r.CreateMachine(typeof(M), "M"); });
+            var test = new Action<IMachineRuntime>((r) => { r.CreateMachine(typeof(M), "M"); });
             var bugReport = "Machine 'M()' popped with no matching push.";
             this.AssertFailed(test, bugReport, true);
         }
@@ -65,7 +65,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestPopDuringOnExit()
         {
-            var test = new Action<PSharpRuntime>((r) => { r.CreateMachine(typeof(N), "N"); });
+            var test = new Action<IMachineRuntime>((r) => { r.CreateMachine(typeof(N), "N"); });
             var bugReport = "Machine 'N()' has called raise, goto, push or pop inside an OnExit method.";
             this.AssertFailed(test, bugReport, true);
         }

--- a/Tests/TestingServices.Tests/Machines/Transitions/GotoTransitions/GotoStateExitFailTest.cs
+++ b/Tests/TestingServices.Tests/Machines/Transitions/GotoTransitions/GotoStateExitFailTest.cs
@@ -44,7 +44,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestGotoStateExitFail()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(Program));
             });

--- a/Tests/TestingServices.Tests/Machines/Transitions/GotoTransitions/GotoStateFailTest.cs
+++ b/Tests/TestingServices.Tests/Machines/Transitions/GotoTransitions/GotoStateFailTest.cs
@@ -59,7 +59,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestGotoStateFail()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(Program));
             });

--- a/Tests/TestingServices.Tests/Machines/Transitions/GotoTransitions/GotoStateMultipleInActionFailTest.cs
+++ b/Tests/TestingServices.Tests/Machines/Transitions/GotoTransitions/GotoStateMultipleInActionFailTest.cs
@@ -91,7 +91,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestGotoStateTopLevelActionFail1()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(Program), new Configure(ErrorType.CallGoto));
             });
@@ -103,7 +103,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestGotoStateTopLevelActionFail2()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(Program), new Configure(ErrorType.CallRaise));
             });
@@ -115,7 +115,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestGotoStateTopLevelActionFail3()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(Program), new Configure(ErrorType.CallSend));
             });
@@ -127,7 +127,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestGotoStateTopLevelActionFail4()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(Program), new Configure(ErrorType.OnExit));
             });
@@ -139,7 +139,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestGotoStateTopLevelActionFail5()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(Program), new Configure(ErrorType.CallPush));
             });

--- a/Tests/TestingServices.Tests/Machines/Transitions/GotoTransitions/GotoStateTest.cs
+++ b/Tests/TestingServices.Tests/Machines/Transitions/GotoTransitions/GotoStateTest.cs
@@ -63,7 +63,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestGotoMachineState()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(Program));
             });
@@ -74,7 +74,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestGotoMonitorState()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(M));
             });

--- a/Tests/TestingServices.Tests/Machines/Transitions/PushTransitions/PushApiTest.cs
+++ b/Tests/TestingServices.Tests/Machines/Transitions/PushTransitions/PushApiTest.cs
@@ -139,7 +139,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestPushSimple()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M1));
             });
@@ -150,7 +150,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestPushPopSimple()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var m = r.CreateMachine(typeof(M2));
                 r.SendEvent(m, new E());
@@ -162,7 +162,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestPushStateExit()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M3));
             });
@@ -173,7 +173,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestPushBadStateFail()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M4a));
             });

--- a/Tests/TestingServices.Tests/Machines/Transitions/PushTransitions/PushStateTest.cs
+++ b/Tests/TestingServices.Tests/Machines/Transitions/PushTransitions/PushStateTest.cs
@@ -76,7 +76,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestPushStateEvent()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(B));
             });

--- a/Tests/TestingServices.Tests/Machines/TwoMachineIntegrationTests.cs
+++ b/Tests/TestingServices.Tests/Machines/TwoMachineIntegrationTests.cs
@@ -431,7 +431,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             var configuration = GetConfiguration();
             configuration.SchedulingStrategy = SchedulingStrategy.DFS;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M1));
             });
@@ -445,7 +445,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             var configuration = GetConfiguration();
             configuration.SchedulingStrategy = SchedulingStrategy.DFS;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M3));
             });
@@ -459,7 +459,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             var configuration = GetConfiguration();
             configuration.SchedulingStrategy = SchedulingStrategy.DFS;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M5));
             });
@@ -473,7 +473,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             var configuration = GetConfiguration();
             configuration.SchedulingStrategy = SchedulingStrategy.DFS;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M7));
             });
@@ -484,7 +484,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestTwoMachineIntegration5()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M9));
             });

--- a/Tests/TestingServices.Tests/Monitors/IdempotentRegisterMonitorTest.cs
+++ b/Tests/TestingServices.Tests/Monitors/IdempotentRegisterMonitorTest.cs
@@ -70,7 +70,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestIdempotentRegisterMonitorInvocation()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(M));
                 r.RegisterMonitor(typeof(M));

--- a/Tests/TestingServices.Tests/Monitors/MachineMonitorIntegrationTests.cs
+++ b/Tests/TestingServices.Tests/Monitors/MachineMonitorIntegrationTests.cs
@@ -109,7 +109,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             var configuration = GetConfiguration();
             configuration.SchedulingStrategy = SchedulingStrategy.DFS;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(Spec1));
                 r.CreateMachine(typeof(M1<Spec1>));
@@ -124,7 +124,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             var configuration = GetConfiguration();
             configuration.SchedulingStrategy = SchedulingStrategy.DFS;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(Spec2));
                 r.CreateMachine(typeof(M2));
@@ -139,7 +139,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             var configuration = GetConfiguration();
             configuration.SchedulingStrategy = SchedulingStrategy.DFS;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(Spec3));
                 r.CreateMachine(typeof(M1<Spec3>));

--- a/Tests/TestingServices.Tests/Properties/codeanalysis.ruleset
+++ b/Tests/TestingServices.Tests/Properties/codeanalysis.ruleset
@@ -75,7 +75,7 @@
     <Rule Id="SA1101" Action="Error" />
     <Rule Id="SA1106" Action="Error" />
     <Rule Id="SA1108" Action="Error" />
-    <Rule Id="SA1116" Action="Error" />
+    <Rule Id="SA1116" Action="None" />
     <Rule Id="SA1117" Action="None" />
     <Rule Id="SA1118" Action="None" />
     <Rule Id="SA1119" Action="Error" />

--- a/Tests/TestingServices.Tests/Protocols/ChainReplicationTest.cs
+++ b/Tests/TestingServices.Tests/Protocols/ChainReplicationTest.cs
@@ -1548,7 +1548,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             configuration.RandomSchedulingSeed = seed;
             configuration.SchedulingIterations = 2;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(InvariantMonitor));
                 r.RegisterMonitor(typeof(ServerResponseSeqMonitor));

--- a/Tests/TestingServices.Tests/Protocols/ChordTest.cs
+++ b/Tests/TestingServices.Tests/Protocols/ChordTest.cs
@@ -881,7 +881,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             configuration.RandomSchedulingSeed = seed;
             configuration.SchedulingIterations = 1;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(LivenessMonitor));
                 r.CreateMachine(typeof(ClusterManager));
@@ -903,7 +903,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             configuration.RandomSchedulingSeed = seed;
             configuration.SchedulingIterations = 1;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(LivenessMonitor));
                 r.CreateMachine(typeof(ClusterManager));

--- a/Tests/TestingServices.Tests/Protocols/DiningPhilosophersTest.cs
+++ b/Tests/TestingServices.Tests/Protocols/DiningPhilosophersTest.cs
@@ -224,7 +224,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             configuration.RandomSchedulingSeed = seed;
             configuration.SchedulingIterations = 1;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(LivenessMonitor));
                 r.CreateMachine(typeof(Environment));

--- a/Tests/TestingServices.Tests/Protocols/FailureDetectorTest.cs
+++ b/Tests/TestingServices.Tests/Protocols/FailureDetectorTest.cs
@@ -531,7 +531,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             configuration.SchedulingIterations = 1;
             configuration.ReductionStrategy = Utilities.ReductionStrategy.ForceSchedule; // TODO
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(Safety));
                 r.CreateMachine(typeof(Driver), new Driver.Config(2));
@@ -554,7 +554,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             configuration.SchedulingIterations = 1;
             configuration.ReductionStrategy = Utilities.ReductionStrategy.ForceSchedule; // TODO
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(LivenessMonitor));
                 r.CreateMachine(typeof(Driver), new Driver.Config(2));
@@ -576,7 +576,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             configuration.RandomSchedulingSeed = 270;
             configuration.SchedulingIterations = 1;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(LivenessMonitor));
                 r.CreateMachine(typeof(Driver), new Driver.Config(2));

--- a/Tests/TestingServices.Tests/Protocols/ProcessSchedulerTest.cs
+++ b/Tests/TestingServices.Tests/Protocols/ProcessSchedulerTest.cs
@@ -632,7 +632,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             configuration.RandomSchedulingSeed = seed;
             configuration.SchedulingIterations = 1;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(LivenessMonitor));
                 r.CreateMachine(typeof(Environment));

--- a/Tests/TestingServices.Tests/Protocols/RaftTest.cs
+++ b/Tests/TestingServices.Tests/Protocols/RaftTest.cs
@@ -1238,7 +1238,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             configuration.RandomSchedulingSeed = seed;
             configuration.SchedulingIterations = 1;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(SafetyMonitor));
                 r.CreateMachine(typeof(ClusterManager));

--- a/Tests/TestingServices.Tests/Protocols/ReplicatingStorageTest.cs
+++ b/Tests/TestingServices.Tests/Protocols/ReplicatingStorageTest.cs
@@ -869,7 +869,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             configuration.RandomSchedulingSeed = 315;
             configuration.SchedulingIterations = 1;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(LivenessMonitor));
                 r.CreateMachine(typeof(Environment));
@@ -891,7 +891,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             configuration.RandomSchedulingSeed = 2;
             configuration.SchedulingIterations = 1;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(LivenessMonitor));
                 r.CreateMachine(typeof(Environment));

--- a/Tests/TestingServices.Tests/RuntimeInterface/CreateMachineIdFromNameTest.cs
+++ b/Tests/TestingServices.Tests/RuntimeInterface/CreateMachineIdFromNameTest.cs
@@ -59,7 +59,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestCreateMachineIdFromName1()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(LivenessMonitor));
                 var m1 = r.CreateMachine(typeof(M));
@@ -74,7 +74,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestCreateMachineIdFromName2()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(LivenessMonitor));
                 var m1 = r.CreateMachineIdFromName(typeof(M), "M1");
@@ -106,7 +106,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestCreateMachineIdFromName4()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var m3 = r.CreateMachineIdFromName(typeof(M3), "M3");
                 r.CreateMachine(m3, typeof(M2));
@@ -118,7 +118,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestCreateMachineIdFromName5()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var m1 = r.CreateMachineIdFromName(typeof(M2), "M2");
                 r.CreateMachine(m1, typeof(M2));
@@ -131,7 +131,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestCreateMachineIdFromName6()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var m = r.CreateMachineIdFromName(typeof(M2), "M2");
                 r.SendEvent(m, new E());
@@ -144,7 +144,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestCreateMachineIdFromName7()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var m = r.CreateMachineIdFromName(typeof(M2), "M2");
                 r.CreateMachine(m, typeof(M2));
@@ -205,7 +205,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestCreateMachineIdFromName8()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var m = r.CreateMachineIdFromName(typeof(M4), "M4");
                 r.CreateMachine(typeof(M5), new E2(m));
@@ -222,7 +222,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestCreateMachineIdFromName9()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var m1 = r.CreateMachineIdFromName(typeof(M4), "M4");
                 var m2 = r.CreateMachineIdFromName(typeof(M4), "M4");
@@ -250,7 +250,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestCreateMachineIdFromName10()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M6));
                 r.CreateMachine(typeof(M6));
@@ -297,7 +297,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestCreateMachineIdFromName11()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(WaitUntilDone));
                 r.CreateMachine(typeof(M7));

--- a/Tests/TestingServices.Tests/RuntimeInterface/CreateMachineWithIdTest.cs
+++ b/Tests/TestingServices.Tests/RuntimeInterface/CreateMachineWithIdTest.cs
@@ -58,7 +58,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestCreateMachineWithId1()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(LivenessMonitor));
                 var m = r.CreateMachine(typeof(M));
@@ -165,7 +165,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestCreateMachineWithId2()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(LivenessMonitor));
                 var m = r.CreateMachine(typeof(Harness));
@@ -193,7 +193,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestCreateMachineWithId3()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var m3 = r.CreateMachineId(typeof(M3));
                 r.CreateMachine(m3, typeof(M2));
@@ -205,7 +205,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestCreateMachineWithId4()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var m2 = r.CreateMachine(typeof(M2));
                 r.CreateMachine(m2, typeof(M2));
@@ -217,7 +217,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestCreateMachineWithId5()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var m = r.CreateMachineId(typeof(M2));
                 r.SendEvent(m, new E());
@@ -230,7 +230,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestCreateMachineWithId6()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var m = r.CreateMachine(typeof(M2));
 
@@ -290,7 +290,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestCreateMachineWithId7()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 var m = r.CreateMachineId(typeof(M4));
                 r.CreateMachine(typeof(M5), new E2(m));

--- a/Tests/TestingServices.Tests/RuntimeInterface/FairRandomTest.cs
+++ b/Tests/TestingServices.Tests/RuntimeInterface/FairRandomTest.cs
@@ -26,7 +26,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
 
         private class Engine
         {
-            public static bool FairRandom(PSharpRuntime runtime)
+            public static bool FairRandom(IMachineRuntime runtime)
             {
                 return runtime.FairRandom();
             }
@@ -83,7 +83,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestFairRandom()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(UntilDone));
                 var m = r.CreateMachine(typeof(M));

--- a/Tests/TestingServices.Tests/RuntimeInterface/ReceivingExternalEventTest.cs
+++ b/Tests/TestingServices.Tests/RuntimeInterface/ReceivingExternalEventTest.cs
@@ -28,7 +28,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
 
         private class Engine
         {
-            public static void Send(PSharpRuntime runtime, MachineId target)
+            public static void Send(IMachineRuntime runtime, MachineId target)
             {
                 runtime.SendEvent(target, new E(2));
             }
@@ -57,7 +57,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestReceivingExternalEvents()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(M));
             });

--- a/Tests/TestingServices.Tests/RuntimeInterface/SendAndExecuteTest1.cs
+++ b/Tests/TestingServices.Tests/RuntimeInterface/SendAndExecuteTest1.cs
@@ -88,7 +88,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestSendAndExecuteNoDeadlockWithReceive()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(A), new Configure(false));
             });
@@ -100,7 +100,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         public void TestSendAndExecuteDeadlockWithReceive()
         {
             var config = Configuration.Create().WithNumberOfIterations(10);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(A), new Configure(true));
             });

--- a/Tests/TestingServices.Tests/RuntimeInterface/SendAndExecuteTest2.cs
+++ b/Tests/TestingServices.Tests/RuntimeInterface/SendAndExecuteTest2.cs
@@ -90,7 +90,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         public void TestSyncSendToReceive()
         {
             var config = Configuration.Create().WithNumberOfIterations(1000);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(A));
             });
@@ -102,7 +102,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         public void TestSyncSendSometimesDoesNotHandle()
         {
             var config = Configuration.Create().WithNumberOfIterations(1000);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(C));
             });

--- a/Tests/TestingServices.Tests/RuntimeInterface/SendAndExecuteTest3.cs
+++ b/Tests/TestingServices.Tests/RuntimeInterface/SendAndExecuteTest3.cs
@@ -82,7 +82,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestSendBlocks()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(Harness));
             });

--- a/Tests/TestingServices.Tests/RuntimeInterface/SendAndExecuteTest4.cs
+++ b/Tests/TestingServices.Tests/RuntimeInterface/SendAndExecuteTest4.cs
@@ -68,7 +68,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestSendCycleDoesNotDeadlock()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(Harness));
             });

--- a/Tests/TestingServices.Tests/RuntimeInterface/SendAndExecuteTest5.cs
+++ b/Tests/TestingServices.Tests/RuntimeInterface/SendAndExecuteTest5.cs
@@ -100,7 +100,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestMachineHaltsOnSendExec()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(SafetyMonitor));
                 r.CreateMachine(typeof(Harness));

--- a/Tests/TestingServices.Tests/RuntimeInterface/SendAndExecuteTest6.cs
+++ b/Tests/TestingServices.Tests/RuntimeInterface/SendAndExecuteTest6.cs
@@ -104,7 +104,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestHandledExceptionOnSendExec()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(SafetyMonitor));
                 r.CreateMachine(typeof(Harness), new Config(true));
@@ -117,7 +117,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestUnHandledExceptionOnSendExec()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(SafetyMonitor));
                 r.CreateMachine(typeof(Harness), new Config(false));

--- a/Tests/TestingServices.Tests/RuntimeInterface/SendAndExecuteTest7.cs
+++ b/Tests/TestingServices.Tests/RuntimeInterface/SendAndExecuteTest7.cs
@@ -48,7 +48,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestUnhandledEventOnSendExec()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(Harness));
             });

--- a/Tests/TestingServices.Tests/RuntimeInterface/SendAndExecuteTest8.cs
+++ b/Tests/TestingServices.Tests/RuntimeInterface/SendAndExecuteTest8.cs
@@ -59,7 +59,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestUnhandledEventOnSendExec()
         {
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(Harness));
             });

--- a/Tests/TestingServices.Tests/SchedulingStrategies/DPORTest.cs
+++ b/Tests/TestingServices.Tests/SchedulingStrategies/DPORTest.cs
@@ -158,7 +158,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestDPOR1Reduces()
         {
-            var test = new Action<PSharpRuntime>(r =>
+            var test = new Action<IMachineRuntime>(r =>
             {
                 MachineId waiter = r.CreateMachine(typeof(Waiter));
                 MachineId sender1 = r.CreateMachine(typeof(Sender), new SenderInitEvent(waiter));
@@ -186,7 +186,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestDPOR2NonDet()
         {
-            var test = new Action<PSharpRuntime>(r =>
+            var test = new Action<IMachineRuntime>(r =>
             {
                 MachineId waiter = r.CreateMachine(typeof(Waiter));
                 MachineId sender1 = r.CreateMachine(typeof(Sender), new SenderInitEvent(waiter, false, true));
@@ -209,7 +209,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestDPOR3CreatingMany()
         {
-            var test = new Action<PSharpRuntime>(r =>
+            var test = new Action<IMachineRuntime>(r =>
             {
                 MachineId waiter = r.CreateMachine(typeof(Waiter));
                 r.CreateMachine(typeof(LevelOne), new ReceiverAddressEvent(waiter));
@@ -226,7 +226,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         [Fact]
         public void TestDPOR4UseReceive()
         {
-            var test = new Action<PSharpRuntime>(r =>
+            var test = new Action<IMachineRuntime>(r =>
             {
                 MachineId waiter = r.CreateMachine(typeof(ReceiveWaiter));
 

--- a/Tests/TestingServices.Tests/Timers/BasicTimerTest.cs
+++ b/Tests/TestingServices.Tests/Timers/BasicTimerTest.cs
@@ -49,7 +49,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             var configuration = Configuration.Create().WithNumberOfIterations(1000);
             configuration.MaxSchedulingSteps = 200;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(T1));
             });
@@ -93,7 +93,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
         public void TestBasicPeriodicTimerOperation()
         {
             var configuration = Configuration.Create().WithNumberOfIterations(1000);
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(T2));
             });
@@ -153,7 +153,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             var configuration = Configuration.Create().WithNumberOfIterations(100);
             configuration.MaxSchedulingSteps = 200;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(T3));
             });
@@ -181,7 +181,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             var configuration = Configuration.Create().WithNumberOfIterations(1000);
             configuration.MaxSchedulingSteps = 200;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(T4));
             });
@@ -209,7 +209,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             var configuration = Configuration.Create().WithNumberOfIterations(1000);
             configuration.MaxSchedulingSteps = 200;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(T5));
             });
@@ -264,7 +264,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             var configuration = Configuration.Create().WithNumberOfIterations(1000);
             configuration.MaxSchedulingSteps = 200;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(T6));
             });
@@ -307,7 +307,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             var configuration = Configuration.Create().WithNumberOfIterations(1000);
             configuration.MaxSchedulingSteps = 200;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(T8));
             });

--- a/Tests/TestingServices.Tests/Timers/Deprecated/BasicPeriodicTimeoutTest.cs
+++ b/Tests/TestingServices.Tests/Timers/Deprecated/BasicPeriodicTimeoutTest.cs
@@ -58,7 +58,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Deprecated
             var config = Configuration.Create().WithNumberOfIterations(1000);
             ModelTimerMachine.NumStepsToSkip = 1;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(T1));
             });

--- a/Tests/TestingServices.Tests/Timers/Deprecated/BasicSingleTimeoutTest.cs
+++ b/Tests/TestingServices.Tests/Timers/Deprecated/BasicSingleTimeoutTest.cs
@@ -51,7 +51,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Deprecated
             var config = Configuration.Create().WithNumberOfIterations(1000);
             config.MaxSchedulingSteps = 200;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(T1));
             });

--- a/Tests/TestingServices.Tests/Timers/Deprecated/IllegalPeriodTest.cs
+++ b/Tests/TestingServices.Tests/Timers/Deprecated/IllegalPeriodTest.cs
@@ -42,7 +42,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Deprecated
             var config = Configuration.Create().WithNumberOfIterations(1000);
             config.MaxSchedulingSteps = 200;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(T4));
             });

--- a/Tests/TestingServices.Tests/Timers/Deprecated/IllegalTimerStoppageTest.cs
+++ b/Tests/TestingServices.Tests/Timers/Deprecated/IllegalTimerStoppageTest.cs
@@ -74,7 +74,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Deprecated
             var config = Configuration.Create().WithNumberOfIterations(1000);
             config.MaxSchedulingSteps = 200;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.CreateMachine(typeof(T2));
             });

--- a/Tests/TestingServices.Tests/Timers/Deprecated/StartStopTimerTest.cs
+++ b/Tests/TestingServices.Tests/Timers/Deprecated/StartStopTimerTest.cs
@@ -73,7 +73,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Deprecated
             config.MaxSchedulingSteps = 300;
             config.SchedulingIterations = 1000;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(LivenessMonitor));
                 r.CreateMachine(typeof(Client));

--- a/Tests/TestingServices.Tests/Timers/Deprecated/TimerLivenessTest.cs
+++ b/Tests/TestingServices.Tests/Timers/Deprecated/TimerLivenessTest.cs
@@ -67,7 +67,7 @@ namespace Microsoft.PSharp.TestingServices.Tests.Deprecated
             config.MaxSchedulingSteps = 300;
             config.SchedulingIterations = 1000;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(LivenessMonitor));
                 r.CreateMachine(typeof(Client));

--- a/Tests/TestingServices.Tests/Timers/StartStopTimerTest.cs
+++ b/Tests/TestingServices.Tests/Timers/StartStopTimerTest.cs
@@ -68,7 +68,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             configuration.MaxSchedulingSteps = 300;
             configuration.SchedulingIterations = 1000;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(LivenessMonitor));
                 r.CreateMachine(typeof(Client));

--- a/Tests/TestingServices.Tests/Timers/TimerLivenessTest.cs
+++ b/Tests/TestingServices.Tests/Timers/TimerLivenessTest.cs
@@ -64,7 +64,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
             configuration.MaxSchedulingSteps = 300;
             configuration.SchedulingIterations = 1000;
 
-            var test = new Action<PSharpRuntime>((r) =>
+            var test = new Action<IMachineRuntime>((r) =>
             {
                 r.RegisterMonitor(typeof(LivenessMonitor));
                 r.CreateMachine(typeof(Client));

--- a/Tests/Tests.Common/Properties/codeanalysis.ruleset
+++ b/Tests/Tests.Common/Properties/codeanalysis.ruleset
@@ -75,7 +75,7 @@
     <Rule Id="SA1101" Action="Error" />
     <Rule Id="SA1106" Action="Error" />
     <Rule Id="SA1108" Action="Error" />
-    <Rule Id="SA1116" Action="Error" />
+    <Rule Id="SA1116" Action="None" />
     <Rule Id="SA1117" Action="None" />
     <Rule Id="SA1118" Action="None" />
     <Rule Id="SA1119" Action="Error" />

--- a/Tests/Tests.Launcher/Program.cs
+++ b/Tests/Tests.Launcher/Program.cs
@@ -42,7 +42,7 @@ namespace Microsoft.PSharp.Tests.Launcher
 
 #pragma warning disable CA1801 // Parameter not used
         [Test]
-        public static void Execute(PSharpRuntime r)
+        public static void Execute(IMachineRuntime r)
         {
         }
 #pragma warning restore CA1801 // Parameter not used

--- a/Tests/Tests.Launcher/Properties/codeanalysis.ruleset
+++ b/Tests/Tests.Launcher/Properties/codeanalysis.ruleset
@@ -75,7 +75,7 @@
     <Rule Id="SA1101" Action="Error" />
     <Rule Id="SA1106" Action="Error" />
     <Rule Id="SA1108" Action="Error" />
-    <Rule Id="SA1116" Action="Error" />
+    <Rule Id="SA1116" Action="None" />
     <Rule Id="SA1117" Action="None" />
     <Rule Id="SA1118" Action="None" />
     <Rule Id="SA1119" Action="Error" />

--- a/Tools/Benchmarking/PSharpBenchmarkRunner/Properties/codeanalysis.ruleset
+++ b/Tools/Benchmarking/PSharpBenchmarkRunner/Properties/codeanalysis.ruleset
@@ -75,7 +75,7 @@
     <Rule Id="SA1101" Action="Error" />
     <Rule Id="SA1106" Action="Error" />
     <Rule Id="SA1108" Action="Error" />
-    <Rule Id="SA1116" Action="Error" />
+    <Rule Id="SA1116" Action="None" />
     <Rule Id="SA1117" Action="None" />
     <Rule Id="SA1118" Action="None" />
     <Rule Id="SA1119" Action="Error" />

--- a/Tools/Compilation/Compiler/Properties/codeanalysis.ruleset
+++ b/Tools/Compilation/Compiler/Properties/codeanalysis.ruleset
@@ -75,7 +75,7 @@
     <Rule Id="SA1101" Action="Error" />
     <Rule Id="SA1106" Action="Error" />
     <Rule Id="SA1108" Action="Error" />
-    <Rule Id="SA1116" Action="Error" />
+    <Rule Id="SA1116" Action="None" />
     <Rule Id="SA1117" Action="None" />
     <Rule Id="SA1118" Action="None" />
     <Rule Id="SA1119" Action="Error" />

--- a/Tools/Compilation/SyntaxRewriter/Properties/codeanalysis.ruleset
+++ b/Tools/Compilation/SyntaxRewriter/Properties/codeanalysis.ruleset
@@ -75,7 +75,7 @@
     <Rule Id="SA1101" Action="Error" />
     <Rule Id="SA1106" Action="Error" />
     <Rule Id="SA1108" Action="Error" />
-    <Rule Id="SA1116" Action="Error" />
+    <Rule Id="SA1116" Action="None" />
     <Rule Id="SA1117" Action="None" />
     <Rule Id="SA1118" Action="None" />
     <Rule Id="SA1119" Action="Error" />

--- a/Tools/Compilation/SyntaxRewriterProcess/Properties/codeanalysis.ruleset
+++ b/Tools/Compilation/SyntaxRewriterProcess/Properties/codeanalysis.ruleset
@@ -75,7 +75,7 @@
     <Rule Id="SA1101" Action="Error" />
     <Rule Id="SA1106" Action="Error" />
     <Rule Id="SA1108" Action="Error" />
-    <Rule Id="SA1116" Action="Error" />
+    <Rule Id="SA1116" Action="None" />
     <Rule Id="SA1117" Action="None" />
     <Rule Id="SA1118" Action="None" />
     <Rule Id="SA1119" Action="Error" />

--- a/Tools/Testing/CoverageReportMerger/Properties/codeanalysis.ruleset
+++ b/Tools/Testing/CoverageReportMerger/Properties/codeanalysis.ruleset
@@ -75,7 +75,7 @@
     <Rule Id="SA1101" Action="Error" />
     <Rule Id="SA1106" Action="Error" />
     <Rule Id="SA1108" Action="Error" />
-    <Rule Id="SA1116" Action="Error" />
+    <Rule Id="SA1116" Action="None" />
     <Rule Id="SA1117" Action="None" />
     <Rule Id="SA1118" Action="None" />
     <Rule Id="SA1119" Action="Error" />

--- a/Tools/Testing/Replayer/Properties/codeanalysis.ruleset
+++ b/Tools/Testing/Replayer/Properties/codeanalysis.ruleset
@@ -75,7 +75,7 @@
     <Rule Id="SA1101" Action="Error" />
     <Rule Id="SA1106" Action="Error" />
     <Rule Id="SA1108" Action="Error" />
-    <Rule Id="SA1116" Action="Error" />
+    <Rule Id="SA1116" Action="None" />
     <Rule Id="SA1117" Action="None" />
     <Rule Id="SA1118" Action="None" />
     <Rule Id="SA1119" Action="Error" />

--- a/Tools/Testing/Tester/Properties/codeanalysis.ruleset
+++ b/Tools/Testing/Tester/Properties/codeanalysis.ruleset
@@ -75,7 +75,7 @@
     <Rule Id="SA1101" Action="Error" />
     <Rule Id="SA1106" Action="Error" />
     <Rule Id="SA1108" Action="Error" />
-    <Rule Id="SA1116" Action="Error" />
+    <Rule Id="SA1116" Action="None" />
     <Rule Id="SA1117" Action="None" />
     <Rule Id="SA1118" Action="None" />
     <Rule Id="SA1119" Action="Error" />


### PR DESCRIPTION
The public `PSharpRuntime` type is now replaced by the `IMachineRuntime` interface, which exposes the same APIs as the `PSharpRuntime` did previously.

The `PSharpRuntime` still exists, but is now a static factory class that returns a `IMachineRuntime` via `PSharpRuntime.Create(...)`. So the only change a user needs to do is replace `PSharpRuntime runtime = PSharpRuntime.Create(...)` with `IMachineRuntime runtime = PSharpRuntime.Create(...)`. If someone is using `var runtime = PSharpRuntime.Create(...)`, then it is already fine. Additionally the machine id is returning a `IMachineRuntime` now instead of `PSharpRuntime`.

The actual implementation of these interfaces is now internal (the previous `PSharpRuntime` base runtime class is now simply renamed as `BaseRuntime`, alongside the already existing `ProductionRuntime` and `TestingRuntime`), which gives us more freedom in the long term to modify the runtime classes (we just need to return an implementation of `IMachineRuntime`). An additional benefit is that we can potentially inject completely different implementations of `IMachineRuntime` (e.g. for our own unit testing purposes).

Also updated the documentation and samples accordingly.