### PR TITLE
Coverage reporting with multiple tests

### DIFF
--- a/Source/Core/Runtime/Machines/MachineFactory.cs
+++ b/Source/Core/Runtime/Machines/MachineFactory.cs
@@ -17,7 +17,7 @@ namespace Microsoft.PSharp.Runtime
         /// <summary>
         /// Cache storing machine constructors.
         /// </summary>
-        private static Dictionary<Type, Func<Machine>> MachineConstructorCache =
+        private static readonly Dictionary<Type, Func<Machine>> MachineConstructorCache =
             new Dictionary<Type, Func<Machine>>();
 
         /// <summary>
@@ -37,19 +37,6 @@ namespace Microsoft.PSharp.Runtime
                 }
 
                 return constructor();
-            }
-        }
-
-        /// <summary>
-        /// Checks if the constructor of the specified machine type exists in the cache.
-        /// </summary>
-        /// <param name="type">Type of the machine.</param>
-        /// <returns>True if the constructor exists, else false.</returns>
-        internal static bool IsCached(Type type)
-        {
-            lock (MachineConstructorCache)
-            {
-                return MachineConstructorCache.ContainsKey(type);
             }
         }
     }

--- a/Source/TestingServices/Runtime/SystematicTestingRuntime.cs
+++ b/Source/TestingServices/Runtime/SystematicTestingRuntime.cs
@@ -495,7 +495,6 @@ namespace Microsoft.PSharp.TestingServices.Runtime
                 opGroupId = creator.OperationGroupId;
             }
 
-            var isMachineTypeCached = MachineFactory.IsCached(type);
             Machine machine = MachineFactory.Create(type);
             this.MachineOperations.GetOrAdd(mid.Value, new AsyncOperation(mid));
             IMachineStateManager stateManager = new SerializedMachineStateManager(this, machine, opGroupId);
@@ -504,7 +503,7 @@ namespace Microsoft.PSharp.TestingServices.Runtime
             machine.Initialize(this, mid, stateManager, eventQueue);
             machine.InitializeStateInformation();
 
-            if (this.Configuration.ReportActivityCoverage && !isMachineTypeCached)
+            if (this.Configuration.ReportActivityCoverage)
             {
                 this.ReportActivityCoverageOfMachine(machine);
             }
@@ -1474,10 +1473,13 @@ namespace Microsoft.PSharp.TestingServices.Runtime
         private void ReportActivityCoverageOfMachine(Machine machine)
         {
             var machineName = machine.GetType().FullName;
+            if (this.CoverageInfo.IsMachineDeclared(machineName))
+            {
+                return;
+            }
 
             // Fetch states.
             var states = machine.GetAllStates();
-
             foreach (var state in states)
             {
                 this.CoverageInfo.DeclareMachineState(machineName, state);
@@ -1485,7 +1487,6 @@ namespace Microsoft.PSharp.TestingServices.Runtime
 
             // Fetch registered events.
             var pairs = machine.GetAllStateEventPairs();
-
             foreach (var tup in pairs)
             {
                 this.CoverageInfo.DeclareStateEvent(machineName, tup.Item1, tup.Item2);

--- a/Source/TestingServices/Statistics/Coverage/CoverageInfo.cs
+++ b/Source/TestingServices/Statistics/Coverage/CoverageInfo.cs
@@ -45,13 +45,13 @@ namespace Microsoft.PSharp.TestingServices.Coverage
         }
 
         /// <summary>
+        /// Checks if the machine type has already been registered for coverage.
+        /// </summary>
+        public bool IsMachineDeclared(string machineName) => this.MachinesToStates.ContainsKey(machineName);
+
+        /// <summary>
         /// Adds a new transition.
         /// </summary>
-        /// <param name="machineOrigin">Origin machine</param>
-        /// <param name="stateOrigin">Origin state</param>
-        /// <param name="edgeLabel">Edge label</param>
-        /// <param name="machineTarget">Target machine</param>
-        /// <param name="stateTarget">Target state</param>
         public void AddTransition(string machineOrigin, string stateOrigin, string edgeLabel,
             string machineTarget, string stateTarget)
         {
@@ -64,19 +64,11 @@ namespace Microsoft.PSharp.TestingServices.Coverage
         /// <summary>
         /// Declares a state.
         /// </summary>
-        /// <param name="machine">Machine name</param>
-        /// <param name="state">state name</param>
-        public void DeclareMachineState(string machine, string state)
-        {
-            this.AddState(machine, state);
-        }
+        public void DeclareMachineState(string machine, string state) => this.AddState(machine, state);
 
         /// <summary>
         /// Declares a registered state, event pair.
         /// </summary>
-        /// <param name="machine">Machine name</param>
-        /// <param name="state">state name</param>
-        /// <param name="eventName">Event name that the state is prepared to handle</param>
         public void DeclareStateEvent(string machine, string state, string eventName)
         {
             this.AddState(machine, state);
@@ -87,7 +79,6 @@ namespace Microsoft.PSharp.TestingServices.Coverage
         /// Merges the information from the specified
         /// coverage info. This is not thread-safe.
         /// </summary>
-        /// <param name="coverageInfo">CoverageInfo</param>
         public void Merge(CoverageInfo coverageInfo)
         {
             foreach (var machine in coverageInfo.MachinesToStates)
@@ -113,8 +104,6 @@ namespace Microsoft.PSharp.TestingServices.Coverage
         /// <summary>
         /// Adds a new state.
         /// </summary>
-        /// <param name="machineName">Machine name</param>
-        /// <param name="stateName">State name</param>
         private void AddState(string machineName, string stateName)
         {
             if (!this.MachinesToStates.ContainsKey(machineName))


### PR DESCRIPTION
Fix coverage reporting across multiple invocations of the testing engine. Added a test case to capture future regressions.