### PR TITLE
New test APIs for unit-testing machines in isolation

### DIFF
--- a/Docs/README.md
+++ b/Docs/README.md
@@ -19,8 +19,9 @@ Now you are ready to dive into various features and topics:
 - [Using timers in P#](Features/Timers.md)
 - [Logging](Features/Logging.md) and [tracking operation groups](Features/TrackingOperationGroups.md)
 
-Learn how to use the P# testing infrastructure to thoroughly check safety and liveness properties, and deterministically reproduce bugs:
-- [Testing P# programs and reproducing bugs](Testing/TestingMethodology.md)
+Learn how to use the P# testing infrastructure to write unit-tests, thoroughly check safety and liveness properties, and deterministically reproduce bugs:
+- [Unit-testing P# machines in isolation](Testing/UnitTesting.md)
+- [Automatically testing P# programs end-to-end and reproducing bugs](Testing/TestingMethodology.md)
 - [Effectively checking liveness properties](Testing/LivenessChecking.md)
 - [Testing async/await code using P#](Testing/TestingAsyncAwait.md)
 - [Code and activity coverage](Testing/CodeCoverageVisualisation.md)

--- a/Docs/Testing/TestingMethodology.md
+++ b/Docs/Testing/TestingMethodology.md
@@ -1,6 +1,6 @@
-Testing P# programs and reproducing bugs
-========================================
-The P# tester can be used to **systematically test** a P# program to find **safety** and **liveness property violations** (specified by the user).
+Automatically testing P# programs end-to-end and reproducing bugs
+=================================================================
+The P# tester can be used to **automatically test** a P# program to find and determinitically reproduce generic errors, as well as (specified by the user) **safety** and **liveness property violations**.
 
 To invoke the tester use the following command:
 ```

--- a/Docs/Testing/UnitTesting.md
+++ b/Docs/Testing/UnitTesting.md
@@ -1,0 +1,125 @@
+Unit-testing P# machines in isolation
+=====================================
+The `MachineTestKit` API provides the capability to _unit-test_ a machine of type `T` _sequentially_ and in _isolation_ from other machines, or the external environment. This is orthogonal from using the `PSharpTester` (see [here](./TestingMethodology.md)) which provides the capability to automatically test a P# program end-to-end (i.e. integration-testing) against concurrency and specifications. We recommend writing both unit-tests and integration-tests to get the most value out of the P# framework.
+
+We will now discuss how to use `MachineTestKit` by going through some simple examples.
+
+Say that you have the following machine `M`, which has a method `Add(int m, int k)` that takes two integers, adds them, and returns the result:
+```C#
+private class M : Machine
+{
+   [Start]
+   private class Init : MachineState {}
+
+   internal int Add(int m, int k)
+   {
+         return m + k;
+   }
+}
+```
+
+To unit-test the above `Add` machine method, first import the `Microsoft.PSharp.TestingServices` library:
+```C#
+using Microsoft.PSharp.TestingServices;
+```
+
+Next, create a new `MachineTestKit` instance for the machine `M` in your test method, as seen below. You can pass an optional `Configuration` (e.g. if you want to enable verbosity).
+```C#
+public void Test()
+{
+   var test = new MachineTestKit<M>(configuration: Configuration.Create());
+}
+```
+
+When `MachineTestKit<M>` is instantiated, it creates an instance of the machine `M`, which executes in a special runtime that provides isolation. The internals of the machine (e.g. the queue) are properly initialized, as if the machine was executing in production. However, if the machine is trying to create other machines, it will get a _dummy_ `MachineId`, and if the machine tries to send an event to a machine other than itself, that event will be dropped. Talking to external APIs (e.g. network or storage) might still require mocking (as is the case in regular unit-testing).
+
+The `MachineTestKit<M>` instance gives you access to the machine reference through the `MachineTestKit.Machine` property, as seen below. You can use this referene to directly invoke methods of the machine, in a unit-testing fashion. We also provide `MachineTestKit.Assert`, which is a generic assertion that you can use for checking correctness, as well as several build-in assertions, e.g. for asserting state transitions, or if the inbox is empty (and more assertions can be added based on user feedback).
+```C#
+public void Test()
+{
+   var test = new MachineTestKit<M>(configuration: Configuration.Create());
+   int result = test.Machine.Add(3, 4);
+   test.Assert(result == 7, $"Incorrect result '{result}'");
+}
+```
+
+Note that directly calling machine methods (as above) only works if these methods are declared as `public` or `internal`. This is typically not recommended for machines (and actors, in general), since the only way to interact with them should be by sending messages. However, it can be very useful to unit-test private machine methods, and for this reason the `MachineTestKit` provides the `Invoke` and `InvokeAsync` APIs, which accept the name of the method (and, optionally, parameter types for distinguishing overloaded methods), as well as the parameters to invoke the method, if any. The following example shows how to use these APIs to invoke private machine methods:
+
+```C#
+private class M : Machine
+{
+   [Start]
+   private class Init : MachineState {}
+
+   private int Add(int m, int k)
+   {
+         return m + k;
+   }
+
+   private async Task<int> AddAsync(int m, int k)
+   {
+         await Task.CompletedTask;
+         return m + k;
+   }
+}
+
+public async Task TestAsync()
+{
+   var test = new MachineTestKit<M>(configuration: Configuration.Create());
+
+   // Use this API to unit-test a private machine method.
+   int result = (int)test.Invoke("Add", 3, 4);
+   test.Assert(result == 7, $"Incorrect result '{result}'");
+
+   // Use this API to unit-test an overloaded private machine method.
+   result = (int)test.Invoke("Add", new Type[] { typeof(int), typeof(int) }, 3, 4);
+   test.Assert(result == 7, $"Incorrect result '{result}'");
+
+   // Use this API to unit-test an asynchronous private machine method.
+   int result = (int)await test.InvokeAsync("AddAsync", 3, 4);
+   test.Assert(result == 7, $"Incorrect result '{result}'");
+
+   // Use this API to unit-test an asynchronous overloaded private machine method.
+   result = (int)await test.InvokeAsync("AddAsync", new Type[] { typeof(int), typeof(int) }, 3, 4);
+   test.Assert(result == 7, $"Incorrect result '{result}'");
+}
+```
+
+Besides allowing the user to directly call machine methods, the `MachineTestKit` also provides access to two APIs that allow the user to asynchronously (but sequentially) interact with the machine via its inbox, and thus test how the machine transitions to different states and handles events. These two APIs are `StartMachineAsync(Event initialEvent = null)` and `SendEventAsync(Event e)`.
+
+The `StartMachineAsync` method transitions the machine to its `Start` state, passes the optional specified event (`initialEvent`) and invokes its `OnEntry` handler, if there is one available. This method returns a task that completes when the machine reaches quiescence (typically when the event handler finishes executing because there are not more events to dequeue, or when the machine asynchronously waits to receive an event). This method should only be called in the beginning of the unit-test, since a machine only transitions to its `Start` state once.
+
+The `SendEventAsync` method sends an event to the machine and starts its event handler. Similar to `StartMachineAsync`, this method returns a task that completes when the machine reaches quiescence (typically when the event handler finishes executing because there are not more events to dequeue, or when the machine asynchronously waits to receive an event).
+
+An example of using these two methods is the following:
+```C#
+private class E : Event {}
+
+private class M : Machine
+{
+   [Start]
+   [OnEntry(nameof(InitOnEntry))]
+   private class Init : MachineState {}
+
+   private async Task InitOnEntry()
+   {
+         await this.Receive(typeof(E));
+   }
+}
+
+public async Task Test()
+{
+   var test = new MachineTestKit<M>();
+
+   await test.StartMachineAsync();
+   test.AssertIsWaitingToReceiveEvent(true);
+
+   await test.SendEventAsync(new E());
+   test.AssertIsWaitingToReceiveEvent(false);
+   test.AssertInboxSize(0);
+}
+```
+
+The above unit-test, creates a new instance of the machine `M`, then transitions the machine to its `Start` state using `StartMachineAsync`, and then asserts that the machine is asynchronously waiting to receive an event of type `E` (via the `Receive` statement) by invoking the `AssertIsWaitingToReceiveEvent(true)` assertion. Next, the test is sending the expected event `E` using `SendEventAsync`, and finally asserts that the machine is not waiting any event, by calling `AssertIsWaitingToReceiveEvent(false)`, and that its inbox is empty, by calling `AssertInboxSize(0)`.
+
+Note that its possible to use both the `StartMachineAsync` and `SendEventAsync`, as well as invoke directly methods by accessing the `MachineTestKit.Machine` property, based on the testing scenario.

--- a/README.md
+++ b/README.md
@@ -2,16 +2,14 @@
 [![NuGet](https://img.shields.io/nuget/v/Microsoft.PSharp.svg)](https://www.nuget.org/packages/Microsoft.PSharp/)
 [![Build status](https://p-language.visualstudio.com/plang-ci/_apis/build/status/psharp/psharp-win-build-and-test?branchName=master)](https://p-language.visualstudio.com/plang-ci/_build/latest?definitionId=1)
 
-P#
-===
-A framework for **building** and **systematically testing** highly-reliable asynchronous reactive software. P# is used by several teams in [Azure](https://azure.microsoft.com/) to design, implement and thoroughly test production distributed systems and services.
+P# is a framework for rapid development of reliable asynchronous software. P# is used by several teams in [Azure](https://azure.microsoft.com/) to design, implement and automatically test production distributed systems and services.
 
 ## Features
 The P# framework provides:
-- An actor-based programming model for building **event-driven asynchronous** applications and services. The unit of concurrency in P# is an **asynchronous communicating state machine**, which is basically an actor that can create new machines, send and receive events, and transition to different states. Using P# machines, you can express your design and code at a higher level that is a natural fit for many cloud services.
+- An actor-based programming model for building event-driven asynchronous applications. The unit of concurrency in P# is an asynchronous communicating state-machine, which is basically an actor that can create new machines, send and receive events, and transition to different states. Using P# machines, you can express your design and code at a higher level that is a natural fit for many cloud services.
 - An efficient, lightweight runtime that is build on top of the Task Parallel Library (TPL). This runtime can be used to deploy a P# program in production. The P# runtime is very flexible and can work with any communication and storage layer.
-- The capability to easily write **safety** and **liveness specifications** (similar to TLA+) programmatically in C#.
-- A **systematic testing engine** that can control the P# program schedule, as well as all declared sources of nondeterminism (e.g. failures and timeouts), and systematically explore the actual executable code to discover bugs (e.g. crashes or specification violations). If a bug is found, the P# testing engine will report a deterministic reproducible trace that can be replayed using the Visual Studio Debugger.
+- The capability to easily write safety and liveness specifications (similar to TLA+) programmatically in C#.
+- A systematic testing engine that can control the P# program schedule, as well as all declared sources of nondeterminism (e.g. failures and timeouts), and systematically explore the actual executable code to discover bugs (e.g. crashes or specification violations). If a bug is found, the P# testing engine will report a deterministic reproducible trace that can be replayed using the Visual Studio Debugger.
 
 ## Getting started
 Read the P# programming guide and then read about various features and topics [here](Docs/README.md).

--- a/Source/Core/IO/Logging/MachineLogger.cs
+++ b/Source/Core/IO/Logging/MachineLogger.cs
@@ -4,7 +4,6 @@
 // ------------------------------------------------------------------------------------------------
 
 using System;
-using System.Linq;
 
 using Microsoft.PSharp.Timers;
 using Microsoft.PSharp.Utilities;

--- a/Source/Core/Runtime/BaseRuntime.cs
+++ b/Source/Core/Runtime/BaseRuntime.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -270,9 +271,8 @@ namespace Microsoft.PSharp.Runtime
         /// method returns only when the machine is initialized and the <see cref="Event"/>
         /// (if any) is handled.
         /// </summary>
-        /// <returns>MachineId</returns>
-        internal abstract Task<MachineId> CreateMachineAndExecute(MachineId mid, Type type, string machineName,
-            Event e, Machine creator, Guid? operationGroupId);
+        internal abstract Task<MachineId> CreateMachineAndExecuteAsync(MachineId mid, Type type, string machineName, Event e,
+            Machine creator, Guid? operationGroupId);
 
         /// <summary>
         /// Sends an asynchronous <see cref="Event"/> to a machine.
@@ -280,11 +280,10 @@ namespace Microsoft.PSharp.Runtime
         internal abstract void SendEvent(MachineId target, Event e, BaseMachine sender, SendOptions options);
 
         /// <summary>
-        /// Sends an asynchronous <see cref="Event"/> to a machine. Returns immediately
-        /// if the target machine was already running. Otherwise blocks until the machine handles
-        /// the event and reaches quiescense again.
+        /// Sends an asynchronous <see cref="Event"/> to a machine. Returns immediately if the target machine was
+        /// already running. Otherwise blocks until the machine handles the event and reaches quiescense again.
         /// </summary>
-        internal abstract Task<bool> SendEventAndExecute(MachineId target, Event e, BaseMachine sender, SendOptions options);
+        internal abstract Task<bool> SendEventAndExecuteAsync(MachineId target, Event e, BaseMachine sender, SendOptions options);
 
         /// <summary>
         /// Creates a new timer that sends a <see cref="TimerElapsedEvent"/> to its owner machine.
@@ -462,17 +461,9 @@ namespace Microsoft.PSharp.Runtime
         }
 
         /// <summary>
-        /// Notifies that a machine is waiting to receive an event of the specified type.
-        /// </summary>
-        internal virtual void NotifyWaitEvent(Machine machine, Type eventType)
-        {
-            // Override to implement the notification.
-        }
-
-        /// <summary>
         /// Notifies that a machine is waiting to receive an event of one of the specified types.
         /// </summary>
-        internal virtual void NotifyWaitEvent(Machine machine, params Type[] eventTypes)
+        internal virtual void NotifyWaitEvent(Machine machine, IEnumerable<Type> eventTypes)
         {
             // Override to implement the notification.
         }
@@ -543,7 +534,7 @@ namespace Microsoft.PSharp.Runtime
         /// <summary>
         /// Sets the operation group id for the specified machine.
         /// </summary>
-        internal void SetOperationGroupIdForMachine(Machine created, BaseMachine sender, Guid? operationGroupId)
+        internal static void SetOperationGroupIdForMachine(Machine created, BaseMachine sender, Guid? operationGroupId)
         {
             if (operationGroupId.HasValue)
             {

--- a/Source/Core/Runtime/EventQueues/EventQueue.cs
+++ b/Source/Core/Runtime/EventQueues/EventQueue.cs
@@ -107,7 +107,7 @@ namespace Microsoft.PSharp.Runtime
 
             if (enqueueStatus is EnqueueStatus.Received)
             {
-                this.Runtime.Logger.OnReceive(this.Machine.Id, this.Machine.CurrentStateName, e.GetType().FullName, wasBlocked: true);
+                this.Runtime.NotifyReceivedEvent(this.Machine, e, info);
                 this.ReceiveCompletionSource.SetResult(e);
                 return enqueueStatus;
             }
@@ -267,11 +267,11 @@ namespace Microsoft.PSharp.Runtime
 
             if (e is null)
             {
-                this.Runtime.Logger.OnWait(this.Machine.Id, this.Machine.CurrentStateName, Array.Empty<Type>());
+                this.Runtime.NotifyWaitEvent(this.Machine, this.EventWaitTypes.Keys);
                 return this.ReceiveCompletionSource.Task;
             }
 
-            this.Runtime.Logger.OnReceive(this.Machine.Id, this.Machine.CurrentStateName, e.GetType().FullName, wasBlocked: false);
+            this.Runtime.NotifyReceivedEventWithoutWaiting(this.Machine, e, null);
             return Task.FromResult(e);
         }
 

--- a/Source/TestingServices/Runtime/EventQueues/MockEventQueue.cs
+++ b/Source/TestingServices/Runtime/EventQueues/MockEventQueue.cs
@@ -104,7 +104,6 @@ namespace Microsoft.PSharp.TestingServices.Runtime
             {
                 this.EventWaitTypes.Clear();
                 this.Machine.Info.IsWaitingToReceive = false;
-                this.Runtime.Logger.OnReceive(this.Machine.Id, this.Machine.CurrentStateName, info.EventName, wasBlocked: true);
                 this.Runtime.NotifyReceivedEvent(this.Machine, e, info);
                 this.ReceiveCompletionSource.SetResult(e);
                 return EnqueueStatus.EventHandlerRunning;
@@ -340,23 +339,10 @@ namespace Microsoft.PSharp.TestingServices.Runtime
                 this.ReceiveCompletionSource = new TaskCompletionSource<Event>();
                 this.EventWaitTypes = eventWaitTypes;
                 this.Machine.Info.IsWaitingToReceive = true;
-
-                var eventWaitTypesArray = this.EventWaitTypes.Keys.ToArray();
-                if (eventWaitTypesArray.Length == 1)
-                {
-                    this.Runtime.Logger.OnWait(this.Machine.Id, this.Machine.CurrentStateName, eventWaitTypesArray[0]);
-                    this.Runtime.NotifyWaitEvent(this.Machine, eventWaitTypesArray[0]);
-                }
-                else
-                {
-                    this.Runtime.Logger.OnWait(this.Machine.Id, this.Machine.CurrentStateName, eventWaitTypesArray);
-                    this.Runtime.NotifyWaitEvent(this.Machine, eventWaitTypesArray);
-                }
-
+                this.Runtime.NotifyWaitEvent(this.Machine, this.EventWaitTypes.Keys);
                 return this.ReceiveCompletionSource.Task;
             }
 
-            this.Runtime.Logger.OnReceive(this.Machine.Id, this.Machine.CurrentStateName, e.GetType().FullName, wasBlocked: false);
             this.Runtime.NotifyReceivedEventWithoutWaiting(this.Machine, e, info);
             return Task.FromResult(e);
         }

--- a/Source/TestingServices/Runtime/Machines/MachineTestKit.cs
+++ b/Source/TestingServices/Runtime/Machines/MachineTestKit.cs
@@ -1,0 +1,255 @@
+﻿// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------------------------------------------
+
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+using Microsoft.PSharp.TestingServices.Runtime;
+
+namespace Microsoft.PSharp.TestingServices
+{
+    /// <summary>
+    /// Provides methods for testing a machine of type <typeparamref name="T"/> in isolation.
+    /// </summary>
+    /// <typeparam name="T">The machine type to test.</typeparam>
+    public sealed class MachineTestKit<T>
+        where T : Machine
+    {
+        /// <summary>
+        /// The machine testing runtime.
+        /// </summary>
+        private readonly MachineTestingRuntime Runtime;
+
+        /// <summary>
+        /// The instance of the machine being tested.
+        /// </summary>
+        public readonly T Machine;
+
+        /// <summary>
+        /// True if the machine has started its execution, else false.
+        /// </summary>
+        private bool IsRunning;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MachineTestKit{T}"/> class.
+        /// </summary>
+        /// <param name="configuration">The runtime configuration to use.</param>
+        public MachineTestKit(Configuration configuration)
+        {
+            configuration = configuration ?? Configuration.Create();
+            this.Runtime = new MachineTestingRuntime(typeof(T), configuration);
+            this.Machine = this.Runtime.Machine as T;
+            this.IsRunning = false;
+            this.Runtime.OnFailure += ex =>
+            {
+                this.Runtime.Logger.WriteLine(ex.ToString());
+            };
+        }
+
+        /// <summary>
+        /// Transitions the machine to its start state, passes the optional specified event
+        /// and invokes its on-entry handler, if there is one available. This method returns
+        /// a task that completes when the machine reaches quiescence (typically when the
+        /// event handler finishes executing because there are not more events to dequeue,
+        /// or when the machine asynchronously waits to receive an event).
+        /// </summary>
+        /// <param name="initialEvent">Optional event used during initialization.</param>
+        /// <returns>Task that represents the asynchronous operation.</returns>
+        public Task StartMachineAsync(Event initialEvent = null)
+        {
+            this.Runtime.Assert(!this.IsRunning,
+                string.Format("Machine '{0}' is already running.", this.Machine.Id));
+            this.IsRunning = true;
+            return this.Runtime.StartAsync(initialEvent);
+        }
+
+        /// <summary>
+        /// Sends an event to the machine and starts its event handler. This method returns
+        /// a task that completes when the machine reaches quiescence (typically when the
+        /// event handler finishes executing because there are not more events to dequeue,
+        /// or when the machine asynchronously waits to receive an event).
+        /// </summary>
+        /// <returns>Task that represents the asynchronous operation.</returns>
+        public Task SendEventAsync(Event e)
+        {
+            this.Runtime.Assert(this.IsRunning,
+                string.Format("Machine '{0}' is not running.", this.Machine.Id));
+            return this.Runtime.SendEventAndExecuteAsync(this.Runtime.Machine.Id, e, null, null);
+        }
+
+        /// <summary>
+        /// Invokes the machine method with the specified name, and passing the specified
+        /// optional parameters. Use this method to invoke private methods of the machine.
+        /// </summary>
+        /// <param name="methodName">The name of the machine method.</param>
+        /// <param name="parameters">The parameters to the method.</param>
+        public object Invoke(string methodName, params object[] parameters)
+        {
+            MethodInfo method = this.GetMethod(methodName, false, null);
+            return method.Invoke(this.Machine, parameters);
+        }
+
+        /// <summary>
+        /// Invokes the machine method with the specified name and parameter types, and passing the
+        /// specified optional parameters. Use this method to invoke private methods of the machine.
+        /// </summary>
+        /// <param name="methodName">The name of the machine method.</param>
+        /// <param name="parameterTypes">The parameter types of the method.</param>
+        /// <param name="parameters">The parameters to the method.</param>
+        public object Invoke(string methodName, Type[] parameterTypes, params object[] parameters)
+        {
+            MethodInfo method = this.GetMethod(methodName, false, parameterTypes);
+            return method.Invoke(this.Machine, parameters);
+        }
+
+        /// <summary>
+        /// Invokes the asynchronous machine method with the specified name, and passing the specified
+        /// optional parameters. Use this method to invoke private methods of the machine.
+        /// </summary>
+        /// <param name="methodName">The name of the machine method.</param>
+        /// <param name="parameters">The parameters to the method.</param>
+        public async Task<object> InvokeAsync(string methodName, params object[] parameters)
+        {
+            MethodInfo method = this.GetMethod(methodName, true, null);
+            var task = (Task)method.Invoke(this.Machine, parameters);
+            await task.ConfigureAwait(false);
+            var resultProperty = task.GetType().GetProperty("Result");
+            return resultProperty.GetValue(task);
+        }
+
+        /// <summary>
+        /// Invokes the asynchronous machine method with the specified name and parameter types, and passing
+        /// the specified optional parameters. Use this method to invoke private methods of the machine.
+        /// </summary>
+        /// <param name="methodName">The name of the machine method.</param>
+        /// <param name="parameterTypes">The parameter types of the method.</param>
+        /// <param name="parameters">The parameters to the method.</param>
+        public async Task<object> InvokeAsync(string methodName, Type[] parameterTypes, params object[] parameters)
+        {
+            MethodInfo method = this.GetMethod(methodName, true, parameterTypes);
+            var task = (Task)method.Invoke(this.Machine, parameters);
+            await task.ConfigureAwait(false);
+            var resultProperty = task.GetType().GetProperty("Result");
+            return resultProperty.GetValue(task);
+        }
+
+        /// <summary>
+        /// Uses reflection to get the machine method with the specified name and parameter types.
+        /// </summary>
+        /// <param name="methodName">The name of the machine method.</param>
+        /// <param name="isAsync">True if the method is async, else false.</param>
+        /// <param name="parameterTypes">The parameter types of the method.</param>
+        private MethodInfo GetMethod(string methodName, bool isAsync, Type[] parameterTypes)
+        {
+            var bindingFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+            MethodInfo method;
+            if (parameterTypes is null)
+            {
+                method = this.Machine.GetType().GetMethod(methodName, bindingFlags);
+            }
+            else
+            {
+                method = this.Machine.GetType().GetMethod(methodName, bindingFlags,
+                    Type.DefaultBinder, parameterTypes, null);
+            }
+
+            this.Runtime.Assert(method != null,
+                string.Format("Unable to invoke method '{0}' in machine '{1}'.",
+                methodName, this.Machine.Id));
+            this.Runtime.Assert(method.GetCustomAttribute(typeof(AsyncStateMachineAttribute)) is null != isAsync,
+                string.Format("Must invoke {0}method '{1}' of machine '{2}' using '{3}'.",
+                isAsync ? string.Empty : "async ", methodName, this.Machine.Id, isAsync ? "Invoke" : "InvokeAsync"));
+
+            return method;
+        }
+
+        /// <summary>
+        /// Asserts if the specified condition holds.
+        /// </summary>
+        public void Assert(bool predicate)
+        {
+            this.Runtime.Assert(predicate);
+        }
+
+        /// <summary>
+        /// Asserts if the specified condition holds.
+        /// </summary>
+        public void Assert(bool predicate, string s, object arg0)
+        {
+            this.Runtime.Assert(predicate, s, arg0);
+        }
+
+        /// <summary>
+        /// Asserts if the specified condition holds.
+        /// </summary>
+        public void Assert(bool predicate, string s, object arg0, object arg1)
+        {
+            this.Runtime.Assert(predicate, s, arg0, arg1);
+        }
+
+        /// <summary>
+        /// Asserts if the specified condition holds.
+        /// </summary>
+        public void Assert(bool predicate, string s, object arg0, object arg1, object arg2)
+        {
+            this.Runtime.Assert(predicate, s, arg0, arg1, arg2);
+        }
+
+        /// <summary>
+        /// Asserts if the specified condition holds.
+        /// </summary>
+        public void Assert(bool predicate, string s, params object[] args)
+        {
+            this.Runtime.Assert(predicate, s, args);
+        }
+
+        /// <summary>
+        /// Asserts that the machine has transitioned to the state with the specified type <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="S">The type of the machine state.</typeparam>
+        public void AssertStateTransition<S>()
+            where S : MachineState
+        {
+            this.AssertStateTransition(typeof(S).FullName);
+        }
+
+        /// <summary>
+        /// Asserts that the machine has transitioned to the state with the specified name
+        /// (either <see cref="Type.FullName"/> or <see cref="MemberInfo.Name"/>).
+        /// </summary>
+        /// <param name="machineStateName">The name of the machine state.</param>
+        public void AssertStateTransition(string machineStateName)
+        {
+            bool predicate = this.Machine.CurrentState.FullName.Equals(machineStateName) ||
+                this.Machine.CurrentState.FullName.Equals(
+                    this.Machine.CurrentState.DeclaringType.FullName + "+" + machineStateName);
+            this.Runtime.Assert(predicate, string.Format("Machine '{0}' is in state '{1}', not in '{2}'.",
+                this.Machine.Id, this.Machine.CurrentState.FullName, machineStateName));
+        }
+
+        /// <summary>
+        /// Asserts that the machine is waiting (or not) to receive an event.
+        /// </summary>
+        public void AssertIsWaitingToReceiveEvent(bool isWaiting)
+        {
+            this.Runtime.Assert(this.Runtime.IsMachineWaitingToReceiveEvent == isWaiting,
+                "Machine '{0}' is {1}waiting to receive an event.",
+                this.Machine.Id, this.Runtime.IsMachineWaitingToReceiveEvent ? string.Empty : "not ");
+        }
+
+        /// <summary>
+        /// Asserts that the machine inbox contains the specified number of events.
+        /// </summary>
+        /// <param name="numEvents">The number of events in the inbox.</param>
+        public void AssertInboxSize(int numEvents)
+        {
+            this.Runtime.Assert(this.Runtime.MachineInbox.Size == numEvents,
+                "Machine '{0}' contains '{1}' events in its inbox.",
+                this.Machine.Id, this.Runtime.MachineInbox.Size);
+        }
+    }
+}

--- a/Source/TestingServices/Runtime/TestingRuntime.cs
+++ b/Source/TestingServices/Runtime/TestingRuntime.cs
@@ -189,7 +189,7 @@ namespace Microsoft.PSharp.TestingServices.Runtime
         /// the machine is initialized and the <see cref="Event"/> (if any) is handled.
         /// </summary>
         public override Task<MachineId> CreateMachineAndExecuteAsync(Type type, Event e = null, Guid? operationGroupId = null) =>
-            this.CreateMachineAndExecute(null, type, null, e, operationGroupId);
+            this.CreateMachineAndExecuteAsync(null, type, null, e, operationGroupId);
 
         /// <summary>
         /// Creates a new machine of the specified <see cref="Type"/> and name, and with
@@ -198,7 +198,7 @@ namespace Microsoft.PSharp.TestingServices.Runtime
         /// machine is initialized and the <see cref="Event"/> (if any) is handled.
         /// </summary>
         public override Task<MachineId> CreateMachineAndExecuteAsync(Type type, string machineName, Event e = null, Guid? operationGroupId = null) =>
-            this.CreateMachineAndExecute(null, type, machineName, e, operationGroupId);
+            this.CreateMachineAndExecuteAsync(null, type, machineName, e, operationGroupId);
 
         /// <summary>
         /// Creates a new machine of the specified <see cref="Type"/>, using the specified
@@ -210,7 +210,7 @@ namespace Microsoft.PSharp.TestingServices.Runtime
         public override Task<MachineId> CreateMachineAndExecuteAsync(MachineId mid, Type type, Event e = null, Guid? operationGroupId = null)
         {
             this.Assert(mid != null, "Cannot create a machine using a null machine id.");
-            return this.CreateMachineAndExecute(mid, type, null, e, operationGroupId);
+            return this.CreateMachineAndExecuteAsync(mid, type, null, e, operationGroupId);
         }
 
         /// <summary>
@@ -220,7 +220,7 @@ namespace Microsoft.PSharp.TestingServices.Runtime
         /// the machine is initialized and the <see cref="Event"/> (if any) is handled.
         /// </summary>
         public override Task<MachineId> CreateMachineAndExecute(Type type, Event e = null, Guid? operationGroupId = null) =>
-            this.CreateMachineAndExecute(null, type, null, e, operationGroupId);
+            this.CreateMachineAndExecuteAsync(null, type, null, e, operationGroupId);
 
         /// <summary>
         /// Creates a new machine of the specified <see cref="Type"/> and name, and with
@@ -229,7 +229,7 @@ namespace Microsoft.PSharp.TestingServices.Runtime
         /// machine is initialized and the <see cref="Event"/> (if any) is handled.
         /// </summary>
         public override Task<MachineId> CreateMachineAndExecute(Type type, string machineName, Event e = null, Guid? operationGroupId = null) =>
-            this.CreateMachineAndExecute(null, type, machineName, e, operationGroupId);
+            this.CreateMachineAndExecuteAsync(null, type, machineName, e, operationGroupId);
 
         /// <summary>
         /// Creates a new machine of the specified <see cref="Type"/>, using the specified
@@ -241,7 +241,7 @@ namespace Microsoft.PSharp.TestingServices.Runtime
         public override Task<MachineId> CreateMachineAndExecute(MachineId mid, Type type, Event e = null, Guid? operationGroupId = null)
         {
             this.Assert(mid != null, "Cannot create a machine using a null machine id.");
-            return this.CreateMachineAndExecute(mid, type, null, e, operationGroupId);
+            return this.CreateMachineAndExecuteAsync(mid, type, null, e, operationGroupId);
         }
 
         /// <summary>
@@ -258,7 +258,7 @@ namespace Microsoft.PSharp.TestingServices.Runtime
         /// event and reaches quiescense again.
         /// </summary>
         public override Task<bool> SendEventAndExecuteAsync(MachineId target, Event e, SendOptions options = null) =>
-            this.SendEventAndExecute(target, e, this.GetCurrentMachine(), options);
+            this.SendEventAndExecuteAsync(target, e, this.GetCurrentMachine(), options);
 
         /// <summary>
         /// Sends an <see cref="Event"/> to a machine. Returns immediately if the target machine was already
@@ -362,7 +362,7 @@ namespace Microsoft.PSharp.TestingServices.Runtime
             this.Scheduler.Schedule(OperationType.Create, OperationTargetType.Schedulable, ulong.MaxValue);
 
             Machine machine = this.CreateMachine(mid, type, machineName, creator);
-            this.SetOperationGroupIdForMachine(machine, creator, operationGroupId);
+            SetOperationGroupIdForMachine(machine, creator, operationGroupId);
 
             this.BugTrace.AddCreateMachineStep(creator, machine.Id, e is null ? null : new EventInfo(e));
             this.RunMachineEventHandler(machine, e, true, null, null);
@@ -376,7 +376,7 @@ namespace Microsoft.PSharp.TestingServices.Runtime
         /// can only be used to access its payload, and cannot be handled. The method returns only
         /// when the machine is initialized and the <see cref="Event"/> (if any) is handled.
         /// </summary>
-        internal Task<MachineId> CreateMachineAndExecute(MachineId mid, Type type, string machineName, Event e = null, Guid? operationGroupId = null)
+        internal Task<MachineId> CreateMachineAndExecuteAsync(MachineId mid, Type type, string machineName, Event e = null, Guid? operationGroupId = null)
         {
             Machine creator = null;
             if (this.TaskMap.ContainsKey((int)Task.CurrentId))
@@ -384,7 +384,7 @@ namespace Microsoft.PSharp.TestingServices.Runtime
                 creator = this.TaskMap[(int)Task.CurrentId];
             }
 
-            return this.CreateMachineAndExecute(mid, type, machineName, e, creator, operationGroupId);
+            return this.CreateMachineAndExecuteAsync(mid, type, machineName, e, creator, operationGroupId);
         }
 
         /// <summary>
@@ -392,7 +392,7 @@ namespace Microsoft.PSharp.TestingServices.Runtime
         /// method returns only when the machine is initialized and the <see cref="Event"/>
         /// (if any) is handled.
         /// </summary>
-        internal override async Task<MachineId> CreateMachineAndExecute(MachineId mid, Type type, string machineName, Event e,
+        internal override async Task<MachineId> CreateMachineAndExecuteAsync(MachineId mid, Type type, string machineName, Event e,
             Machine creator, Guid? operationGroupId)
         {
             this.AssertCorrectCallerMachine(creator, "CreateMachineAndExecute");
@@ -405,7 +405,7 @@ namespace Microsoft.PSharp.TestingServices.Runtime
             this.Scheduler.Schedule(OperationType.Create, OperationTargetType.Schedulable, ulong.MaxValue);
 
             Machine machine = this.CreateMachine(mid, type, machineName, creator);
-            this.SetOperationGroupIdForMachine(machine, creator, operationGroupId);
+            SetOperationGroupIdForMachine(machine, creator, operationGroupId);
 
             this.BugTrace.AddCreateMachineStep(creator, machine.Id, e is null ? null : new EventInfo(e));
             this.RunMachineEventHandler(machine, e, true, creator, null);
@@ -514,7 +514,7 @@ namespace Microsoft.PSharp.TestingServices.Runtime
         /// if the target machine was already running. Otherwise blocks until the machine handles
         /// the event and reaches quiescense again.
         /// </summary>
-        internal override async Task<bool> SendEventAndExecute(MachineId target, Event e, BaseMachine sender, SendOptions options)
+        internal override async Task<bool> SendEventAndExecuteAsync(MachineId target, Event e, BaseMachine sender, SendOptions options)
         {
             this.Assert(sender is Machine,
                 "Only a machine can call 'SendEventAndExecute': avoid calling it directly from the 'Test' method; instead call it through a 'harness' machine.");
@@ -1138,33 +1138,36 @@ namespace Microsoft.PSharp.TestingServices.Runtime
         }
 
         /// <summary>
-        /// Notifies that a machine is waiting to receive an event of the specified type.
-        /// </summary>
-        internal override void NotifyWaitEvent(Machine machine, Type eventType)
-        {
-            (machine.Info as SchedulableInfo).IsEnabled = false;
-
-            this.BugTrace.AddWaitToReceiveStep(machine.Id, machine.CurrentStateName, eventType.FullName);
-            this.Scheduler.Schedule(OperationType.Receive, OperationTargetType.Inbox, machine.Info.Id);
-        }
-
-        /// <summary>
         /// Notifies that a machine is waiting to receive an event of one of the specified types.
         /// </summary>
-        internal override void NotifyWaitEvent(Machine machine, params Type[] eventTypes)
+        internal override void NotifyWaitEvent(Machine machine, IEnumerable<Type> eventTypes)
         {
             (machine.Info as SchedulableInfo).IsEnabled = false;
 
-            string eventNames = string.Empty;
-            if (eventTypes.Length > 0)
+            string eventNames;
+            var eventWaitTypesArray = eventTypes.ToArray();
+            if (eventWaitTypesArray.Length == 1)
             {
-                string[] eventNameArray = new string[eventTypes.Length - 1];
-                for (int i = 0; i < eventTypes.Length - 2; i++)
+                this.Logger.OnWait(machine.Id, machine.CurrentStateName, eventWaitTypesArray[0]);
+                eventNames = eventWaitTypesArray[0].FullName;
+            }
+            else
+            {
+                this.Logger.OnWait(machine.Id, machine.CurrentStateName, eventWaitTypesArray);
+                if (eventWaitTypesArray.Length > 0)
                 {
-                    eventNameArray[i] = eventTypes[i].FullName;
-                }
+                    string[] eventNameArray = new string[eventWaitTypesArray.Length - 1];
+                    for (int i = 0; i < eventWaitTypesArray.Length - 2; i++)
+                    {
+                        eventNameArray[i] = eventWaitTypesArray[i].FullName;
+                    }
 
-                eventNames = string.Join(", ", eventNameArray) + " or " + eventTypes[eventTypes.Length - 1].FullName;
+                    eventNames = string.Join(", ", eventNameArray) + " or " + eventWaitTypesArray[eventWaitTypesArray.Length - 1].FullName;
+                }
+                else
+                {
+                    eventNames = string.Empty;
+                }
             }
 
             this.BugTrace.AddWaitToReceiveStep(machine.Id, machine.CurrentStateName, eventNames);
@@ -1176,6 +1179,7 @@ namespace Microsoft.PSharp.TestingServices.Runtime
         /// </summary>
         internal override void NotifyReceivedEvent(Machine machine, Event e, EventInfo eventInfo)
         {
+            this.Logger.OnReceive(machine.Id, machine.CurrentStateName, e.GetType().FullName, wasBlocked: true);
             this.BugTrace.AddReceivedEventStep(machine.Id, machine.CurrentStateName, eventInfo);
 
             // A subsequent enqueue unblocked the receive action of machine.
@@ -1199,6 +1203,8 @@ namespace Microsoft.PSharp.TestingServices.Runtime
         /// </summary>
         internal override void NotifyReceivedEventWithoutWaiting(Machine machine, Event e, EventInfo eventInfo)
         {
+            this.Logger.OnReceive(machine.Id, machine.CurrentStateName, e.GetType().FullName, wasBlocked: false);
+
             (machine.Info as SchedulableInfo).NextOperationMatchingSendIndex = (ulong)eventInfo.SendStep;
 
             if (this.Configuration.EnableDataRaceDetection)

--- a/Tests/Core.Tests/Core.Tests.csproj
+++ b/Tests/Core.Tests/Core.Tests.csproj
@@ -16,6 +16,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Source\Core\Core.csproj" />
+    <ProjectReference Include="..\..\Source\TestingServices\TestingServices.csproj" />
     <ProjectReference Include="..\Tests.Common\Tests.Common.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/Tests/Core.Tests/Machines/GotoStateTransitionTest.cs
+++ b/Tests/Core.Tests/Machines/GotoStateTransitionTest.cs
@@ -1,0 +1,104 @@
+﻿// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------------------------------------------
+
+using System.Threading.Tasks;
+using Microsoft.PSharp.TestingServices;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.PSharp.Core.Tests
+{
+    public class GotoStateTransitionTest : BaseTest
+    {
+        public GotoStateTransitionTest(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        private class Message : Event
+        {
+        }
+
+        private class M1 : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            private class Init : MachineState
+            {
+            }
+
+            private void InitOnEntry()
+            {
+                this.Goto<Final>();
+            }
+
+            private class Final : MachineState
+            {
+            }
+        }
+
+        private class M2 : Machine
+        {
+            [Start]
+            [OnEventGotoState(typeof(Message), typeof(Final))]
+            private class Init : MachineState
+            {
+            }
+
+            private class Final : MachineState
+            {
+            }
+        }
+
+        private class M3 : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            [OnEventGotoState(typeof(Message), typeof(Final))]
+            private class Init : MachineState
+            {
+            }
+
+            private void InitOnEntry()
+            {
+                this.Raise(new Message());
+            }
+
+            private class Final : MachineState
+            {
+            }
+        }
+
+        [Fact(Timeout = 5000)]
+        public async Task TestGotoStateTransition()
+        {
+            var configuration = GetConfiguration();
+            var test = new MachineTestKit<M1>(configuration: configuration);
+            await test.StartMachineAsync();
+            test.AssertStateTransition("Final");
+        }
+
+        [Fact(Timeout = 5000)]
+        public async Task TestGotoStateTransitionAfterSend()
+        {
+            var configuration = GetConfiguration();
+            var test = new MachineTestKit<M2>(configuration: configuration);
+            await test.StartMachineAsync();
+            test.AssertStateTransition("Init");
+
+            await test.SendEventAsync(new Message());
+            test.AssertStateTransition("Final");
+        }
+
+        [Fact(Timeout = 5000)]
+        public async Task TestGotoStateTransitionAfterRaise()
+        {
+            var configuration = GetConfiguration();
+            var test = new MachineTestKit<M3>(configuration: configuration);
+            await test.StartMachineAsync();
+            test.AssertStateTransition("Final");
+        }
+    }
+}

--- a/Tests/Core.Tests/Machines/HandleEventTest.cs
+++ b/Tests/Core.Tests/Machines/HandleEventTest.cs
@@ -1,0 +1,137 @@
+﻿// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------------------------------------------
+
+using System.Threading.Tasks;
+using Microsoft.PSharp.TestingServices;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.PSharp.Core.Tests
+{
+    public class HandleEventTest : BaseTest
+    {
+        public HandleEventTest(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        private class Result
+        {
+            public int Value = 0;
+        }
+
+        private class SetupEvent : Event
+        {
+            public Result Result;
+
+            public SetupEvent(Result result)
+            {
+                this.Result = result;
+            }
+        }
+
+        private class E1 : Event
+        {
+        }
+
+        private class E2 : Event
+        {
+        }
+
+        private class E3 : Event
+        {
+        }
+
+        private class M1 : Machine
+        {
+            private Result Result;
+
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            [OnEventDoAction(typeof(E1), nameof(HandleE1))]
+            private class Init : MachineState
+            {
+            }
+
+            private void InitOnEntry()
+            {
+                this.Result = (this.ReceivedEvent as SetupEvent).Result;
+            }
+
+            private void HandleE1()
+            {
+                this.Result.Value += 1;
+            }
+        }
+
+        private class M2 : Machine
+        {
+            private Result Result;
+
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            [OnEventDoAction(typeof(E1), nameof(HandleE1))]
+            [OnEventDoAction(typeof(E2), nameof(HandleE2))]
+            [OnEventDoAction(typeof(E3), nameof(HandleE3))]
+            private class Init : MachineState
+            {
+            }
+
+            private void InitOnEntry()
+            {
+                this.Result = (this.ReceivedEvent as SetupEvent).Result;
+            }
+
+            private void HandleE1()
+            {
+                this.Result.Value += 1;
+            }
+
+            private void HandleE2()
+            {
+                this.Result.Value += 2;
+            }
+
+            private void HandleE3()
+            {
+                this.Result.Value += 3;
+            }
+        }
+
+        [Fact(Timeout = 5000)]
+        public async Task TestHandleEvent()
+        {
+            var result = new Result();
+
+            var configuration = GetConfiguration();
+            var test = new MachineTestKit<M1>(configuration: configuration);
+
+            await test.StartMachineAsync(new SetupEvent(result));
+
+            await test.SendEventAsync(new E1());
+
+            test.AssertInboxSize(0);
+            test.Assert(result.Value == 1, $"Incorrect result '{result.Value}'");
+        }
+
+        [Fact(Timeout = 5000)]
+        public async Task TestHandleMultipleEvents()
+        {
+            var result = new Result();
+
+            var configuration = GetConfiguration();
+            var test = new MachineTestKit<M2>(configuration: configuration);
+
+            await test.StartMachineAsync(new SetupEvent(result));
+
+            await test.SendEventAsync(new E1());
+            await test.SendEventAsync(new E2());
+            await test.SendEventAsync(new E3());
+
+            test.AssertInboxSize(0);
+            test.Assert(result.Value == 6, $"Incorrect result '{result.Value}'");
+        }
+    }
+}

--- a/Tests/Core.Tests/Machines/InvokeMethodTest.cs
+++ b/Tests/Core.Tests/Machines/InvokeMethodTest.cs
@@ -1,0 +1,125 @@
+﻿// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.PSharp.TestingServices;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.PSharp.Core.Tests
+{
+    public class InvokeMethodTest : BaseTest
+    {
+        public InvokeMethodTest(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        private class M1 : Machine
+        {
+            [Start]
+            private class Init : MachineState
+            {
+            }
+
+            internal int Add(int m, int k)
+            {
+                return m + k;
+            }
+        }
+
+        [Fact(Timeout = 5000)]
+        public void TestInvokeInternalMethod()
+        {
+            var configuration = GetConfiguration();
+            var test = new MachineTestKit<M1>(configuration: configuration);
+
+            int result = test.Machine.Add(3, 4);
+            test.Assert(result == 7, $"Incorrect result '{result}'");
+        }
+
+        private class M2 : Machine
+        {
+            [Start]
+            private class Init : MachineState
+            {
+            }
+
+            internal async Task<int> AddAsync(int m, int k)
+            {
+                await Task.CompletedTask;
+                return m + k;
+            }
+        }
+
+        [Fact(Timeout = 5000)]
+        public async Task TestInvokeInternalAsyncMethod()
+        {
+            var configuration = GetConfiguration();
+            var test = new MachineTestKit<M2>(configuration: configuration);
+
+            int result = await test.Machine.AddAsync(3, 4);
+            test.Assert(result == 7, $"Incorrect result '{result}'");
+        }
+
+        private class M3 : Machine
+        {
+            [Start]
+            private class Init : MachineState
+            {
+            }
+
+#pragma warning disable IDE0051 // Remove unused private members
+            private int Add(int m, int k)
+            {
+                return m + k;
+            }
+#pragma warning restore IDE0051 // Remove unused private members
+        }
+
+        [Fact(Timeout = 5000)]
+        public void TestInvokePrivateMethod()
+        {
+            var configuration = GetConfiguration();
+            var test = new MachineTestKit<M3>(configuration: configuration);
+
+            int result = (int)test.Invoke("Add", 3, 4);
+            test.Assert(result == 7, $"Incorrect result '{result}'");
+
+            result = (int)test.Invoke("Add", new Type[] { typeof(int), typeof(int) }, 3, 4);
+            test.Assert(result == 7, $"Incorrect result '{result}'");
+        }
+
+        private class M4 : Machine
+        {
+            [Start]
+            private class Init : MachineState
+            {
+            }
+
+#pragma warning disable IDE0051 // Remove unused private members
+            private async Task<int> AddAsync(int m, int k)
+            {
+                await Task.CompletedTask;
+                return m + k;
+            }
+#pragma warning restore IDE0051 // Remove unused private members
+        }
+
+        [Fact(Timeout = 5000)]
+        public async Task TestInvokePrivateAsyncMethod()
+        {
+            var configuration = GetConfiguration();
+            var test = new MachineTestKit<M4>(configuration: configuration);
+
+            int result = (int)await test.InvokeAsync("AddAsync", 3, 4);
+            test.Assert(result == 7, $"Incorrect result '{result}'");
+
+            result = (int)await test.InvokeAsync("AddAsync", new Type[] { typeof(int), typeof(int) }, 3, 4);
+            test.Assert(result == 7, $"Incorrect result '{result}'");
+        }
+    }
+}

--- a/Tests/Core.Tests/Machines/ReceiveEventIntegrationTest.cs
+++ b/Tests/Core.Tests/Machines/ReceiveEventIntegrationTest.cs
@@ -10,9 +10,9 @@ using Xunit.Abstractions;
 
 namespace Microsoft.PSharp.Core.Tests
 {
-    public class ReceiveTest : BaseTest
+    public class ReceiveEventIntegrationTest : BaseTest
     {
-        public ReceiveTest(ITestOutputHelper output)
+        public ReceiveEventIntegrationTest(ITestOutputHelper output)
             : base(output)
         {
         }

--- a/Tests/Core.Tests/Machines/ReceiveEventStressTest.cs
+++ b/Tests/Core.Tests/Machines/ReceiveEventStressTest.cs
@@ -10,9 +10,9 @@ using Xunit.Abstractions;
 
 namespace Microsoft.PSharp.Core.Tests
 {
-    public class ReceiveStressTest : BaseTest
+    public class ReceiveEventStressTest : BaseTest
     {
-        public ReceiveStressTest(ITestOutputHelper output)
+        public ReceiveEventStressTest(ITestOutputHelper output)
             : base(output)
         {
         }
@@ -161,7 +161,7 @@ namespace Microsoft.PSharp.Core.Tests
             {
             }
 
-            private void InitOnEntry()
+            private async Task InitOnEntry()
             {
                 var tcs = (this.ReceivedEvent as SetupTcsEvent).Tcs;
                 var numMessages = (this.ReceivedEvent as SetupTcsEvent).NumMessages;
@@ -173,7 +173,7 @@ namespace Microsoft.PSharp.Core.Tests
                 {
                     counter++;
                     this.Send(mid, new Message());
-                    this.Receive(typeof(Message));
+                    await this.Receive(typeof(Message));
                 }
 
                 tcs.SetResult(true);
@@ -197,17 +197,17 @@ namespace Microsoft.PSharp.Core.Tests
                 while (counter < numMessages)
                 {
                     counter++;
-                    await this.Receive(typeof(Message));
+                    await Task.WhenAny(this.Receive(typeof(Message)), Task.Delay(5000));
                     this.Send(mid, new Message());
                 }
             }
         }
 
         [Fact(Timeout = 15000)]
-        public void StressTestReceiveEvent()
+        public void TestReceiveEvent()
         {
             var configuration = GetConfiguration();
-            for (int i = 0; i < 10; i++)
+            for (int i = 0; i < 100; i++)
             {
                 var test = new Action<IMachineRuntime>((r) =>
                 {
@@ -223,10 +223,10 @@ namespace Microsoft.PSharp.Core.Tests
         }
 
         [Fact(Timeout = 15000)]
-        public void StressTestReceiveEventAlternate()
+        public void TestReceiveEventAlternate()
         {
             var configuration = GetConfiguration();
-            for (int i = 0; i < 10; i++)
+            for (int i = 0; i < 100; i++)
             {
                 var test = new Action<IMachineRuntime>((r) =>
                 {
@@ -242,10 +242,10 @@ namespace Microsoft.PSharp.Core.Tests
         }
 
         [Fact(Timeout = 15000)]
-        public void StressTestReceiveEventExchange()
+        public void TestReceiveEventExchange()
         {
             var configuration = GetConfiguration();
-            for (int i = 0; i < 10; i++)
+            for (int i = 0; i < 100; i++)
             {
                 var test = new Action<IMachineRuntime>((r) =>
                 {

--- a/Tests/Core.Tests/Machines/ReceiveEventTest.cs
+++ b/Tests/Core.Tests/Machines/ReceiveEventTest.cs
@@ -1,0 +1,182 @@
+﻿// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------------------------------------------
+
+using System.Threading.Tasks;
+using Microsoft.PSharp.TestingServices;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.PSharp.Core.Tests
+{
+    public class ReceiveEventTest : BaseTest
+    {
+        public ReceiveEventTest(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        private class E1 : Event
+        {
+        }
+
+        private class E2 : Event
+        {
+        }
+
+        private class E3 : Event
+        {
+        }
+
+        private class M1 : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            private class Init : MachineState
+            {
+            }
+
+            private async Task InitOnEntry()
+            {
+                await this.Receive(typeof(E1));
+            }
+        }
+
+        private class M2 : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            private class Init : MachineState
+            {
+            }
+
+            private async Task InitOnEntry()
+            {
+                await this.Receive(typeof(E1));
+                await this.Receive(typeof(E2));
+                await this.Receive(typeof(E3));
+            }
+        }
+
+        private class M3 : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            private class Init : MachineState
+            {
+            }
+
+            private async Task InitOnEntry()
+            {
+                await this.Receive(typeof(E1), typeof(E2), typeof(E3));
+            }
+        }
+
+        private class M4 : Machine
+        {
+            [Start]
+            [OnEntry(nameof(InitOnEntry))]
+            private class Init : MachineState
+            {
+            }
+
+            private async Task InitOnEntry()
+            {
+                await this.Receive(typeof(E1), typeof(E2), typeof(E3));
+                await this.Receive(typeof(E1), typeof(E2), typeof(E3));
+                await this.Receive(typeof(E1), typeof(E2), typeof(E3));
+            }
+        }
+
+        [Fact(Timeout = 5000)]
+        public async Task TestReceiveEventStatement()
+        {
+            var configuration = GetConfiguration();
+            var test = new MachineTestKit<M1>(configuration: configuration);
+
+            await test.StartMachineAsync();
+            test.AssertIsWaitingToReceiveEvent(true);
+
+            await test.SendEventAsync(new E1());
+            test.AssertIsWaitingToReceiveEvent(false);
+            test.AssertInboxSize(0);
+        }
+
+        [Fact(Timeout = 5000)]
+        public async Task TestMultipleReceiveEventStatements()
+        {
+            var configuration = GetConfiguration();
+            var test = new MachineTestKit<M2>(configuration: configuration);
+
+            await test.StartMachineAsync();
+            test.AssertIsWaitingToReceiveEvent(true);
+
+            await test.SendEventAsync(new E1());
+            test.AssertIsWaitingToReceiveEvent(true);
+
+            await test.SendEventAsync(new E2());
+            test.AssertIsWaitingToReceiveEvent(true);
+
+            await test.SendEventAsync(new E3());
+            test.AssertIsWaitingToReceiveEvent(false);
+            test.AssertInboxSize(0);
+        }
+
+        [Fact(Timeout = 5000)]
+        public async Task TestMultipleReceiveEventStatementsUnordered()
+        {
+            var configuration = GetConfiguration();
+            var test = new MachineTestKit<M2>(configuration: configuration);
+
+            await test.StartMachineAsync();
+            test.AssertIsWaitingToReceiveEvent(true);
+
+            await test.SendEventAsync(new E2());
+            test.AssertIsWaitingToReceiveEvent(true);
+            test.AssertInboxSize(1);
+
+            await test.SendEventAsync(new E3());
+            test.AssertIsWaitingToReceiveEvent(true);
+            test.AssertInboxSize(2);
+
+            await test.SendEventAsync(new E1());
+            test.AssertIsWaitingToReceiveEvent(false);
+            test.AssertInboxSize(0);
+        }
+
+        [Fact(Timeout = 5000)]
+        public async Task TestReceiveEventStatementWithMultipleTypes()
+        {
+            var configuration = GetConfiguration();
+            var test = new MachineTestKit<M3>(configuration: configuration);
+
+            await test.StartMachineAsync();
+            test.AssertIsWaitingToReceiveEvent(true);
+
+            await test.SendEventAsync(new E1());
+            test.AssertIsWaitingToReceiveEvent(false);
+            test.AssertInboxSize(0);
+        }
+
+        [Fact(Timeout = 5000)]
+        public async Task TestMultipleReceiveEventStatementsWithMultipleTypes()
+        {
+            var configuration = GetConfiguration();
+            var test = new MachineTestKit<M4>(configuration: configuration);
+
+            await test.StartMachineAsync();
+            test.AssertIsWaitingToReceiveEvent(true);
+
+            await test.SendEventAsync(new E1());
+            test.AssertIsWaitingToReceiveEvent(true);
+
+            await test.SendEventAsync(new E2());
+            test.AssertIsWaitingToReceiveEvent(true);
+
+            await test.SendEventAsync(new E3());
+            test.AssertIsWaitingToReceiveEvent(false);
+            test.AssertInboxSize(0);
+        }
+    }
+}


### PR DESCRIPTION
Our current testing APIs (i.e. `BugFindingEngine` and P# tester) allows someone to write powerful _integration-tests_, which can serialize a P# program, and systematically test _end-to-end_ a collection of P# machines, as well as the concurrency between machines. However, we do not support a proper way of testing production machines, especially in isolation in a true _unit-testing_ fashion. All our tests under `Core.Tests` today are integration tests for production, where we nondeterministically run machines waiting for a task completion source, to assert that the execution completed

This PR introduces `MachineTestKit`, which allows us (and P# clients) to write true unit-tests, i.e. execute machines sequentially (in relation to the test method), manually send events every time machine reaches quiescence, assert state changes. This new API also allows someone to create and get access to the instance of a machine, which allows direct method invocation. Creating other machines, or sending external events is a no-op operation to provide isolation. Mocks are still required, e.g. if a machine is directly writing to Azure Tables, but this is true even without P#.