### PR TITLE
Removed assert/assume parsing from psharp syntax. 

### DIFF
--- a/Source/LanguageServices/Parsing/Visitors/Syntax/Declarations/EventDeclarationVisitor.cs
+++ b/Source/LanguageServices/Parsing/Visitors/Syntax/Declarations/EventDeclarationVisitor.cs
@@ -59,9 +59,7 @@ namespace Microsoft.PSharp.LanguageServices.Parsing.Syntax
             }
 
             if (this.TokenStream.Done ||
-                (this.TokenStream.Peek().Type != TokenType.Assert &&
-                this.TokenStream.Peek().Type != TokenType.Assume &&
-                this.TokenStream.Peek().Type != TokenType.LeftAngleBracket &&
+                (this.TokenStream.Peek().Type != TokenType.LeftAngleBracket &&
                 this.TokenStream.Peek().Type != TokenType.LeftParenthesis &&
                 this.TokenStream.Peek().Type != TokenType.Colon &&
                 this.TokenStream.Peek().Type != TokenType.Semicolon))
@@ -69,8 +67,6 @@ namespace Microsoft.PSharp.LanguageServices.Parsing.Syntax
                 // TODO: Create an overload of ParsingException ctor that generates the message with a predefined format enum.
                 var expectedTokenTypes = new TokenType[]
                 {
-                    TokenType.Assert,
-                    TokenType.Assume,
                     TokenType.LeftAngleBracket,
                     TokenType.LeftParenthesis,
                     TokenType.Semicolon,
@@ -85,66 +81,13 @@ namespace Microsoft.PSharp.LanguageServices.Parsing.Syntax
             this.VisitBaseEventDeclaration(node, declarations);
 
             if (this.TokenStream.Done ||
-                (this.TokenStream.Peek().Type != TokenType.Assert &&
-                this.TokenStream.Peek().Type != TokenType.Assume &&
-                this.TokenStream.Peek().Type != TokenType.LeftParenthesis &&
+                (this.TokenStream.Peek().Type != TokenType.LeftParenthesis &&
                 this.TokenStream.Peek().Type != TokenType.Semicolon))
             {
                 throw new ParsingException(
                     "Expected \"(\" or \";\".",
-                    TokenType.Assert,
-                    TokenType.Assume,
                     TokenType.LeftParenthesis,
                     TokenType.Semicolon);
-            }
-
-            if (this.TokenStream.Peek().Type == TokenType.Assert ||
-                this.TokenStream.Peek().Type == TokenType.Assume)
-            {
-                if (isExtern)
-                {
-                    throw new ParsingException("\"extern\" cannot have an Assert or Assume specification.");
-                }
-
-                bool isAssert = true;
-                if (this.TokenStream.Peek().Type == TokenType.Assert)
-                {
-                    node.AssertKeyword = this.TokenStream.Peek();
-                }
-                else
-                {
-                    node.AssumeKeyword = this.TokenStream.Peek();
-                    isAssert = false;
-                }
-
-                this.TokenStream.Index++;
-                this.TokenStream.SkipWhiteSpaceAndCommentTokens();
-
-                if (this.TokenStream.Done ||
-                    this.TokenStream.Peek().Type != TokenType.Identifier ||
-                    !int.TryParse(this.TokenStream.Peek().TextUnit.Text, out int value))
-                {
-                    throw new ParsingException("Expected integer.", TokenType.Identifier);
-                }
-
-                if (isAssert)
-                {
-                    node.AssertValue = value;
-                }
-                else
-                {
-                    node.AssumeValue = value;
-                }
-
-                this.TokenStream.Index++;
-                this.TokenStream.SkipWhiteSpaceAndCommentTokens();
-
-                if (this.TokenStream.Done ||
-                    (this.TokenStream.Peek().Type != TokenType.LeftParenthesis &&
-                    this.TokenStream.Peek().Type != TokenType.Semicolon))
-                {
-                    throw new ParsingException("Expected \"(\" or \";\".", TokenType.LeftParenthesis, TokenType.Semicolon);
-                }
             }
 
             if (this.TokenStream.Peek().Type == TokenType.LeftParenthesis)
@@ -263,8 +206,6 @@ namespace Microsoft.PSharp.LanguageServices.Parsing.Syntax
         {
             int genericCount = 0;
             while (!this.TokenStream.Done &&
-                this.TokenStream.Peek().Type != TokenType.Assert &&
-                this.TokenStream.Peek().Type != TokenType.Assume &&
                 this.TokenStream.Peek().Type != TokenType.LeftParenthesis &&
                 this.TokenStream.Peek().Type != TokenType.Semicolon)
             {

--- a/Source/LanguageServices/Syntax/Declarations/EventDeclaration.cs
+++ b/Source/LanguageServices/Syntax/Declarations/EventDeclaration.cs
@@ -64,26 +64,6 @@ namespace Microsoft.PSharp.LanguageServices.Syntax
         internal Token RightParenthesis;
 
         /// <summary>
-        /// The assert keyword.
-        /// </summary>
-        internal Token AssertKeyword;
-
-        /// <summary>
-        /// The assume keyword.
-        /// </summary>
-        internal Token AssumeKeyword;
-
-        /// <summary>
-        /// The assert value.
-        /// </summary>
-        internal int AssertValue;
-
-        /// <summary>
-        /// The assume value.
-        /// </summary>
-        internal int AssumeValue;
-
-        /// <summary>
         /// The semicolon token.
         /// </summary>
         internal Token SemicolonToken;
@@ -221,22 +201,6 @@ namespace Microsoft.PSharp.LanguageServices.Syntax
             text += ")\n";
             text += indent2 + ": base(";
 
-            void addAssertAssumeParams(bool forDerived)
-            {
-                if (this.AssertKeyword != null)
-                {
-                    text += this.AssertValue + ", -1";
-                }
-                else if (this.AssumeKeyword != null)
-                {
-                    text += "-1, " + this.AssumeValue;
-                }
-                else if (forDerived)
-                {
-                    text += "-1, -1";
-                }
-            }
-
             if (allDecls.Length > 1)
             {
                 // We don't pass the most-derived decl's params to the base class
@@ -250,11 +214,6 @@ namespace Microsoft.PSharp.LanguageServices.Syntax
                     }
                 }
             }
-            else
-            {
-                // Assert/Assume are passed as params to ctor overload for classes that derive directly from Event.
-                addAssertAssumeParams(forDerived: false);
-            }
 
             text += ")\n";
             text += indent1 + "{\n";
@@ -263,15 +222,6 @@ namespace Microsoft.PSharp.LanguageServices.Syntax
             {
                 text += indent2 + "this." + this.PayloadIdentifiers[i].TextUnit.Text + " = ";
                 text += this.PayloadIdentifiers[i].TextUnit.Text + ";\n";
-            }
-
-            if (this.BaseClassDecl != null)
-            {
-                // Assert/Assume are passed as to a protected method for classes that don't derive directly from Event.
-                // Override any base-class declaration; if none are specified on the derived class then this will turn it off.
-                text += indent2 + "base.SetCardinalityConstraints(";
-                addAssertAssumeParams(forDerived: true);
-                text += ");\n";
             }
 
             text += indent1 + "}\n";

--- a/Tests/LanguageServices.Tests/Declarations/EventInheritanceTests.cs
+++ b/Tests/LanguageServices.Tests/Declarations/EventInheritanceTests.cs
@@ -37,7 +37,6 @@ namespace Foo
         public E2()
             : base()
         {
-            base.SetCardinalityConstraints(-1, -1);
         }
     }
 
@@ -46,7 +45,6 @@ namespace Foo
         public E2x()
             : base()
         {
-            base.SetCardinalityConstraints(-1, -1);
         }
     }
 }
@@ -88,7 +86,6 @@ namespace Foo
             public E2()
                 : base()
             {
-                base.SetCardinalityConstraints(-1, -1);
             }
         }
 
@@ -97,7 +94,6 @@ namespace Foo
             public E2x()
                 : base()
             {
-                base.SetCardinalityConstraints(-1, -1);
             }
         }
 
@@ -143,7 +139,6 @@ namespace Bar
         public E2()
             : base()
         {
-            base.SetCardinalityConstraints(-1, -1);
         }
     }
 }
@@ -179,7 +174,6 @@ namespace Foo
         public E2()
             : base()
         {
-            base.SetCardinalityConstraints(-1, -1);
         }
     }
 
@@ -188,7 +182,6 @@ namespace Foo
         public E2x()
             : base()
         {
-            base.SetCardinalityConstraints(-1, -1);
         }
     }
 }
@@ -227,7 +220,6 @@ namespace Foo
             : base()
         {
             this.b = b;
-            base.SetCardinalityConstraints(-1, -1);
         }
     }
 
@@ -239,7 +231,6 @@ namespace Foo
             : base()
         {
             this.b = b;
-            base.SetCardinalityConstraints(-1, -1);
         }
     }
 }
@@ -278,7 +269,6 @@ namespace Foo
         public E2(string a)
             : base(a)
         {
-            base.SetCardinalityConstraints(-1, -1);
         }
     }
 
@@ -287,7 +277,6 @@ namespace Foo
         public E2x(string a)
             : base(a)
         {
-            base.SetCardinalityConstraints(-1, -1);
         }
     }
 }
@@ -329,7 +318,6 @@ namespace Foo
             : base(a)
         {
             this.b = b;
-            base.SetCardinalityConstraints(-1, -1);
         }
     }
 
@@ -341,7 +329,6 @@ namespace Foo
             : base(a)
         {
             this.b = b;
-            base.SetCardinalityConstraints(-1, -1);
         }
     }
 }
@@ -389,7 +376,6 @@ namespace Foo
         {
             this.a1 = a1;
             this.b1 = b1;
-            base.SetCardinalityConstraints(-1, -1);
         }
     }
 
@@ -403,7 +389,6 @@ namespace Foo
         {
             this.a2 = a2;
             this.b2 = b2;
-            base.SetCardinalityConstraints(-1, -1);
         }
     }
 
@@ -417,7 +402,6 @@ namespace Foo
         {
             this.a2x = a2x;
             this.b2x = b2x;
-            base.SetCardinalityConstraints(-1, -1);
         }
     }
 }
@@ -467,7 +451,6 @@ namespace Foo
         {
             this.a1 = a1;
             this.b1 = b1;
-            base.SetCardinalityConstraints(-1, -1);
         }
     }
 
@@ -481,7 +464,6 @@ namespace Foo
         {
             this.a2 = a2;
             this.b2 = b2;
-            base.SetCardinalityConstraints(-1, -1);
         }
     }
 
@@ -495,7 +477,6 @@ namespace Foo
         {
             this.a2x = a2x;
             this.b2x = b2x;
-            base.SetCardinalityConstraints(-1, -1);
         }
     }
 }
@@ -503,86 +484,46 @@ namespace Foo
             LanguageTestUtilities.AssertRewritten(expected, test);
         }
 
-        [Fact(Timeout=5000)]
-        public void TestAssumeAssertInheritance()
+        [Fact(Timeout = 5000)]
+        public void TestAssertUnsupported()
         {
             var test = @"
 namespace Foo {
     internal event E1 assert 1;
-    internal event E2: E1 assert 2;
-    internal event E3 assume 3;
-    internal event E4: E3 assume 4;
-    internal event E5 assert 5;
-    internal event E6: E5 assume 6;
-    internal event E7: E6;
 }";
-            var expected = @"
-using Microsoft.PSharp;
-
-namespace Foo
-{
-    internal class E1 : Event
-    {
-        public E1()
-            : base(1, -1)
-        {
+            LanguageTestUtilities.AssertFailedTestLog("Expected one of: \"<\", \"(\", \";\", \":\".", test);
         }
-    }
 
-    internal class E2 : E1
-    {
-        public E2()
-            : base()
+        [Fact(Timeout = 5000)]
+        public void TestAssumeUnsupported()
         {
-            base.SetCardinalityConstraints(2, -1);
+            var test = @"
+namespace Foo {
+    internal event E1 assume 1;
+}";
+            LanguageTestUtilities.AssertFailedTestLog("Expected one of: \"<\", \"(\", \";\", \":\".", test);
         }
-    }
 
-    internal class E3 : Event
-    {
-        public E3()
-            : base(-1, 3)
+        [Fact(Timeout = 5000)]
+        public void TestAssertInheritanceUnsupported()
         {
+            var test = @"
+namespace Foo {
+    internal event E1;
+    internal event E2: E1 assert 1;
+}";
+            LanguageTestUtilities.AssertFailedTestLog("Expected \"(\" or \";\".", test);
         }
-    }
 
-    internal class E4 : E3
-    {
-        public E4()
-            : base()
+        [Fact(Timeout = 5000)]
+        public void TestAssumeInheritanceUnsupported()
         {
-            base.SetCardinalityConstraints(-1, 4);
-        }
-    }
-
-    internal class E5 : Event
-    {
-        public E5()
-            : base(5, -1)
-        {
-        }
-    }
-
-    internal class E6 : E5
-    {
-        public E6()
-            : base()
-        {
-            base.SetCardinalityConstraints(-1, 6);
-        }
-    }
-
-    internal class E7 : E6
-    {
-        public E7()
-            : base()
-        {
-            base.SetCardinalityConstraints(-1, -1);
-        }
-    }
-}
-";
-            LanguageTestUtilities.AssertRewritten(expected, test);
+            var test = @"
+namespace Foo {
+    internal event E1;
+    internal event E2: E1 assume 1;
+}";
+            LanguageTestUtilities.AssertFailedTestLog("Expected \"(\" or \";\".", test);
         }
 
         [Fact(Timeout=5000)]
@@ -639,28 +580,6 @@ namespace Foo {
     internal event E2 : E1;
 }";
             LanguageTestUtilities.AssertFailedTestLog("\"extern\" applies only to events and can have no access modifiers.", test);
-        }
-
-        [Fact(Timeout=5000)]
-        public void TestExternWithAssert()
-        {
-            var test = @"
-namespace Foo {
-    extern event E1 assert 42;
-    internal event E2 : E1;
-}";
-            LanguageTestUtilities.AssertFailedTestLog("\"extern\" cannot have an Assert or Assume specification.", test);
-        }
-
-        [Fact(Timeout=5000)]
-        public void TestExternWithAssume()
-        {
-            var test = @"
-namespace Foo {
-    extern event E1 assume 42;
-    internal event E2 : E1;
-}";
-            LanguageTestUtilities.AssertFailedTestLog("\"extern\" cannot have an Assert or Assume specification.", test);
         }
 
         [Fact(Timeout=5000)]

--- a/Tests/LanguageServices.Tests/Declarations/EventTests.cs
+++ b/Tests/LanguageServices.Tests/Declarations/EventTests.cs
@@ -342,7 +342,7 @@ private event e;
 namespace Foo {
 public event e>;
 }";
-            LanguageTestUtilities.AssertFailedTestLog("Expected one of: \"assert\", \"assume\", \"<\", \"(\", \";\", \":\".", test);
+            LanguageTestUtilities.AssertFailedTestLog("Expected one of: \"<\", \"(\", \";\", \":\".", test);
         }
 
         [Fact(Timeout=5000)]


### PR DESCRIPTION
Also, fixed error with insertion of call to SetCardinalityConstraints in the generated code.