### PR TITLE
brace matching fixes and switch to standard colors

### DIFF
--- a/Samples/Framework/BoundedAsync/Process.cs
+++ b/Samples/Framework/BoundedAsync/Process.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp;
+﻿using Microsoft.PSharp;
 
 namespace BoundedAsync
 {

--- a/Samples/Framework/BoundedAsync/Scheduler.cs
+++ b/Samples/Framework/BoundedAsync/Scheduler.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp;
+﻿using Microsoft.PSharp;
 
 namespace BoundedAsync
 {

--- a/Samples/Framework/BoundedAsync/Test.cs
+++ b/Samples/Framework/BoundedAsync/Test.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp;
 
 namespace BoundedAsync

--- a/Samples/Framework/CacheCoherence/CPU.cs
+++ b/Samples/Framework/CacheCoherence/CPU.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp;
 
 namespace CacheCoherence

--- a/Samples/Framework/CacheCoherence/Client.cs
+++ b/Samples/Framework/CacheCoherence/Client.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp;
+﻿using Microsoft.PSharp;
 
 namespace CacheCoherence
 {

--- a/Samples/Framework/CacheCoherence/Host.cs
+++ b/Samples/Framework/CacheCoherence/Host.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Microsoft.PSharp;
 

--- a/Samples/Framework/CacheCoherence/Test.cs
+++ b/Samples/Framework/CacheCoherence/Test.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp;
 
 namespace CacheCoherence

--- a/Samples/Framework/ChainReplication/ChainReplicationMaster.cs
+++ b/Samples/Framework/ChainReplication/ChainReplicationMaster.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Microsoft.PSharp;
 
 namespace ChainReplication

--- a/Samples/Framework/ChainReplication/ChainReplicationServer.cs
+++ b/Samples/Framework/ChainReplication/ChainReplicationServer.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Microsoft.PSharp;
 
 namespace ChainReplication

--- a/Samples/Framework/ChainReplication/Client.cs
+++ b/Samples/Framework/ChainReplication/Client.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Microsoft.PSharp;
 
 namespace ChainReplication

--- a/Samples/Framework/ChainReplication/Environment.cs
+++ b/Samples/Framework/ChainReplication/Environment.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Microsoft.PSharp;
 
 namespace ChainReplication

--- a/Samples/Framework/ChainReplication/FailureDetector.cs
+++ b/Samples/Framework/ChainReplication/FailureDetector.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Microsoft.PSharp;
 
 namespace ChainReplication

--- a/Samples/Framework/ChainReplication/InvariantMonitor.cs
+++ b/Samples/Framework/ChainReplication/InvariantMonitor.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Microsoft.PSharp;
 
 namespace ChainReplication

--- a/Samples/Framework/ChainReplication/SentLog.cs
+++ b/Samples/Framework/ChainReplication/SentLog.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp;
+﻿using Microsoft.PSharp;
 
 namespace ChainReplication
 {

--- a/Samples/Framework/ChainReplication/ServerResponseSeqMonitor.cs
+++ b/Samples/Framework/ChainReplication/ServerResponseSeqMonitor.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Microsoft.PSharp;
 
 namespace ChainReplication

--- a/Samples/Framework/ChainReplication/Test.cs
+++ b/Samples/Framework/ChainReplication/Test.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp;
 
 namespace ChainReplication

--- a/Samples/Framework/Chord/ChordNode.cs
+++ b/Samples/Framework/Chord/ChordNode.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.PSharp;

--- a/Samples/Framework/Chord/Client.cs
+++ b/Samples/Framework/Chord/Client.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Microsoft.PSharp;
 
 namespace Chord

--- a/Samples/Framework/Chord/ClusterManager.cs
+++ b/Samples/Framework/Chord/ClusterManager.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Microsoft.PSharp;
 

--- a/Samples/Framework/Chord/Finger.cs
+++ b/Samples/Framework/Chord/Finger.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp;
+﻿using Microsoft.PSharp;
 
 namespace Chord
 {

--- a/Samples/Framework/Chord/LivenessMonitor.cs
+++ b/Samples/Framework/Chord/LivenessMonitor.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp;
+﻿using Microsoft.PSharp;
 
 namespace Chord
 {

--- a/Samples/Framework/Chord/Test.cs
+++ b/Samples/Framework/Chord/Test.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp;
 
 namespace Chord

--- a/Samples/Framework/FailureDetector/Driver.cs
+++ b/Samples/Framework/FailureDetector/Driver.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Microsoft.PSharp;
 

--- a/Samples/Framework/FailureDetector/FailureDetector.cs
+++ b/Samples/Framework/FailureDetector/FailureDetector.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Microsoft.PSharp;
 
 namespace FailureDetector

--- a/Samples/Framework/FailureDetector/Liveness.cs
+++ b/Samples/Framework/FailureDetector/Liveness.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Microsoft.PSharp;
 

--- a/Samples/Framework/FailureDetector/Node.cs
+++ b/Samples/Framework/FailureDetector/Node.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Microsoft.PSharp;
 

--- a/Samples/Framework/FailureDetector/Safety.cs
+++ b/Samples/Framework/FailureDetector/Safety.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Microsoft.PSharp;
 

--- a/Samples/Framework/FailureDetector/Test.cs
+++ b/Samples/Framework/FailureDetector/Test.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp;
 
 namespace FailureDetector

--- a/Samples/Framework/FailureDetector/Timer.cs
+++ b/Samples/Framework/FailureDetector/Timer.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp;
+﻿using Microsoft.PSharp;
 
 namespace FailureDetector
 {

--- a/Samples/Framework/MultiPaxos/BasicPaxosInvariant_P2b.cs
+++ b/Samples/Framework/MultiPaxos/BasicPaxosInvariant_P2b.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Microsoft.PSharp;
 

--- a/Samples/Framework/MultiPaxos/Client.cs
+++ b/Samples/Framework/MultiPaxos/Client.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Microsoft.PSharp;
 

--- a/Samples/Framework/MultiPaxos/Events.cs
+++ b/Samples/Framework/MultiPaxos/Events.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp;
+﻿using Microsoft.PSharp;
 
 namespace MultiPaxos
 {

--- a/Samples/Framework/MultiPaxos/GodMachine.cs
+++ b/Samples/Framework/MultiPaxos/GodMachine.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Microsoft.PSharp;
 

--- a/Samples/Framework/MultiPaxos/LeaderElection.cs
+++ b/Samples/Framework/MultiPaxos/LeaderElection.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Microsoft.PSharp;
 

--- a/Samples/Framework/MultiPaxos/PaxosNode.cs
+++ b/Samples/Framework/MultiPaxos/PaxosNode.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Microsoft.PSharp;
 

--- a/Samples/Framework/MultiPaxos/Test.cs
+++ b/Samples/Framework/MultiPaxos/Test.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp;
 
 namespace MultiPaxos

--- a/Samples/Framework/MultiPaxos/Timer.cs
+++ b/Samples/Framework/MultiPaxos/Timer.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Microsoft.PSharp;
 

--- a/Samples/Framework/MultiPaxos/ValidityCheck.cs
+++ b/Samples/Framework/MultiPaxos/ValidityCheck.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Microsoft.PSharp;
 

--- a/Samples/Framework/PingPong.AsyncAwait/Client.cs
+++ b/Samples/Framework/PingPong.AsyncAwait/Client.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Microsoft.PSharp;
 

--- a/Samples/Framework/PingPong.AsyncAwait/NetworkEnvironment.cs
+++ b/Samples/Framework/PingPong.AsyncAwait/NetworkEnvironment.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp;
+﻿using Microsoft.PSharp;
 
 namespace PingPong.AsyncAwait
 {

--- a/Samples/Framework/PingPong.AsyncAwait/Server.cs
+++ b/Samples/Framework/PingPong.AsyncAwait/Server.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp;
+﻿using Microsoft.PSharp;
 
 namespace PingPong.AsyncAwait
 {

--- a/Samples/Framework/PingPong.AsyncAwait/Test.cs
+++ b/Samples/Framework/PingPong.AsyncAwait/Test.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp;
 
 namespace PingPong.AsyncAwait

--- a/Samples/Framework/PingPong/Client.cs
+++ b/Samples/Framework/PingPong/Client.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp;
+﻿using Microsoft.PSharp;
 
 namespace PingPong
 {

--- a/Samples/Framework/PingPong/NetworkEnvironment.cs
+++ b/Samples/Framework/PingPong/NetworkEnvironment.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp;
+﻿using Microsoft.PSharp;
 
 namespace PingPong
 {

--- a/Samples/Framework/PingPong/Server.cs
+++ b/Samples/Framework/PingPong/Server.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp;
+﻿using Microsoft.PSharp;
 
 namespace PingPong
 {

--- a/Samples/Framework/PingPong/Test.cs
+++ b/Samples/Framework/PingPong/Test.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp;
 
 namespace PingPong

--- a/Samples/Framework/Raft/Client.cs
+++ b/Samples/Framework/Raft/Client.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Microsoft.PSharp;
 

--- a/Samples/Framework/Raft/ClusterManager.cs
+++ b/Samples/Framework/Raft/ClusterManager.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Microsoft.PSharp;
 

--- a/Samples/Framework/Raft/Log.cs
+++ b/Samples/Framework/Raft/Log.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Raft
+﻿namespace Raft
 {
     internal class Log
     {

--- a/Samples/Framework/Raft/SafetyMonitor.cs
+++ b/Samples/Framework/Raft/SafetyMonitor.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Microsoft.PSharp;
 

--- a/Samples/Framework/Raft/Server.cs
+++ b/Samples/Framework/Raft/Server.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Microsoft.PSharp;
 

--- a/Samples/Framework/Raft/Test.cs
+++ b/Samples/Framework/Raft/Test.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp;
 
 namespace Raft

--- a/Samples/Framework/Raft/Timers/ElectionTimer.cs
+++ b/Samples/Framework/Raft/Timers/ElectionTimer.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Microsoft.PSharp;
 

--- a/Samples/Framework/Raft/Timers/PeriodicTimer.cs
+++ b/Samples/Framework/Raft/Timers/PeriodicTimer.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Microsoft.PSharp;
 

--- a/Samples/Framework/ReplicatingStorage/Client.cs
+++ b/Samples/Framework/ReplicatingStorage/Client.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp;
 
 namespace ReplicatingStorage

--- a/Samples/Framework/ReplicatingStorage/Environment.cs
+++ b/Samples/Framework/ReplicatingStorage/Environment.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Microsoft.PSharp;
 

--- a/Samples/Framework/ReplicatingStorage/LivenessMonitor.cs
+++ b/Samples/Framework/ReplicatingStorage/LivenessMonitor.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Microsoft.PSharp;
 

--- a/Samples/Framework/ReplicatingStorage/NodeManager.cs
+++ b/Samples/Framework/ReplicatingStorage/NodeManager.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.PSharp;

--- a/Samples/Framework/ReplicatingStorage/StorageNode.cs
+++ b/Samples/Framework/ReplicatingStorage/StorageNode.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp;
 
 namespace ReplicatingStorage

--- a/Samples/Framework/ReplicatingStorage/Test.cs
+++ b/Samples/Framework/ReplicatingStorage/Test.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp;
 
 namespace ReplicatingStorage

--- a/Samples/Framework/ReplicatingStorage/Timers/FailureTimer.cs
+++ b/Samples/Framework/ReplicatingStorage/Timers/FailureTimer.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp;
 
 namespace ReplicatingStorage

--- a/Samples/Framework/ReplicatingStorage/Timers/RepairTimer.cs
+++ b/Samples/Framework/ReplicatingStorage/Timers/RepairTimer.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp;
 
 namespace ReplicatingStorage

--- a/Samples/Framework/ReplicatingStorage/Timers/SyncTimer.cs
+++ b/Samples/Framework/ReplicatingStorage/Timers/SyncTimer.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp;
 
 namespace ReplicatingStorage

--- a/Samples/Framework/SendAndReceive/GenericSendAndReceiveMachine.cs
+++ b/Samples/Framework/SendAndReceive/GenericSendAndReceiveMachine.cs
@@ -1,8 +1,3 @@
-// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Samples/Framework/SendAndReceive/Test.cs
+++ b/Samples/Framework/SendAndReceive/Test.cs
@@ -1,8 +1,3 @@
-// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
 using System;
 using System.Threading.Tasks;
 

--- a/Samples/Framework/Timers/Client.cs
+++ b/Samples/Framework/Timers/Client.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 using Microsoft.PSharp;
 using Microsoft.PSharp.Timers;

--- a/Samples/Framework/Timers/Test.cs
+++ b/Samples/Framework/Timers/Test.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp;
 
 namespace Timers

--- a/Samples/Framework/TwoPhaseCommit/Client.cs
+++ b/Samples/Framework/TwoPhaseCommit/Client.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp;
+﻿using Microsoft.PSharp;
 
 namespace TwoPhaseCommit
 {

--- a/Samples/Framework/TwoPhaseCommit/Coordinator.cs
+++ b/Samples/Framework/TwoPhaseCommit/Coordinator.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Microsoft.PSharp;
 
 namespace TwoPhaseCommit

--- a/Samples/Framework/TwoPhaseCommit/PendingWriteRequest.cs
+++ b/Samples/Framework/TwoPhaseCommit/PendingWriteRequest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp;
+﻿using Microsoft.PSharp;
 
 namespace TwoPhaseCommit
 {

--- a/Samples/Framework/TwoPhaseCommit/Replica.cs
+++ b/Samples/Framework/TwoPhaseCommit/Replica.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Microsoft.PSharp;
 
 namespace TwoPhaseCommit

--- a/Samples/Framework/TwoPhaseCommit/SafetyMonitor.cs
+++ b/Samples/Framework/TwoPhaseCommit/SafetyMonitor.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Microsoft.PSharp;
 
 namespace TwoPhaseCommit

--- a/Samples/Framework/TwoPhaseCommit/Test.cs
+++ b/Samples/Framework/TwoPhaseCommit/Test.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp;
 
 namespace TwoPhaseCommit

--- a/Samples/Framework/TwoPhaseCommit/Timer.cs
+++ b/Samples/Framework/TwoPhaseCommit/Timer.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp;
+﻿using Microsoft.PSharp;
 
 namespace TwoPhaseCommit
 {

--- a/Samples/Framework/TwoPhaseCommit/TwoPhaseCommit.cs
+++ b/Samples/Framework/TwoPhaseCommit/TwoPhaseCommit.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp;
+﻿using Microsoft.PSharp;
 
 namespace TwoPhaseCommit
 {

--- a/Samples/Language/BoundedAsync/Process.psharp
+++ b/Samples/Language/BoundedAsync/Process.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 namespace BoundedAsync
 {

--- a/Samples/Language/BoundedAsync/Scheduler.psharp
+++ b/Samples/Language/BoundedAsync/Scheduler.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace BoundedAsync
 {

--- a/Samples/Language/BoundedAsync/Test.cs
+++ b/Samples/Language/BoundedAsync/Test.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp;
 
 namespace BoundedAsync

--- a/Samples/Language/CacheCoherence/CPU.psharp
+++ b/Samples/Language/CacheCoherence/CPU.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 namespace CacheCoherence
 {

--- a/Samples/Language/CacheCoherence/Client.psharp
+++ b/Samples/Language/CacheCoherence/Client.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace CacheCoherence
+﻿namespace CacheCoherence
 {
     internal machine Client
     {

--- a/Samples/Language/CacheCoherence/Events.psharp
+++ b/Samples/Language/CacheCoherence/Events.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace CacheCoherence

--- a/Samples/Language/CacheCoherence/Host.psharp
+++ b/Samples/Language/CacheCoherence/Host.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace CacheCoherence

--- a/Samples/Language/CacheCoherence/Test.cs
+++ b/Samples/Language/CacheCoherence/Test.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp;
 
 namespace CacheCoherence

--- a/Samples/Language/FailureDetector/Driver.psharp
+++ b/Samples/Language/FailureDetector/Driver.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace FailureDetector
 {

--- a/Samples/Language/FailureDetector/FailureDetector.psharp
+++ b/Samples/Language/FailureDetector/FailureDetector.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace FailureDetector
 {

--- a/Samples/Language/FailureDetector/Liveness.psharp
+++ b/Samples/Language/FailureDetector/Liveness.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace FailureDetector
 {

--- a/Samples/Language/FailureDetector/Node.psharp
+++ b/Samples/Language/FailureDetector/Node.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace FailureDetector
+﻿namespace FailureDetector
 {
 	/// <summary>
     /// Implementation of a simple node.

--- a/Samples/Language/FailureDetector/Safety.psharp
+++ b/Samples/Language/FailureDetector/Safety.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace FailureDetector
 {

--- a/Samples/Language/FailureDetector/Test.cs
+++ b/Samples/Language/FailureDetector/Test.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp;
 
 namespace FailureDetector

--- a/Samples/Language/FailureDetector/Timer.psharp
+++ b/Samples/Language/FailureDetector/Timer.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace FailureDetector
+﻿namespace FailureDetector
 {
 	/// <summary>
     /// This P# machine models the operating system timer.

--- a/Samples/Language/MultiPaxos/Client.psharp
+++ b/Samples/Language/MultiPaxos/Client.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace MultiPaxos
 {

--- a/Samples/Language/MultiPaxos/Events.psharp
+++ b/Samples/Language/MultiPaxos/Events.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace MultiPaxos

--- a/Samples/Language/MultiPaxos/GodMachine.psharp
+++ b/Samples/Language/MultiPaxos/GodMachine.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace MultiPaxos
 {

--- a/Samples/Language/MultiPaxos/LeaderElection.psharp
+++ b/Samples/Language/MultiPaxos/LeaderElection.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace MultiPaxos
 {

--- a/Samples/Language/MultiPaxos/PaxosNode.psharp
+++ b/Samples/Language/MultiPaxos/PaxosNode.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace MultiPaxos

--- a/Samples/Language/MultiPaxos/Test.cs
+++ b/Samples/Language/MultiPaxos/Test.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp;
 
 namespace MultiPaxos

--- a/Samples/Language/MultiPaxos/Timer.psharp
+++ b/Samples/Language/MultiPaxos/Timer.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace MultiPaxos
+﻿namespace MultiPaxos
 {
     machine Timer
     {

--- a/Samples/Language/MultiPaxos/ValidityCheck.psharp
+++ b/Samples/Language/MultiPaxos/ValidityCheck.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace MultiPaxos
 {

--- a/Samples/Language/PingPong.AsyncAwait/Client.psharp
+++ b/Samples/Language/PingPong.AsyncAwait/Client.psharp
@@ -1,8 +1,3 @@
-// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
 using System;
 using System.Threading.Tasks;
 

--- a/Samples/Language/PingPong.AsyncAwait/NetworkEnvironment.psharp
+++ b/Samples/Language/PingPong.AsyncAwait/NetworkEnvironment.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace PingPong.AsyncAwait
+﻿namespace PingPong.AsyncAwait
 {
     /// <summary>
     /// This machine acts as a test harness. It models a network environment,

--- a/Samples/Language/PingPong.AsyncAwait/Server.psharp
+++ b/Samples/Language/PingPong.AsyncAwait/Server.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Threading.Tasks;
 
 namespace PingPong.AsyncAwait

--- a/Samples/Language/PingPong.AsyncAwait/Test.cs
+++ b/Samples/Language/PingPong.AsyncAwait/Test.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp;
 
 namespace PingPong.AsyncAwait

--- a/Samples/Language/PingPong.CustomLogging/Client.psharp
+++ b/Samples/Language/PingPong.CustomLogging/Client.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace PingPong.CustomLogging
+﻿namespace PingPong.CustomLogging
 {
     internal machine Client
     {

--- a/Samples/Language/PingPong.CustomLogging/NetworkEnvironment.psharp
+++ b/Samples/Language/PingPong.CustomLogging/NetworkEnvironment.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace PingPong.CustomLogging
+﻿namespace PingPong.CustomLogging
 {
     internal machine NetworkEnvironment
     {

--- a/Samples/Language/PingPong.CustomLogging/Server.psharp
+++ b/Samples/Language/PingPong.CustomLogging/Server.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace PingPong.CustomLogging
+﻿namespace PingPong.CustomLogging
 {
     internal machine Server
     {

--- a/Samples/Language/PingPong.CustomLogging/Test.cs
+++ b/Samples/Language/PingPong.CustomLogging/Test.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp;
 using Microsoft.PSharp.IO;
 

--- a/Samples/Language/PingPong.MixedMode/Client.cs
+++ b/Samples/Language/PingPong.MixedMode/Client.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp;
+﻿using Microsoft.PSharp;
 
 namespace PingPong.MixedMode
 {

--- a/Samples/Language/PingPong.MixedMode/Client.psharp
+++ b/Samples/Language/PingPong.MixedMode/Client.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 namespace PingPong.MixedMode
 {

--- a/Samples/Language/PingPong.MixedMode/NetworkEnvironment.psharp
+++ b/Samples/Language/PingPong.MixedMode/NetworkEnvironment.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace PingPong.MixedMode
+﻿namespace PingPong.MixedMode
 {
     internal machine NetworkEnvironment
     {

--- a/Samples/Language/PingPong.MixedMode/Server.cs
+++ b/Samples/Language/PingPong.MixedMode/Server.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp;
+﻿using Microsoft.PSharp;
 
 namespace PingPong.MixedMode
 {

--- a/Samples/Language/PingPong.MixedMode/Server.psharp
+++ b/Samples/Language/PingPong.MixedMode/Server.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace PingPong.MixedMode
+﻿namespace PingPong.MixedMode
 {
     /// <summary>
     /// We use the partial keyword to declare the high-level state-machine

--- a/Samples/Language/PingPong.MixedMode/Test.cs
+++ b/Samples/Language/PingPong.MixedMode/Test.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp;
 
 namespace PingPong.MixedMode

--- a/Samples/Language/PingPong/Client.psharp
+++ b/Samples/Language/PingPong/Client.psharp
@@ -1,8 +1,3 @@
-// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
 namespace PingPong
 {
     /// <summary>

--- a/Samples/Language/PingPong/NetworkEnvironment.psharp
+++ b/Samples/Language/PingPong/NetworkEnvironment.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace PingPong
+﻿namespace PingPong
 {
     /// <summary>
     /// This machine acts as a test harness. It models a network environment,

--- a/Samples/Language/PingPong/Server.psharp
+++ b/Samples/Language/PingPong/Server.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace PingPong
+﻿namespace PingPong
 {
     /// <summary>
     /// A P# machine that models a simple server.

--- a/Samples/Language/PingPong/Test.cs
+++ b/Samples/Language/PingPong/Test.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp;
 
 namespace PingPong

--- a/Samples/Language/Raft/Client.psharp
+++ b/Samples/Language/Raft/Client.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/Samples/Language/Raft/ClusterManager.psharp
+++ b/Samples/Language/Raft/ClusterManager.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/Samples/Language/Raft/Events.psharp
+++ b/Samples/Language/Raft/Events.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/Samples/Language/Raft/Log.cs
+++ b/Samples/Language/Raft/Log.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Raft
+﻿namespace Raft
 {
     public class Log
     {

--- a/Samples/Language/Raft/SafetyMonitor.psharp
+++ b/Samples/Language/Raft/SafetyMonitor.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/Samples/Language/Raft/Server.psharp
+++ b/Samples/Language/Raft/Server.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/Samples/Language/Raft/Test.cs
+++ b/Samples/Language/Raft/Test.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp;
 
 namespace Raft

--- a/Samples/Language/Raft/Timers/ElectionTimer.psharp
+++ b/Samples/Language/Raft/Timers/ElectionTimer.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/Samples/Language/Raft/Timers/PeriodicTimer.psharp
+++ b/Samples/Language/Raft/Timers/PeriodicTimer.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/Samples/Language/ReplicatingStorage/Client.psharp
+++ b/Samples/Language/ReplicatingStorage/Client.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 namespace ReplicatingStorage
 {

--- a/Samples/Language/ReplicatingStorage/Environment.psharp
+++ b/Samples/Language/ReplicatingStorage/Environment.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace ReplicatingStorage

--- a/Samples/Language/ReplicatingStorage/Events.psharp
+++ b/Samples/Language/ReplicatingStorage/Events.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace ReplicatingStorage
+﻿namespace ReplicatingStorage
 {
 	#region events
 

--- a/Samples/Language/ReplicatingStorage/LivenessMonitor.psharp
+++ b/Samples/Language/ReplicatingStorage/LivenessMonitor.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 namespace ReplicatingStorage

--- a/Samples/Language/ReplicatingStorage/NodeManager.psharp
+++ b/Samples/Language/ReplicatingStorage/NodeManager.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Samples/Language/ReplicatingStorage/StorageNode.psharp
+++ b/Samples/Language/ReplicatingStorage/StorageNode.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 namespace ReplicatingStorage
 {

--- a/Samples/Language/ReplicatingStorage/Test.cs
+++ b/Samples/Language/ReplicatingStorage/Test.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp;
 
 namespace ReplicatingStorage

--- a/Samples/Language/ReplicatingStorage/Timers/FailureTimer.psharp
+++ b/Samples/Language/ReplicatingStorage/Timers/FailureTimer.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 namespace ReplicatingStorage
 {

--- a/Samples/Language/ReplicatingStorage/Timers/RepairTimer.psharp
+++ b/Samples/Language/ReplicatingStorage/Timers/RepairTimer.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 namespace ReplicatingStorage
 {

--- a/Samples/Language/ReplicatingStorage/Timers/SyncTimer.psharp
+++ b/Samples/Language/ReplicatingStorage/Timers/SyncTimer.psharp
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 namespace ReplicatingStorage
 {

--- a/Source/AddOns/DynamicRaceDetection/RaceDetector/Program.cs
+++ b/Source/AddOns/DynamicRaceDetection/RaceDetector/Program.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.IO;
+﻿using Microsoft.PSharp.IO;
 using Microsoft.PSharp.Utilities;
 using System;
 using System.IO;

--- a/Source/AddOns/DynamicRaceDetection/RaceDetector/Properties/AssemblyInfo.cs
+++ b/Source/AddOns/DynamicRaceDetection/RaceDetector/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("PSharpRaceDetector")]
-[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyCopyright("Copyright © Microsoft Corporation. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Source/AddOns/DynamicRaceDetection/RaceDetector/RaceDetectionProcess.cs
+++ b/Source/AddOns/DynamicRaceDetection/RaceDetector/RaceDetectionProcess.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.ExtendedReflection.Monitoring;
+﻿using Microsoft.ExtendedReflection.Monitoring;
 using System;
 using System.Collections.Specialized;
 using System.Diagnostics;

--- a/Source/AddOns/DynamicRaceDetection/RaceDetector/Utilities/RaceDetectorCommandLineOptions.cs
+++ b/Source/AddOns/DynamicRaceDetection/RaceDetector/Utilities/RaceDetectorCommandLineOptions.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.IO;
+﻿using Microsoft.PSharp.IO;
 
 namespace Microsoft.PSharp.Utilities
 {

--- a/Source/AddOns/DynamicRaceDetection/ThreadMonitor/Engines/RaceInstrumentationEngine.cs
+++ b/Source/AddOns/DynamicRaceDetection/ThreadMonitor/Engines/RaceInstrumentationEngine.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 using Microsoft.ExtendedReflection.Monitoring;
 using Microsoft.ExtendedReflection.Symbols;

--- a/Source/AddOns/DynamicRaceDetection/ThreadMonitor/Engines/RemoteRaceInstrumentationEngine.cs
+++ b/Source/AddOns/DynamicRaceDetection/ThreadMonitor/Engines/RemoteRaceInstrumentationEngine.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.ExtendedReflection.Collections;
+﻿using Microsoft.ExtendedReflection.Collections;
 using Microsoft.PSharp.IO;
 using Microsoft.PSharp.TestingServices;
 using System;

--- a/Source/AddOns/DynamicRaceDetection/ThreadMonitor/Library/ComponentBase.cs
+++ b/Source/AddOns/DynamicRaceDetection/ThreadMonitor/Library/ComponentBase.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.ExtendedReflection.ComponentModel;
+﻿using Microsoft.ExtendedReflection.ComponentModel;
 
 namespace Microsoft.PSharp.Monitoring.ComponentModel
 {

--- a/Source/AddOns/DynamicRaceDetection/ThreadMonitor/Library/ComponentService.cs
+++ b/Source/AddOns/DynamicRaceDetection/ThreadMonitor/Library/ComponentService.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.ExtendedReflection.ComponentModel;
+﻿using Microsoft.ExtendedReflection.ComponentModel;
 
 namespace Microsoft.PSharp.Monitoring.ComponentModel
 {

--- a/Source/AddOns/DynamicRaceDetection/ThreadMonitor/Library/IComponent.cs
+++ b/Source/AddOns/DynamicRaceDetection/ThreadMonitor/Library/IComponent.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.ExtendedReflection.ComponentModel;
+﻿using Microsoft.ExtendedReflection.ComponentModel;
 
 namespace Microsoft.PSharp.Monitoring.ComponentModel
 {

--- a/Source/AddOns/DynamicRaceDetection/ThreadMonitor/Library/IComponentServices.cs
+++ b/Source/AddOns/DynamicRaceDetection/ThreadMonitor/Library/IComponentServices.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.ExtendedReflection.ComponentModel;
+﻿using Microsoft.ExtendedReflection.ComponentModel;
 
 namespace Microsoft.PSharp.Monitoring.ComponentModel
 {

--- a/Source/AddOns/DynamicRaceDetection/ThreadMonitor/Monitoring/IMonitorManager.cs
+++ b/Source/AddOns/DynamicRaceDetection/ThreadMonitor/Monitoring/IMonitorManager.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.ExtendedReflection.Monitoring;
+﻿using Microsoft.ExtendedReflection.Monitoring;
 using Microsoft.ExtendedReflection.ComponentModel;
 
 using Microsoft.PSharp.Monitoring.CallsOnly;

--- a/Source/AddOns/DynamicRaceDetection/ThreadMonitor/Monitoring/MonitorManager.cs
+++ b/Source/AddOns/DynamicRaceDetection/ThreadMonitor/Monitoring/MonitorManager.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 using Microsoft.ExtendedReflection.Monitoring;
 using Microsoft.ExtendedReflection.Utilities.Safe.Diagnostics;

--- a/Source/AddOns/DynamicRaceDetection/ThreadMonitor/Monitoring/Objects/ObjectAccessHandler.cs
+++ b/Source/AddOns/DynamicRaceDetection/ThreadMonitor/Monitoring/Objects/ObjectAccessHandler.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 using Microsoft.ExtendedReflection.Monitoring;
 

--- a/Source/AddOns/DynamicRaceDetection/ThreadMonitor/Monitoring/Objects/ObjectAccessThreadMonitor.cs
+++ b/Source/AddOns/DynamicRaceDetection/ThreadMonitor/Monitoring/Objects/ObjectAccessThreadMonitor.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Diagnostics;
 
 using Microsoft.PSharp.Monitoring.ComponentModel;

--- a/Source/AddOns/DynamicRaceDetection/ThreadMonitor/Monitoring/Threads/IThreadMonitor.cs
+++ b/Source/AddOns/DynamicRaceDetection/ThreadMonitor/Monitoring/Threads/IThreadMonitor.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 namespace Microsoft.PSharp.Monitoring.CallsOnly
 {

--- a/Source/AddOns/DynamicRaceDetection/ThreadMonitor/Monitoring/Threads/ThreadExecutionMonitorDispatcher.cs
+++ b/Source/AddOns/DynamicRaceDetection/ThreadMonitor/Monitoring/Threads/ThreadExecutionMonitorDispatcher.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.ExtendedReflection.Collections;
+﻿using Microsoft.ExtendedReflection.Collections;
 using Microsoft.ExtendedReflection.Logging;
 using Microsoft.ExtendedReflection.Metadata;
 using Microsoft.ExtendedReflection.Monitoring;

--- a/Source/AddOns/DynamicRaceDetection/ThreadMonitor/Monitoring/Threads/ThreadMonitorBase.cs
+++ b/Source/AddOns/DynamicRaceDetection/ThreadMonitor/Monitoring/Threads/ThreadMonitorBase.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 using Microsoft.ExtendedReflection.ComponentModel;
 

--- a/Source/AddOns/DynamicRaceDetection/ThreadMonitor/Monitoring/Threads/ThreadMonitorCollection.cs
+++ b/Source/AddOns/DynamicRaceDetection/ThreadMonitor/Monitoring/Threads/ThreadMonitorCollection.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.ExtendedReflection.Collections;
+﻿using Microsoft.ExtendedReflection.Collections;
 
 namespace Microsoft.PSharp.Monitoring.CallsOnly
 {

--- a/Source/AddOns/DynamicRaceDetection/ThreadMonitor/Monitoring/Threads/ThreadMonitorFactory.cs
+++ b/Source/AddOns/DynamicRaceDetection/ThreadMonitor/Monitoring/Threads/ThreadMonitorFactory.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 using Microsoft.ExtendedReflection.Monitoring;
 

--- a/Source/AddOns/DynamicRaceDetection/ThreadMonitor/Monitoring/Threads/ThreadMonitorManager.cs
+++ b/Source/AddOns/DynamicRaceDetection/ThreadMonitor/Monitoring/Threads/ThreadMonitorManager.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 using Microsoft.ExtendedReflection.ComponentModel;
 using Microsoft.ExtendedReflection.Monitoring;

--- a/Source/AddOns/DynamicRaceDetection/ThreadMonitor/Program.cs
+++ b/Source/AddOns/DynamicRaceDetection/ThreadMonitor/Program.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Specialized;
 using System.Linq;
 using System.Reflection;

--- a/Source/AddOns/DynamicRaceDetection/ThreadMonitor/Properties/AssemblyInfo.cs
+++ b/Source/AddOns/DynamicRaceDetection/ThreadMonitor/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("PSharpThreadMonitor")]
-[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyCopyright("Copyright © Microsoft Corporation. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Source/AddOns/DynamicRaceDetection/ThreadMonitor/ThreadMonitorProcess.cs
+++ b/Source/AddOns/DynamicRaceDetection/ThreadMonitor/ThreadMonitorProcess.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.IO;
 using System.Reflection;
 

--- a/Source/AddOns/DynamicRaceDetection/ThreadMonitor/Utilities/ThreadMonitorCommandLineOptions.cs
+++ b/Source/AddOns/DynamicRaceDetection/ThreadMonitor/Utilities/ThreadMonitorCommandLineOptions.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.IO;
+﻿using Microsoft.PSharp.IO;
 using System;
 
 namespace Microsoft.PSharp.Utilities

--- a/Source/Core/Attributes/ColdAttribute.cs
+++ b/Source/Core/Attributes/ColdAttribute.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 namespace Microsoft.PSharp
 {

--- a/Source/Core/Attributes/DeferEventsAttribute.cs
+++ b/Source/Core/Attributes/DeferEventsAttribute.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 namespace Microsoft.PSharp
 {

--- a/Source/Core/Attributes/EntryPointAttribute.cs
+++ b/Source/Core/Attributes/EntryPointAttribute.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 namespace Microsoft.PSharp
 {

--- a/Source/Core/Attributes/HotAttribute.cs
+++ b/Source/Core/Attributes/HotAttribute.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 namespace Microsoft.PSharp
 {

--- a/Source/Core/Attributes/IgnoreEventsAttribute.cs
+++ b/Source/Core/Attributes/IgnoreEventsAttribute.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 namespace Microsoft.PSharp
 {

--- a/Source/Core/Attributes/OnEntryAttribute.cs
+++ b/Source/Core/Attributes/OnEntryAttribute.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 namespace Microsoft.PSharp
 {

--- a/Source/Core/Attributes/OnEventDoActionAttribute.cs
+++ b/Source/Core/Attributes/OnEventDoActionAttribute.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 namespace Microsoft.PSharp
 {

--- a/Source/Core/Attributes/OnEventGotoStateAttribute.cs
+++ b/Source/Core/Attributes/OnEventGotoStateAttribute.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 namespace Microsoft.PSharp
 {

--- a/Source/Core/Attributes/OnEventPushStateAttribute.cs
+++ b/Source/Core/Attributes/OnEventPushStateAttribute.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 namespace Microsoft.PSharp
 {

--- a/Source/Core/Attributes/OnExitAttribute.cs
+++ b/Source/Core/Attributes/OnExitAttribute.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 namespace Microsoft.PSharp
 {

--- a/Source/Core/Attributes/StartAttribute.cs
+++ b/Source/Core/Attributes/StartAttribute.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 namespace Microsoft.PSharp
 {

--- a/Source/Core/Attributes/TestAttributes.cs
+++ b/Source/Core/Attributes/TestAttributes.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 namespace Microsoft.PSharp
 {

--- a/Source/Core/Configuration.cs
+++ b/Source/Core/Configuration.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 

--- a/Source/Core/IMachineRuntime.cs
+++ b/Source/Core/IMachineRuntime.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 

--- a/Source/Core/IO/Debugging/Debug.cs
+++ b/Source/Core/IO/Debugging/Debug.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Globalization;
 
 namespace Microsoft.PSharp.IO

--- a/Source/Core/IO/Debugging/Error.cs
+++ b/Source/Core/IO/Debugging/Error.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Globalization;
 
 namespace Microsoft.PSharp.IO

--- a/Source/Core/IO/Logging/ConsoleLogger.cs
+++ b/Source/Core/IO/Logging/ConsoleLogger.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 namespace Microsoft.PSharp.IO
 {

--- a/Source/Core/IO/Logging/DisposingLogger.cs
+++ b/Source/Core/IO/Logging/DisposingLogger.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 using Microsoft.PSharp.Timers;
 using Microsoft.PSharp.Utilities;

--- a/Source/Core/IO/Logging/ILogger.cs
+++ b/Source/Core/IO/Logging/ILogger.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 using Microsoft.PSharp.Timers;
 using Microsoft.PSharp.Utilities;

--- a/Source/Core/IO/Logging/InMemoryLogger.cs
+++ b/Source/Core/IO/Logging/InMemoryLogger.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.IO;
 
 namespace Microsoft.PSharp.IO

--- a/Source/Core/IO/Logging/LogWriter.cs
+++ b/Source/Core/IO/Logging/LogWriter.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.IO;
+﻿using System.IO;
 using System.Text;
 
 namespace Microsoft.PSharp.IO

--- a/Source/Core/IO/Logging/MachineLogger.cs
+++ b/Source/Core/IO/Logging/MachineLogger.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 using Microsoft.PSharp.Timers;
 using Microsoft.PSharp.Utilities;

--- a/Source/Core/IO/Output.cs
+++ b/Source/Core/IO/Output.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.IO
+﻿namespace Microsoft.PSharp.IO
 {
     /// <summary>
     /// Static class implementing output methods.

--- a/Source/Core/Networking/INetworkProvider.cs
+++ b/Source/Core/Networking/INetworkProvider.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 namespace Microsoft.PSharp.Net
 {

--- a/Source/Core/Networking/NetworkProviders/LocalNetworkProvider.cs
+++ b/Source/Core/Networking/NetworkProviders/LocalNetworkProvider.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 namespace Microsoft.PSharp.Net
 {

--- a/Source/Core/PSharpRuntime.cs
+++ b/Source/Core/PSharpRuntime.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.Runtime;
+﻿using Microsoft.PSharp.Runtime;
 
 namespace Microsoft.PSharp
 {

--- a/Source/Core/Properties/InternalsVisibleTo.cs
+++ b/Source/Core/Properties/InternalsVisibleTo.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 
 // Libraries
 [assembly: InternalsVisibleTo("Microsoft.PSharp.LanguageServices,PublicKey=" +

--- a/Source/Core/Properties/codeanalysis.ruleset
+++ b/Source/Core/Properties/codeanalysis.ruleset
@@ -140,7 +140,7 @@
     <Rule Id="SA1626" Action="Error" />
     <Rule Id="SA1628" Action="Error" />
     <Rule Id="SA1629" Action="Error" />
-    <Rule Id="SA1633" Action="Error" />
+    <Rule Id="SA1633" Action="None" />
     <Rule Id="SA1642" Action="Error" />
     <Rule Id="SA1649" Action="None" />
     <Rule Id="SA1652" Action="None" />

--- a/Source/Core/Properties/stylecop.json
+++ b/Source/Core/Properties/stylecop.json
@@ -2,13 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
   "settings": {
     "documentationRules": {
-      "companyName": "Microsoft Corporation",
-      "copyrightText": "{header}\nCopyright (c) {companyName}. All rights reserved.\n{licenseNameInfo}. {licenseFileInfo}.\n{header}",
-      "variables": {
-        "header": "------------------------------------------------------------------------------------------------",
-        "licenseNameInfo": "Licensed under the MIT License (MIT)",
-        "licenseFileInfo": "See License.txt in the repo root for license information"
-      },
       "xmlHeader": false,
       "documentInterfaces": true,
       "documentExposedElements": true,

--- a/Source/Core/Runtime/CachedAction.cs
+++ b/Source/Core/Runtime/CachedAction.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Reflection;
 using System.Threading.Tasks;
 

--- a/Source/Core/Runtime/EventHandlers/ActionBinding.cs
+++ b/Source/Core/Runtime/EventHandlers/ActionBinding.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.Runtime
+﻿namespace Microsoft.PSharp.Runtime
 {
     /// <summary>
     /// Defines an action binding.

--- a/Source/Core/Runtime/EventHandlers/DeferAction.cs
+++ b/Source/Core/Runtime/EventHandlers/DeferAction.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.Runtime
+﻿namespace Microsoft.PSharp.Runtime
 {
     /// <summary>
     /// Defines a defer action.

--- a/Source/Core/Runtime/EventHandlers/EventActionHandler.cs
+++ b/Source/Core/Runtime/EventHandlers/EventActionHandler.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.Runtime
+﻿namespace Microsoft.PSharp.Runtime
 {
     /// <summary>
     /// An abstract event handler.

--- a/Source/Core/Runtime/EventHandlers/EventHandlerStatus.cs
+++ b/Source/Core/Runtime/EventHandlers/EventHandlerStatus.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.Runtime
+﻿namespace Microsoft.PSharp.Runtime
 {
     /// <summary>
     /// The status of the machine event handler.

--- a/Source/Core/Runtime/EventHandlers/EventWaitHandler.cs
+++ b/Source/Core/Runtime/EventHandlers/EventWaitHandler.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 namespace Microsoft.PSharp.Runtime
 {

--- a/Source/Core/Runtime/EventHandlers/GotoStateTransition.cs
+++ b/Source/Core/Runtime/EventHandlers/GotoStateTransition.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 namespace Microsoft.PSharp.Runtime
 {

--- a/Source/Core/Runtime/EventHandlers/IgnoreAction.cs
+++ b/Source/Core/Runtime/EventHandlers/IgnoreAction.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.Runtime
+﻿namespace Microsoft.PSharp.Runtime
 {
     /// <summary>
     /// Defines a skip action binding (for ignore).

--- a/Source/Core/Runtime/EventHandlers/PushStateTransition.cs
+++ b/Source/Core/Runtime/EventHandlers/PushStateTransition.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 namespace Microsoft.PSharp.Runtime
 {

--- a/Source/Core/Runtime/EventQueues/EventQueue.cs
+++ b/Source/Core/Runtime/EventQueues/EventQueue.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 

--- a/Source/Core/Runtime/EventQueues/IEventQueue.cs
+++ b/Source/Core/Runtime/EventQueues/IEventQueue.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Threading.Tasks;
 
 namespace Microsoft.PSharp.Runtime

--- a/Source/Core/Runtime/Events/Default.cs
+++ b/Source/Core/Runtime/Events/Default.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 
 namespace Microsoft.PSharp
 {

--- a/Source/Core/Runtime/Events/Event.cs
+++ b/Source/Core/Runtime/Events/Event.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 
 namespace Microsoft.PSharp
 {

--- a/Source/Core/Runtime/Events/EventInfo.cs
+++ b/Source/Core/Runtime/Events/EventInfo.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Runtime.Serialization;
 
 using Microsoft.PSharp.Runtime;

--- a/Source/Core/Runtime/Events/EventOriginInfo.cs
+++ b/Source/Core/Runtime/Events/EventOriginInfo.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 
 namespace Microsoft.PSharp.Runtime
 {

--- a/Source/Core/Runtime/Events/GotoStateEvent.cs
+++ b/Source/Core/Runtime/Events/GotoStateEvent.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Runtime.Serialization;
 
 namespace Microsoft.PSharp

--- a/Source/Core/Runtime/Events/Halt.cs
+++ b/Source/Core/Runtime/Events/Halt.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 
 namespace Microsoft.PSharp
 {

--- a/Source/Core/Runtime/Events/PushStateEvent.cs
+++ b/Source/Core/Runtime/Events/PushStateEvent.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Runtime.Serialization;
 
 namespace Microsoft.PSharp

--- a/Source/Core/Runtime/Events/WildcardEvent.cs
+++ b/Source/Core/Runtime/Events/WildcardEvent.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 
 namespace Microsoft.PSharp
 {

--- a/Source/Core/Runtime/Exceptions/AssertionFailureException.cs
+++ b/Source/Core/Runtime/Exceptions/AssertionFailureException.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 namespace Microsoft.PSharp.Runtime
 {

--- a/Source/Core/Runtime/Exceptions/ExecutionCanceledException.cs
+++ b/Source/Core/Runtime/Exceptions/ExecutionCanceledException.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.Runtime
+﻿namespace Microsoft.PSharp.Runtime
 {
     /// <summary>
     /// The exception that is thrown in a P# machine upon cancellation

--- a/Source/Core/Runtime/Exceptions/MachineActionExceptionFilterException.cs
+++ b/Source/Core/Runtime/Exceptions/MachineActionExceptionFilterException.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 namespace Microsoft.PSharp.Runtime
 {

--- a/Source/Core/Runtime/Exceptions/OnEventDroppedHandler.cs
+++ b/Source/Core/Runtime/Exceptions/OnEventDroppedHandler.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.Runtime
+﻿namespace Microsoft.PSharp.Runtime
 {
     /// <summary>
     /// Handles the <see cref="IMachineRuntime.OnEventDropped"/> event.

--- a/Source/Core/Runtime/Exceptions/OnExceptionOutcome.cs
+++ b/Source/Core/Runtime/Exceptions/OnExceptionOutcome.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.Runtime
+﻿namespace Microsoft.PSharp.Runtime
 {
     /// <summary>
     /// The outcome when a machine throws an exception.

--- a/Source/Core/Runtime/Exceptions/OnFailureHandler.cs
+++ b/Source/Core/Runtime/Exceptions/OnFailureHandler.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 namespace Microsoft.PSharp.Runtime
 {

--- a/Source/Core/Runtime/Exceptions/RuntimeException.cs
+++ b/Source/Core/Runtime/Exceptions/RuntimeException.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Runtime.Serialization;
 
 namespace Microsoft.PSharp.Runtime

--- a/Source/Core/Runtime/Exceptions/UnHandledEventException.cs
+++ b/Source/Core/Runtime/Exceptions/UnHandledEventException.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.Runtime
+﻿namespace Microsoft.PSharp.Runtime
 {
     /// <summary>
     /// Signals that a machine received an unhandled event.

--- a/Source/Core/Runtime/MachineRuntime.cs
+++ b/Source/Core/Runtime/MachineRuntime.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;

--- a/Source/Core/Runtime/Machines/AsyncMachine.cs
+++ b/Source/Core/Runtime/Machines/AsyncMachine.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.ComponentModel;
 
 using Microsoft.PSharp.IO;

--- a/Source/Core/Runtime/Machines/DequeueStatus.cs
+++ b/Source/Core/Runtime/Machines/DequeueStatus.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.Runtime
+﻿namespace Microsoft.PSharp.Runtime
 {
     /// <summary>
     /// The status returned as the result of a dequeue operation.

--- a/Source/Core/Runtime/Machines/EnqueueStatus.cs
+++ b/Source/Core/Runtime/Machines/EnqueueStatus.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.Runtime
+﻿namespace Microsoft.PSharp.Runtime
 {
     /// <summary>
     /// The status returned as the result of an enqueue operation.

--- a/Source/Core/Runtime/Machines/IMachineStateManager.cs
+++ b/Source/Core/Runtime/Machines/IMachineStateManager.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace Microsoft.PSharp.Runtime

--- a/Source/Core/Runtime/Machines/Machine.cs
+++ b/Source/Core/Runtime/Machines/Machine.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;

--- a/Source/Core/Runtime/Machines/MachineFactory.cs
+++ b/Source/Core/Runtime/Machines/MachineFactory.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 

--- a/Source/Core/Runtime/Machines/MachineId.cs
+++ b/Source/Core/Runtime/Machines/MachineId.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Globalization;
 using System.Runtime.Serialization;
 using System.Threading;

--- a/Source/Core/Runtime/Machines/MachineState.cs
+++ b/Source/Core/Runtime/Machines/MachineState.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Reflection;
 

--- a/Source/Core/Runtime/Machines/MachineStateManager.cs
+++ b/Source/Core/Runtime/Machines/MachineStateManager.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 

--- a/Source/Core/Runtime/Machines/SingleStateMachine.cs
+++ b/Source/Core/Runtime/Machines/SingleStateMachine.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace Microsoft.PSharp
 {

--- a/Source/Core/Runtime/Machines/StateGroup.cs
+++ b/Source/Core/Runtime/Machines/StateGroup.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp
+﻿namespace Microsoft.PSharp
 {
     /// <summary>
     /// Abstract class used for representing a group of related states.

--- a/Source/Core/Runtime/ProductionRuntime.cs
+++ b/Source/Core/Runtime/ProductionRuntime.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/Source/Core/Runtime/SendOptions.cs
+++ b/Source/Core/Runtime/SendOptions.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp
+﻿namespace Microsoft.PSharp
 {
     /// <summary>
     /// Represents a send event configuration that is used during testing.

--- a/Source/Core/Runtime/Specifications/Monitor.cs
+++ b/Source/Core/Runtime/Specifications/Monitor.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;

--- a/Source/Core/Runtime/Specifications/MonitorState.cs
+++ b/Source/Core/Runtime/Specifications/MonitorState.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Reflection;
 

--- a/Source/Core/Runtime/Timers/IMachineTimer.cs
+++ b/Source/Core/Runtime/Timers/IMachineTimer.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 namespace Microsoft.PSharp.Timers
 {

--- a/Source/Core/Runtime/Timers/MachineTimer.cs
+++ b/Source/Core/Runtime/Timers/MachineTimer.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Threading;
 
 namespace Microsoft.PSharp.Timers

--- a/Source/Core/Runtime/Timers/TimerElapsedEvent.cs
+++ b/Source/Core/Runtime/Timers/TimerElapsedEvent.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.Timers
+﻿namespace Microsoft.PSharp.Timers
 {
     /// <summary>
     /// Defines a timer elapsed event that is sent from a timer to the machine that owns the timer.

--- a/Source/Core/Runtime/Timers/TimerInfo.cs
+++ b/Source/Core/Runtime/Timers/TimerInfo.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 namespace Microsoft.PSharp.Timers
 {

--- a/Source/Core/Utilities/ErrorReporter.cs
+++ b/Source/Core/Utilities/ErrorReporter.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 using Microsoft.PSharp.IO;
 

--- a/Source/Core/Utilities/NameResolver.cs
+++ b/Source/Core/Utilities/NameResolver.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Globalization;
 

--- a/Source/Core/Utilities/Profiler.cs
+++ b/Source/Core/Utilities/Profiler.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Diagnostics;
+﻿using System.Diagnostics;
 
 namespace Microsoft.PSharp.Utilities
 {

--- a/Source/Core/Utilities/Tooling/BaseCommandLineOptions.cs
+++ b/Source/Core/Utilities/Tooling/BaseCommandLineOptions.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Text.RegularExpressions;
 using Microsoft.PSharp.IO;
 

--- a/Source/Core/Utilities/Tooling/CompilationTarget.cs
+++ b/Source/Core/Utilities/Tooling/CompilationTarget.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.Utilities
+﻿namespace Microsoft.PSharp.Utilities
 {
     /// <summary>
     /// P# compilation target.

--- a/Source/Core/Utilities/Tooling/OptimizationTarget.cs
+++ b/Source/Core/Utilities/Tooling/OptimizationTarget.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.Utilities
+﻿namespace Microsoft.PSharp.Utilities
 {
     /// <summary>
     /// P# compilation optimization target.

--- a/Source/Core/Utilities/Tooling/ReductionStrategy.cs
+++ b/Source/Core/Utilities/Tooling/ReductionStrategy.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.Utilities
+﻿namespace Microsoft.PSharp.Utilities
 {
     /// <summary>
     /// Type of reduction strategy.

--- a/Source/Core/Utilities/Tooling/SchedulingStrategy.cs
+++ b/Source/Core/Utilities/Tooling/SchedulingStrategy.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 
 namespace Microsoft.PSharp.Utilities
 {

--- a/Source/DataFlowAnalysis/AnalysisContext.cs
+++ b/Source/DataFlowAnalysis/AnalysisContext.cs
@@ -1,8 +1,3 @@
-// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Source/DataFlowAnalysis/ControlFlow/ControlFlowGraph.cs
+++ b/Source/DataFlowAnalysis/ControlFlow/ControlFlowGraph.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace Microsoft.PSharp.DataFlowAnalysis

--- a/Source/DataFlowAnalysis/ControlFlow/ControlFlowNode.cs
+++ b/Source/DataFlowAnalysis/ControlFlow/ControlFlowNode.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Source/DataFlowAnalysis/ControlFlow/IControlFlowNode.cs
+++ b/Source/DataFlowAnalysis/ControlFlow/IControlFlowNode.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace Microsoft.PSharp.DataFlowAnalysis
 {

--- a/Source/DataFlowAnalysis/ControlFlow/LoopHeadControlFlowNode.cs
+++ b/Source/DataFlowAnalysis/ControlFlow/LoopHeadControlFlowNode.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.DataFlowAnalysis
+﻿namespace Microsoft.PSharp.DataFlowAnalysis
 {
     /// <summary>
     /// A loop head control-flow graph node.

--- a/Source/DataFlowAnalysis/ControlFlow/Statement.cs
+++ b/Source/DataFlowAnalysis/ControlFlow/Statement.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 
 namespace Microsoft.PSharp.DataFlowAnalysis
 {

--- a/Source/DataFlowAnalysis/DataFlow/Analyses/TaintTrackingAnalysis.cs
+++ b/Source/DataFlowAnalysis/DataFlow/Analyses/TaintTrackingAnalysis.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Source/DataFlowAnalysis/DataFlow/DataFlowGraph.cs
+++ b/Source/DataFlowAnalysis/DataFlow/DataFlowGraph.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Source/DataFlowAnalysis/DataFlow/DataFlowInfo.cs
+++ b/Source/DataFlowAnalysis/DataFlow/DataFlowInfo.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;

--- a/Source/DataFlowAnalysis/DataFlow/DataFlowNode.cs
+++ b/Source/DataFlowAnalysis/DataFlow/DataFlowNode.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.PSharp.DataFlowAnalysis

--- a/Source/DataFlowAnalysis/DataFlow/IDataFlowAnalysis.cs
+++ b/Source/DataFlowAnalysis/DataFlow/IDataFlowAnalysis.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 
 namespace Microsoft.PSharp.DataFlowAnalysis
 {

--- a/Source/DataFlowAnalysis/DataFlow/IDataFlowNode.cs
+++ b/Source/DataFlowAnalysis/DataFlow/IDataFlowNode.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.PSharp.DataFlowAnalysis

--- a/Source/DataFlowAnalysis/Graphs/Graph.cs
+++ b/Source/DataFlowAnalysis/Graphs/Graph.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Source/DataFlowAnalysis/Graphs/IGraph.cs
+++ b/Source/DataFlowAnalysis/Graphs/IGraph.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Source/DataFlowAnalysis/Graphs/INode.cs
+++ b/Source/DataFlowAnalysis/Graphs/INode.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.DataFlowAnalysis
+﻿namespace Microsoft.PSharp.DataFlowAnalysis
 {
     /// <summary>
     /// Interface for a node.

--- a/Source/DataFlowAnalysis/Graphs/ITraversable.cs
+++ b/Source/DataFlowAnalysis/Graphs/ITraversable.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace Microsoft.PSharp.DataFlowAnalysis
 {

--- a/Source/DataFlowAnalysis/Library/GivenUpOwnershipSymbol.cs
+++ b/Source/DataFlowAnalysis/Library/GivenUpOwnershipSymbol.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 
 namespace Microsoft.PSharp.DataFlowAnalysis
 {

--- a/Source/DataFlowAnalysis/Library/IAnalysisPass.cs
+++ b/Source/DataFlowAnalysis/Library/IAnalysisPass.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.DataFlowAnalysis
+﻿namespace Microsoft.PSharp.DataFlowAnalysis
 {
     /// <summary>
     /// Interface of a generic analysis pass.

--- a/Source/DataFlowAnalysis/Library/MethodSideEffectsInfo.cs
+++ b/Source/DataFlowAnalysis/Library/MethodSideEffectsInfo.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/Source/DataFlowAnalysis/Library/MethodSummary.cs
+++ b/Source/DataFlowAnalysis/Library/MethodSummary.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Source/DataFlowAnalysis/Library/MethodSummaryResolver.cs
+++ b/Source/DataFlowAnalysis/Library/MethodSummaryResolver.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;

--- a/Source/DataFlowAnalysis/Library/SymbolDefinition.cs
+++ b/Source/DataFlowAnalysis/Library/SymbolDefinition.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.PSharp.DataFlowAnalysis

--- a/Source/DataFlowAnalysis/Properties/codeanalysis.ruleset
+++ b/Source/DataFlowAnalysis/Properties/codeanalysis.ruleset
@@ -140,7 +140,7 @@
     <Rule Id="SA1626" Action="Error" />
     <Rule Id="SA1628" Action="Error" />
     <Rule Id="SA1629" Action="Error" />
-    <Rule Id="SA1633" Action="Error" />
+    <Rule Id="SA1633" Action="None" />
     <Rule Id="SA1642" Action="Error" />
     <Rule Id="SA1649" Action="None" />
     <Rule Id="SA1652" Action="None" />

--- a/Source/DataFlowAnalysis/Properties/stylecop.json
+++ b/Source/DataFlowAnalysis/Properties/stylecop.json
@@ -2,13 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
   "settings": {
     "documentationRules": {
-      "companyName": "Microsoft Corporation",
-      "copyrightText": "{header}\nCopyright (c) {companyName}. All rights reserved.\n{licenseNameInfo}. {licenseFileInfo}.\n{header}",
-      "variables": {
-        "header": "------------------------------------------------------------------------------------------------",
-        "licenseNameInfo": "Licensed under the MIT License (MIT)",
-        "licenseFileInfo": "See License.txt in the repo root for license information"
-      },
       "xmlHeader": false,
       "documentInterfaces": true,
       "documentExposedElements": true,

--- a/Source/LanguageServices/Compilation/CompilationContext.cs
+++ b/Source/LanguageServices/Compilation/CompilationContext.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/Source/LanguageServices/Compilation/CompilationEngine.cs
+++ b/Source/LanguageServices/Compilation/CompilationEngine.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;

--- a/Source/LanguageServices/Exceptions/ParsingException.cs
+++ b/Source/LanguageServices/Exceptions/ParsingException.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Source/LanguageServices/Exceptions/RewritingException.cs
+++ b/Source/LanguageServices/Exceptions/RewritingException.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 namespace Microsoft.PSharp.LanguageServices
 {

--- a/Source/LanguageServices/PSharpProject.cs
+++ b/Source/LanguageServices/PSharpProject.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;

--- a/Source/LanguageServices/Parsing/Lexers/BaseLexer.cs
+++ b/Source/LanguageServices/Parsing/Lexers/BaseLexer.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
 

--- a/Source/LanguageServices/Parsing/Lexers/ILexer.cs
+++ b/Source/LanguageServices/Parsing/Lexers/ILexer.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace Microsoft.PSharp.LanguageServices.Parsing
 {

--- a/Source/LanguageServices/Parsing/Lexers/PSharpLexer.cs
+++ b/Source/LanguageServices/Parsing/Lexers/PSharpLexer.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.LanguageServices.Parsing
+﻿namespace Microsoft.PSharp.LanguageServices.Parsing
 {
     /// <summary>
     /// The P# lexer.

--- a/Source/LanguageServices/Parsing/Parsers/BaseParser.cs
+++ b/Source/LanguageServices/Parsing/Parsers/BaseParser.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 
 namespace Microsoft.PSharp.LanguageServices.Parsing
 {

--- a/Source/LanguageServices/Parsing/Parsers/CSharpParser.cs
+++ b/Source/LanguageServices/Parsing/Parsers/CSharpParser.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.PSharp.LanguageServices.Parsing.Framework;

--- a/Source/LanguageServices/Parsing/Parsers/IParser.cs
+++ b/Source/LanguageServices/Parsing/Parsers/IParser.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace Microsoft.PSharp.LanguageServices.Parsing
 {

--- a/Source/LanguageServices/Parsing/Parsers/PSharpParser.cs
+++ b/Source/LanguageServices/Parsing/Parsers/PSharpParser.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 
 using Microsoft.PSharp.LanguageServices.Parsing.Syntax;
 using Microsoft.PSharp.LanguageServices.Syntax;

--- a/Source/LanguageServices/Parsing/Parsers/TokenParser.cs
+++ b/Source/LanguageServices/Parsing/Parsers/TokenParser.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/Source/LanguageServices/Parsing/ParsingEngine.cs
+++ b/Source/LanguageServices/Parsing/ParsingEngine.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Linq;
+﻿using System.Linq;
 
 using Microsoft.PSharp.LanguageServices.Compilation;
 

--- a/Source/LanguageServices/Parsing/ParsingOptions.cs
+++ b/Source/LanguageServices/Parsing/ParsingOptions.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.LanguageServices.Parsing
+﻿namespace Microsoft.PSharp.LanguageServices.Parsing
 {
     /// <summary>
     /// The P# parsing options.

--- a/Source/LanguageServices/Parsing/RewritingEngine.cs
+++ b/Source/LanguageServices/Parsing/RewritingEngine.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.LanguageServices.Compilation;
+﻿using Microsoft.PSharp.LanguageServices.Compilation;
 
 namespace Microsoft.PSharp.LanguageServices.Parsing
 {

--- a/Source/LanguageServices/Parsing/Tokens/TextUnit.cs
+++ b/Source/LanguageServices/Parsing/Tokens/TextUnit.cs
@@ -1,8 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-using System.Diagnostics;
+﻿using System.Diagnostics;
 
 namespace Microsoft.PSharp.LanguageServices.Parsing
 {

--- a/Source/LanguageServices/Parsing/Tokens/Token.cs
+++ b/Source/LanguageServices/Parsing/Tokens/Token.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.LanguageServices.Parsing
+﻿namespace Microsoft.PSharp.LanguageServices.Parsing
 {
     /// <summary>
     /// P# syntax token.

--- a/Source/LanguageServices/Parsing/Tokens/TokenRange.cs
+++ b/Source/LanguageServices/Parsing/Tokens/TokenRange.cs
@@ -1,8 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-using System;
+﻿using System;
 using System.Linq;
 
 namespace Microsoft.PSharp.LanguageServices.Parsing

--- a/Source/LanguageServices/Parsing/Tokens/TokenStream.cs
+++ b/Source/LanguageServices/Parsing/Tokens/TokenStream.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 namespace Microsoft.PSharp.LanguageServices.Parsing

--- a/Source/LanguageServices/Parsing/Tokens/TokenType.cs
+++ b/Source/LanguageServices/Parsing/Tokens/TokenType.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.LanguageServices.Parsing
+﻿namespace Microsoft.PSharp.LanguageServices.Parsing
 {
     /// <summary>
     /// P# token types.

--- a/Source/LanguageServices/Parsing/Tokens/TokenTypeRegistry.cs
+++ b/Source/LanguageServices/Parsing/Tokens/TokenTypeRegistry.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.LanguageServices.Parsing
+﻿namespace Microsoft.PSharp.LanguageServices.Parsing
 {
     /// <summary>
     /// The token type registry.

--- a/Source/LanguageServices/Parsing/Visitors/Framework/BaseMachineVisitor.cs
+++ b/Source/LanguageServices/Parsing/Visitors/Framework/BaseMachineVisitor.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Source/LanguageServices/Parsing/Visitors/Framework/BaseStateVisitor.cs
+++ b/Source/LanguageServices/Parsing/Visitors/Framework/BaseStateVisitor.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Source/LanguageServices/Parsing/Visitors/Framework/BaseVisitor.cs
+++ b/Source/LanguageServices/Parsing/Visitors/Framework/BaseVisitor.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;

--- a/Source/LanguageServices/Parsing/Visitors/Framework/MachineDeclarationParser.cs
+++ b/Source/LanguageServices/Parsing/Visitors/Framework/MachineDeclarationParser.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;

--- a/Source/LanguageServices/Parsing/Visitors/Framework/MachineStateDeclarationParser.cs
+++ b/Source/LanguageServices/Parsing/Visitors/Framework/MachineStateDeclarationParser.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Source/LanguageServices/Parsing/Visitors/Framework/MonitorDeclarationParser.cs
+++ b/Source/LanguageServices/Parsing/Visitors/Framework/MonitorDeclarationParser.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;

--- a/Source/LanguageServices/Parsing/Visitors/Framework/MonitorStateDeclarationParser.cs
+++ b/Source/LanguageServices/Parsing/Visitors/Framework/MonitorStateDeclarationParser.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Source/LanguageServices/Parsing/Visitors/Syntax/BaseTokenVisitor.cs
+++ b/Source/LanguageServices/Parsing/Visitors/Syntax/BaseTokenVisitor.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.LanguageServices.Parsing.Syntax
+﻿namespace Microsoft.PSharp.LanguageServices.Parsing.Syntax
 {
     /// <summary>
     /// An abstract P# token parsing visitor.

--- a/Source/LanguageServices/Parsing/Visitors/Syntax/Blocks/BlockSyntaxVisitor.cs
+++ b/Source/LanguageServices/Parsing/Visitors/Syntax/Blocks/BlockSyntaxVisitor.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.CodeAnalysis.CSharp;
+﻿using Microsoft.CodeAnalysis.CSharp;
 
 using Microsoft.PSharp.LanguageServices.Syntax;
 

--- a/Source/LanguageServices/Parsing/Visitors/Syntax/Declarations/DeferEventsDeclarationVisitor.cs
+++ b/Source/LanguageServices/Parsing/Visitors/Syntax/Declarations/DeferEventsDeclarationVisitor.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Text;
 
 using Microsoft.PSharp.LanguageServices.Syntax;

--- a/Source/LanguageServices/Parsing/Visitors/Syntax/Declarations/EventDeclarationVisitor.cs
+++ b/Source/LanguageServices/Parsing/Visitors/Syntax/Declarations/EventDeclarationVisitor.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Linq;
+﻿using System.Linq;
 
 using Microsoft.PSharp.LanguageServices.Syntax;
 

--- a/Source/LanguageServices/Parsing/Visitors/Syntax/Declarations/IgnoreEventsDeclarationVisitor.cs
+++ b/Source/LanguageServices/Parsing/Visitors/Syntax/Declarations/IgnoreEventsDeclarationVisitor.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Text;
 
 using Microsoft.PSharp.LanguageServices.Syntax;

--- a/Source/LanguageServices/Parsing/Visitors/Syntax/Declarations/MachineDeclarationVisitor.cs
+++ b/Source/LanguageServices/Parsing/Visitors/Syntax/Declarations/MachineDeclarationVisitor.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.LanguageServices.Syntax;
+﻿using Microsoft.PSharp.LanguageServices.Syntax;
 
 namespace Microsoft.PSharp.LanguageServices.Parsing.Syntax
 {

--- a/Source/LanguageServices/Parsing/Visitors/Syntax/Declarations/MachineMemberDeclarationVisitor.cs
+++ b/Source/LanguageServices/Parsing/Visitors/Syntax/Declarations/MachineMemberDeclarationVisitor.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.LanguageServices.Syntax;
+﻿using Microsoft.PSharp.LanguageServices.Syntax;
 
 namespace Microsoft.PSharp.LanguageServices.Parsing.Syntax
 {

--- a/Source/LanguageServices/Parsing/Visitors/Syntax/Declarations/MachineMethodDeclarationVisitor.cs
+++ b/Source/LanguageServices/Parsing/Visitors/Syntax/Declarations/MachineMethodDeclarationVisitor.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.LanguageServices.Syntax;
+﻿using Microsoft.PSharp.LanguageServices.Syntax;
 
 namespace Microsoft.PSharp.LanguageServices.Parsing.Syntax
 {

--- a/Source/LanguageServices/Parsing/Visitors/Syntax/Declarations/StateActionDeclarationVisitor.cs
+++ b/Source/LanguageServices/Parsing/Visitors/Syntax/Declarations/StateActionDeclarationVisitor.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Text;
 
 using Microsoft.PSharp.LanguageServices.Syntax;

--- a/Source/LanguageServices/Parsing/Visitors/Syntax/Declarations/StateDeclarationVisitor.cs
+++ b/Source/LanguageServices/Parsing/Visitors/Syntax/Declarations/StateDeclarationVisitor.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.LanguageServices.Syntax;
+﻿using Microsoft.PSharp.LanguageServices.Syntax;
 
 namespace Microsoft.PSharp.LanguageServices.Parsing.Syntax
 {

--- a/Source/LanguageServices/Parsing/Visitors/Syntax/Declarations/StateEntryDeclarationVisitor.cs
+++ b/Source/LanguageServices/Parsing/Visitors/Syntax/Declarations/StateEntryDeclarationVisitor.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.LanguageServices.Syntax;
+﻿using Microsoft.PSharp.LanguageServices.Syntax;
 
 namespace Microsoft.PSharp.LanguageServices.Parsing.Syntax
 {

--- a/Source/LanguageServices/Parsing/Visitors/Syntax/Declarations/StateExitDeclarationVisitor.cs
+++ b/Source/LanguageServices/Parsing/Visitors/Syntax/Declarations/StateExitDeclarationVisitor.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.LanguageServices.Syntax;
+﻿using Microsoft.PSharp.LanguageServices.Syntax;
 
 namespace Microsoft.PSharp.LanguageServices.Parsing.Syntax
 {

--- a/Source/LanguageServices/Parsing/Visitors/Syntax/Declarations/StateGroupDeclarationVisitor.cs
+++ b/Source/LanguageServices/Parsing/Visitors/Syntax/Declarations/StateGroupDeclarationVisitor.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.CodeAnalysis.CSharp.Syntax;
+﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.PSharp.LanguageServices.Syntax;
 
 namespace Microsoft.PSharp.LanguageServices.Parsing.Syntax

--- a/Source/LanguageServices/Parsing/Visitors/Syntax/Expressions/AttributeListVisitor.cs
+++ b/Source/LanguageServices/Parsing/Visitors/Syntax/Expressions/AttributeListVisitor.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.LanguageServices.Parsing.Syntax
+﻿namespace Microsoft.PSharp.LanguageServices.Parsing.Syntax
 {
     /// <summary>
     /// The P# attribute list parsing visitor.

--- a/Source/LanguageServices/Parsing/Visitors/Syntax/Identifiers/NameVisitor.cs
+++ b/Source/LanguageServices/Parsing/Visitors/Syntax/Identifiers/NameVisitor.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
 

--- a/Source/LanguageServices/Parsing/Visitors/Syntax/Modifiers/ModifierVisitor.cs
+++ b/Source/LanguageServices/Parsing/Visitors/Syntax/Modifiers/ModifierVisitor.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.LanguageServices.Syntax;
+﻿using Microsoft.PSharp.LanguageServices.Syntax;
 
 namespace Microsoft.PSharp.LanguageServices.Parsing.Syntax
 {

--- a/Source/LanguageServices/Parsing/Visitors/Syntax/Types/TypeIdentifierVisitor.cs
+++ b/Source/LanguageServices/Parsing/Visitors/Syntax/Types/TypeIdentifierVisitor.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.LanguageServices.Parsing.Syntax
+﻿namespace Microsoft.PSharp.LanguageServices.Parsing.Syntax
 {
     /// <summary>
     /// The P# type identifier parsing visitor.

--- a/Source/LanguageServices/Programs/AbstractPSharpProgram.cs
+++ b/Source/LanguageServices/Programs/AbstractPSharpProgram.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 

--- a/Source/LanguageServices/Programs/CSharpProgram.cs
+++ b/Source/LanguageServices/Programs/CSharpProgram.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/Source/LanguageServices/Programs/IPSharpProgram.cs
+++ b/Source/LanguageServices/Programs/IPSharpProgram.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 
 namespace Microsoft.PSharp.LanguageServices
 {

--- a/Source/LanguageServices/Programs/PSharpProgram.cs
+++ b/Source/LanguageServices/Programs/PSharpProgram.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;

--- a/Source/LanguageServices/Properties/InternalsVisibleTo.cs
+++ b/Source/LanguageServices/Properties/InternalsVisibleTo.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 
 // Libraries
 [assembly: InternalsVisibleTo("Microsoft.PSharp.StaticAnalysis,PublicKey=" +

--- a/Source/LanguageServices/Properties/codeanalysis.ruleset
+++ b/Source/LanguageServices/Properties/codeanalysis.ruleset
@@ -140,7 +140,7 @@
     <Rule Id="SA1626" Action="Error" />
     <Rule Id="SA1628" Action="Error" />
     <Rule Id="SA1629" Action="Error" />
-    <Rule Id="SA1633" Action="Error" />
+    <Rule Id="SA1633" Action="None" />
     <Rule Id="SA1642" Action="Error" />
     <Rule Id="SA1649" Action="None" />
     <Rule Id="SA1652" Action="None" />

--- a/Source/LanguageServices/Properties/stylecop.json
+++ b/Source/LanguageServices/Properties/stylecop.json
@@ -2,13 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
   "settings": {
     "documentationRules": {
-      "companyName": "Microsoft Corporation",
-      "copyrightText": "{header}\nCopyright (c) {companyName}. All rights reserved.\n{licenseNameInfo}. {licenseFileInfo}.\n{header}",
-      "variables": {
-        "header": "------------------------------------------------------------------------------------------------",
-        "licenseNameInfo": "Licensed under the MIT License (MIT)",
-        "licenseFileInfo": "See License.txt in the repo root for license information"
-      },
       "xmlHeader": false,
       "documentInterfaces": true,
       "documentExposedElements": true,

--- a/Source/LanguageServices/Querying.cs
+++ b/Source/LanguageServices/Querying.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Linq;
+﻿using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/Source/LanguageServices/Rewriting/Attributes/CustomCSharpRewritingPassAttribute.cs
+++ b/Source/LanguageServices/Rewriting/Attributes/CustomCSharpRewritingPassAttribute.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 namespace Microsoft.PSharp.LanguageServices.Rewriting.CSharp
 {

--- a/Source/LanguageServices/Rewriting/Attributes/RewritingPassDependencyAttribute.cs
+++ b/Source/LanguageServices/Rewriting/Attributes/RewritingPassDependencyAttribute.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 namespace Microsoft.PSharp.LanguageServices.Rewriting.CSharp
 {

--- a/Source/LanguageServices/Rewriting/CSharp/CSharpRewriter.cs
+++ b/Source/LanguageServices/Rewriting/CSharp/CSharpRewriter.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Microsoft.PSharp.LanguageServices.Rewriting.CSharp

--- a/Source/LanguageServices/Rewriting/CSharp/Statements/GotoStateRewriter.cs
+++ b/Source/LanguageServices/Rewriting/CSharp/Statements/GotoStateRewriter.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Linq;
+﻿using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/Source/LanguageServices/Rewriting/CSharp/Statements/PopRewriter.cs
+++ b/Source/LanguageServices/Rewriting/CSharp/Statements/PopRewriter.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Linq;
+﻿using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/Source/LanguageServices/Rewriting/CSharp/Statements/RaiseRewriter.cs
+++ b/Source/LanguageServices/Rewriting/CSharp/Statements/RaiseRewriter.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Linq;
+﻿using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/Source/LanguageServices/Rewriting/PSharp/Expressions/CurrentStateRewriter.cs
+++ b/Source/LanguageServices/Rewriting/PSharp/Expressions/CurrentStateRewriter.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Linq;
+﻿using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/Source/LanguageServices/Rewriting/PSharp/Expressions/RandomChoiceRewriter.cs
+++ b/Source/LanguageServices/Rewriting/PSharp/Expressions/RandomChoiceRewriter.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Linq;
+﻿using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/Source/LanguageServices/Rewriting/PSharp/Expressions/ThisRewriter.cs
+++ b/Source/LanguageServices/Rewriting/PSharp/Expressions/ThisRewriter.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Linq;
+﻿using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/Source/LanguageServices/Rewriting/PSharp/Expressions/TriggerRewriter.cs
+++ b/Source/LanguageServices/Rewriting/PSharp/Expressions/TriggerRewriter.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Linq;
+﻿using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/Source/LanguageServices/Rewriting/PSharp/PSharpRewriter.cs
+++ b/Source/LanguageServices/Rewriting/PSharp/PSharpRewriter.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Linq;
+﻿using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/Source/LanguageServices/Rewriting/PSharp/ProjectionNode.cs
+++ b/Source/LanguageServices/Rewriting/PSharp/ProjectionNode.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.LanguageServices.Parsing;
+﻿using Microsoft.PSharp.LanguageServices.Parsing;
 
 namespace Microsoft.PSharp.LanguageServices.Rewriting.PSharp
 {

--- a/Source/LanguageServices/Rewriting/PSharp/ProjectionTree.cs
+++ b/Source/LanguageServices/Rewriting/PSharp/ProjectionTree.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace Microsoft.PSharp.LanguageServices.Rewriting.PSharp

--- a/Source/LanguageServices/Rewriting/PSharp/RewrittenTermBatch.cs
+++ b/Source/LanguageServices/Rewriting/PSharp/RewrittenTermBatch.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.PSharp.LanguageServices.Rewriting.PSharp

--- a/Source/LanguageServices/Rewriting/PSharp/Statements/AssertRewriter.cs
+++ b/Source/LanguageServices/Rewriting/PSharp/Statements/AssertRewriter.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Linq;
+﻿using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/Source/LanguageServices/Rewriting/PSharp/Statements/CreateMachineRewriter.cs
+++ b/Source/LanguageServices/Rewriting/PSharp/Statements/CreateMachineRewriter.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;

--- a/Source/LanguageServices/Rewriting/PSharp/Statements/CreateRemoteMachineRewriter.cs
+++ b/Source/LanguageServices/Rewriting/PSharp/Statements/CreateRemoteMachineRewriter.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;

--- a/Source/LanguageServices/Rewriting/PSharp/Statements/GenericTypeRewriter.cs
+++ b/Source/LanguageServices/Rewriting/PSharp/Statements/GenericTypeRewriter.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;

--- a/Source/LanguageServices/Rewriting/PSharp/Statements/GotoStateRewriter.cs
+++ b/Source/LanguageServices/Rewriting/PSharp/Statements/GotoStateRewriter.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Linq;
+﻿using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/Source/LanguageServices/Rewriting/PSharp/Statements/MonitorRewriter.cs
+++ b/Source/LanguageServices/Rewriting/PSharp/Statements/MonitorRewriter.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;

--- a/Source/LanguageServices/Rewriting/PSharp/Statements/PopRewriter.cs
+++ b/Source/LanguageServices/Rewriting/PSharp/Statements/PopRewriter.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Linq;
+﻿using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/Source/LanguageServices/Rewriting/PSharp/Statements/PushStateRewriter.cs
+++ b/Source/LanguageServices/Rewriting/PSharp/Statements/PushStateRewriter.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Linq;
+﻿using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/Source/LanguageServices/Rewriting/PSharp/Statements/RaiseRewriter.cs
+++ b/Source/LanguageServices/Rewriting/PSharp/Statements/RaiseRewriter.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;

--- a/Source/LanguageServices/Rewriting/PSharp/Statements/SendRewriter.cs
+++ b/Source/LanguageServices/Rewriting/PSharp/Statements/SendRewriter.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;

--- a/Source/LanguageServices/Rewriting/PSharp/Statements/TypeNameQualifier.cs
+++ b/Source/LanguageServices/Rewriting/PSharp/Statements/TypeNameQualifier.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;

--- a/Source/LanguageServices/Rewriting/PSharp/Statements/TypeofRewriter.cs
+++ b/Source/LanguageServices/Rewriting/PSharp/Statements/TypeofRewriter.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;

--- a/Source/LanguageServices/Rewriting/PSharp/Types/HaltEventRewriter.cs
+++ b/Source/LanguageServices/Rewriting/PSharp/Types/HaltEventRewriter.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Linq;
+﻿using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/Source/LanguageServices/Rewriting/PSharp/Types/MachineTypeRewriter.cs
+++ b/Source/LanguageServices/Rewriting/PSharp/Types/MachineTypeRewriter.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Linq;
+﻿using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/Source/LanguageServices/Syntax/Blocks/BlockSyntax.cs
+++ b/Source/LanguageServices/Syntax/Blocks/BlockSyntax.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/Source/LanguageServices/Syntax/Declarations/ActionHandler.cs
+++ b/Source/LanguageServices/Syntax/Declarations/ActionHandler.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.LanguageServices.Syntax
+﻿namespace Microsoft.PSharp.LanguageServices.Syntax
 {
     /// <summary>
     /// Anonymous action handler syntax node.

--- a/Source/LanguageServices/Syntax/Declarations/EntryDeclaration.cs
+++ b/Source/LanguageServices/Syntax/Declarations/EntryDeclaration.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.LanguageServices.Parsing;
+﻿using Microsoft.PSharp.LanguageServices.Parsing;
 
 namespace Microsoft.PSharp.LanguageServices.Syntax
 {

--- a/Source/LanguageServices/Syntax/Declarations/EventDeclaration.cs
+++ b/Source/LanguageServices/Syntax/Declarations/EventDeclaration.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Source/LanguageServices/Syntax/Declarations/EventDeclarations.cs
+++ b/Source/LanguageServices/Syntax/Declarations/EventDeclarations.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Source/LanguageServices/Syntax/Declarations/ExitDeclaration.cs
+++ b/Source/LanguageServices/Syntax/Declarations/ExitDeclaration.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.LanguageServices.Parsing;
+﻿using Microsoft.PSharp.LanguageServices.Parsing;
 
 namespace Microsoft.PSharp.LanguageServices.Syntax
 {

--- a/Source/LanguageServices/Syntax/Declarations/FieldDeclaration.cs
+++ b/Source/LanguageServices/Syntax/Declarations/FieldDeclaration.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 using Microsoft.PSharp.IO;
 using Microsoft.PSharp.LanguageServices.Parsing;

--- a/Source/LanguageServices/Syntax/Declarations/MachineDeclaration.cs
+++ b/Source/LanguageServices/Syntax/Declarations/MachineDeclaration.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 using Microsoft.PSharp.IO;

--- a/Source/LanguageServices/Syntax/Declarations/MethodDeclaration.cs
+++ b/Source/LanguageServices/Syntax/Declarations/MethodDeclaration.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 using Microsoft.PSharp.IO;

--- a/Source/LanguageServices/Syntax/Declarations/NamespaceDeclaration.cs
+++ b/Source/LanguageServices/Syntax/Declarations/NamespaceDeclaration.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.PSharp.LanguageServices.Parsing;

--- a/Source/LanguageServices/Syntax/Declarations/StateDeclaration.cs
+++ b/Source/LanguageServices/Syntax/Declarations/StateDeclaration.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Source/LanguageServices/Syntax/Declarations/StateGroupDeclaration.cs
+++ b/Source/LanguageServices/Syntax/Declarations/StateGroupDeclaration.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 using Microsoft.PSharp.IO;

--- a/Source/LanguageServices/Syntax/Declarations/UsingDeclaration.cs
+++ b/Source/LanguageServices/Syntax/Declarations/UsingDeclaration.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 using Microsoft.PSharp.LanguageServices.Parsing;
 

--- a/Source/LanguageServices/Syntax/Modifiers/AccessModifier.cs
+++ b/Source/LanguageServices/Syntax/Modifiers/AccessModifier.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.LanguageServices.Syntax
+﻿namespace Microsoft.PSharp.LanguageServices.Syntax
 {
     /// <summary>
     /// P# access modifiers.

--- a/Source/LanguageServices/Syntax/Modifiers/InheritanceModifier.cs
+++ b/Source/LanguageServices/Syntax/Modifiers/InheritanceModifier.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.LanguageServices.Syntax
+﻿namespace Microsoft.PSharp.LanguageServices.Syntax
 {
     /// <summary>
     /// P# inheritance modifiers.

--- a/Source/LanguageServices/Syntax/Modifiers/ModifierSet.cs
+++ b/Source/LanguageServices/Syntax/Modifiers/ModifierSet.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.LanguageServices.Syntax
+﻿namespace Microsoft.PSharp.LanguageServices.Syntax
 {
     /// <summary>
     /// The set of modifiers for a P# declaration.

--- a/Source/LanguageServices/Syntax/PSharpSyntaxNode.cs
+++ b/Source/LanguageServices/Syntax/PSharpSyntaxNode.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.LanguageServices.Parsing;
+﻿using Microsoft.PSharp.LanguageServices.Parsing;
 using Microsoft.PSharp.LanguageServices.Rewriting.PSharp;
 
 namespace Microsoft.PSharp.LanguageServices.Syntax

--- a/Source/LanguageServices/Syntax/QualifiedMethod.cs
+++ b/Source/LanguageServices/Syntax/QualifiedMethod.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace Microsoft.PSharp.LanguageServices.Syntax
 {

--- a/Source/SharedObjects/Properties/codeanalysis.ruleset
+++ b/Source/SharedObjects/Properties/codeanalysis.ruleset
@@ -140,7 +140,7 @@
     <Rule Id="SA1626" Action="Error" />
     <Rule Id="SA1628" Action="Error" />
     <Rule Id="SA1629" Action="Error" />
-    <Rule Id="SA1633" Action="Error" />
+    <Rule Id="SA1633" Action="None" />
     <Rule Id="SA1642" Action="Error" />
     <Rule Id="SA1649" Action="None" />
     <Rule Id="SA1652" Action="None" />

--- a/Source/SharedObjects/Properties/stylecop.json
+++ b/Source/SharedObjects/Properties/stylecop.json
@@ -2,13 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
   "settings": {
     "documentationRules": {
-      "companyName": "Microsoft Corporation",
-      "copyrightText": "{header}\nCopyright (c) {companyName}. All rights reserved.\n{licenseNameInfo}. {licenseFileInfo}.\n{header}",
-      "variables": {
-        "header": "------------------------------------------------------------------------------------------------",
-        "licenseNameInfo": "Licensed under the MIT License (MIT)",
-        "licenseFileInfo": "See License.txt in the repo root for license information"
-      },
       "xmlHeader": false,
       "documentInterfaces": true,
       "documentExposedElements": true,

--- a/Source/SharedObjects/SharedCounter/ISharedCounter.cs
+++ b/Source/SharedObjects/SharedCounter/ISharedCounter.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.SharedObjects
+﻿namespace Microsoft.PSharp.SharedObjects
 {
     /// <summary>
     /// Interface of a shared counter.

--- a/Source/SharedObjects/SharedCounter/MockSharedCounter.cs
+++ b/Source/SharedObjects/SharedCounter/MockSharedCounter.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.TestingServices.Runtime;
+﻿using Microsoft.PSharp.TestingServices.Runtime;
 
 namespace Microsoft.PSharp.SharedObjects
 {

--- a/Source/SharedObjects/SharedCounter/ProductionSharedCounter.cs
+++ b/Source/SharedObjects/SharedCounter/ProductionSharedCounter.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Threading;
+﻿using System.Threading;
 
 namespace Microsoft.PSharp.SharedObjects
 {

--- a/Source/SharedObjects/SharedCounter/SharedCounter.cs
+++ b/Source/SharedObjects/SharedCounter/SharedCounter.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.Runtime;
+﻿using Microsoft.PSharp.Runtime;
 using Microsoft.PSharp.TestingServices.Runtime;
 
 namespace Microsoft.PSharp.SharedObjects

--- a/Source/SharedObjects/SharedCounter/SharedCounterEvent.cs
+++ b/Source/SharedObjects/SharedCounter/SharedCounterEvent.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.SharedObjects
+﻿namespace Microsoft.PSharp.SharedObjects
 {
     /// <summary>
     /// Event used to communicate with a shared counter machine.

--- a/Source/SharedObjects/SharedCounter/SharedCounterMachine.cs
+++ b/Source/SharedObjects/SharedCounter/SharedCounterMachine.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.SharedObjects
+﻿namespace Microsoft.PSharp.SharedObjects
 {
     /// <summary>
     /// A shared counter modeled using a state-machine for testing.

--- a/Source/SharedObjects/SharedCounter/SharedCounterResponseEvent.cs
+++ b/Source/SharedObjects/SharedCounter/SharedCounterResponseEvent.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.SharedObjects
+﻿namespace Microsoft.PSharp.SharedObjects
 {
     /// <summary>
     /// Event containing the value of a shared counter.

--- a/Source/SharedObjects/SharedDictionary/ISharedDictionary.cs
+++ b/Source/SharedObjects/SharedDictionary/ISharedDictionary.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.SharedObjects
+﻿namespace Microsoft.PSharp.SharedObjects
 {
     /// <summary>
     /// Interface of a shared dictionary.

--- a/Source/SharedObjects/SharedDictionary/MockSharedDictionary.cs
+++ b/Source/SharedObjects/SharedDictionary/MockSharedDictionary.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 using Microsoft.PSharp.TestingServices.Runtime;

--- a/Source/SharedObjects/SharedDictionary/ProductionSharedDictionary.cs
+++ b/Source/SharedObjects/SharedDictionary/ProductionSharedDictionary.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Collections.Generic;
 
 namespace Microsoft.PSharp.SharedObjects

--- a/Source/SharedObjects/SharedDictionary/SharedDictionary.cs
+++ b/Source/SharedObjects/SharedDictionary/SharedDictionary.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 using Microsoft.PSharp.Runtime;
 using Microsoft.PSharp.TestingServices.Runtime;

--- a/Source/SharedObjects/SharedDictionary/SharedDictionaryEvent.cs
+++ b/Source/SharedObjects/SharedDictionary/SharedDictionaryEvent.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.SharedObjects
+﻿namespace Microsoft.PSharp.SharedObjects
 {
     /// <summary>
     /// Event used to communicate with a shared counter machine.

--- a/Source/SharedObjects/SharedDictionary/SharedDictionaryMachine.cs
+++ b/Source/SharedObjects/SharedDictionary/SharedDictionaryMachine.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace Microsoft.PSharp.SharedObjects

--- a/Source/SharedObjects/SharedDictionary/SharedDictionaryResponseEvent.cs
+++ b/Source/SharedObjects/SharedDictionary/SharedDictionaryResponseEvent.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.SharedObjects
+﻿namespace Microsoft.PSharp.SharedObjects
 {
     /// <summary>
     /// Event containing the value of a shared dictionary.

--- a/Source/SharedObjects/SharedRegister/ISharedRegister.cs
+++ b/Source/SharedObjects/SharedRegister/ISharedRegister.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 namespace Microsoft.PSharp.SharedObjects
 {

--- a/Source/SharedObjects/SharedRegister/MockSharedRegister.cs
+++ b/Source/SharedObjects/SharedRegister/MockSharedRegister.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 using Microsoft.PSharp.TestingServices.Runtime;
 

--- a/Source/SharedObjects/SharedRegister/ProductionSharedRegister.cs
+++ b/Source/SharedObjects/SharedRegister/ProductionSharedRegister.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 namespace Microsoft.PSharp.SharedObjects
 {

--- a/Source/SharedObjects/SharedRegister/SharedRegister.cs
+++ b/Source/SharedObjects/SharedRegister/SharedRegister.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.Runtime;
+﻿using Microsoft.PSharp.Runtime;
 using Microsoft.PSharp.TestingServices.Runtime;
 
 namespace Microsoft.PSharp.SharedObjects

--- a/Source/SharedObjects/SharedRegister/SharedRegisterEvent.cs
+++ b/Source/SharedObjects/SharedRegister/SharedRegisterEvent.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.SharedObjects
+﻿namespace Microsoft.PSharp.SharedObjects
 {
     /// <summary>
     /// Event used to communicate with a shared register machine.

--- a/Source/SharedObjects/SharedRegister/SharedRegisterMachine.cs
+++ b/Source/SharedObjects/SharedRegister/SharedRegisterMachine.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 namespace Microsoft.PSharp.SharedObjects
 {

--- a/Source/SharedObjects/SharedRegister/SharedRegisterResponseEvent.cs
+++ b/Source/SharedObjects/SharedRegister/SharedRegisterResponseEvent.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.SharedObjects
+﻿namespace Microsoft.PSharp.SharedObjects
 {
     /// <summary>
     /// Event containing the value of a shared register.

--- a/Source/StaticAnalysis/Analyses/DirectAccessAnalysisPass.cs
+++ b/Source/StaticAnalysis/Analyses/DirectAccessAnalysisPass.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;

--- a/Source/StaticAnalysis/Analyses/NoGenericStatesAnalysisPass.cs
+++ b/Source/StaticAnalysis/Analyses/NoGenericStatesAnalysisPass.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 using Microsoft.PSharp.DataFlowAnalysis;
 using Microsoft.PSharp.IO;

--- a/Source/StaticAnalysis/Analyses/Ownership/GivesUpOwnershipAnalysisPass.cs
+++ b/Source/StaticAnalysis/Analyses/Ownership/GivesUpOwnershipAnalysisPass.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;

--- a/Source/StaticAnalysis/Analyses/Ownership/OwnershipAnalysisPass.cs
+++ b/Source/StaticAnalysis/Analyses/Ownership/OwnershipAnalysisPass.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;

--- a/Source/StaticAnalysis/Analyses/Ownership/RespectsOwnershipAnalysisPass.cs
+++ b/Source/StaticAnalysis/Analyses/Ownership/RespectsOwnershipAnalysisPass.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;

--- a/Source/StaticAnalysis/Analyses/StateMachineAnalysisPass.cs
+++ b/Source/StaticAnalysis/Analyses/StateMachineAnalysisPass.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 using Microsoft.PSharp.DataFlowAnalysis;
 

--- a/Source/StaticAnalysis/Engines/StaticAnalysisEngine.cs
+++ b/Source/StaticAnalysis/Engines/StaticAnalysisEngine.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Source/StaticAnalysis/Properties/InternalsVisibleTo.cs
+++ b/Source/StaticAnalysis/Properties/InternalsVisibleTo.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 
 // Tools
 [assembly: InternalsVisibleTo("PSharpCompiler,PublicKey=" +

--- a/Source/StaticAnalysis/Properties/codeanalysis.ruleset
+++ b/Source/StaticAnalysis/Properties/codeanalysis.ruleset
@@ -140,7 +140,7 @@
     <Rule Id="SA1626" Action="Error" />
     <Rule Id="SA1628" Action="Error" />
     <Rule Id="SA1629" Action="Error" />
-    <Rule Id="SA1633" Action="Error" />
+    <Rule Id="SA1633" Action="None" />
     <Rule Id="SA1642" Action="Error" />
     <Rule Id="SA1649" Action="None" />
     <Rule Id="SA1652" Action="None" />

--- a/Source/StaticAnalysis/Properties/stylecop.json
+++ b/Source/StaticAnalysis/Properties/stylecop.json
@@ -2,13 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
   "settings": {
     "documentationRules": {
-      "companyName": "Microsoft Corporation",
-      "copyrightText": "{header}\nCopyright (c) {companyName}. All rights reserved.\n{licenseNameInfo}. {licenseFileInfo}.\n{header}",
-      "variables": {
-        "header": "------------------------------------------------------------------------------------------------",
-        "licenseNameInfo": "Licensed under the MIT License (MIT)",
-        "licenseFileInfo": "See License.txt in the repo root for license information"
-      },
       "xmlHeader": false,
       "documentInterfaces": true,
       "documentExposedElements": true,

--- a/Source/StaticAnalysis/Summarization/MachineSummarizationPass.cs
+++ b/Source/StaticAnalysis/Summarization/MachineSummarizationPass.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;

--- a/Source/StaticAnalysis/Summarization/StateMachines/MachineAction.cs
+++ b/Source/StaticAnalysis/Summarization/StateMachines/MachineAction.cs
@@ -1,8 +1,3 @@
-// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.PSharp.DataFlowAnalysis;
 

--- a/Source/StaticAnalysis/Summarization/StateMachines/MachineState.cs
+++ b/Source/StaticAnalysis/Summarization/StateMachines/MachineState.cs
@@ -1,8 +1,3 @@
-// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Source/StaticAnalysis/Summarization/StateMachines/OnEntryMachineAction.cs
+++ b/Source/StaticAnalysis/Summarization/StateMachines/OnEntryMachineAction.cs
@@ -1,8 +1,3 @@
-// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.PSharp.DataFlowAnalysis;
 

--- a/Source/StaticAnalysis/Summarization/StateMachines/OnEventDoMachineAction.cs
+++ b/Source/StaticAnalysis/Summarization/StateMachines/OnEventDoMachineAction.cs
@@ -1,8 +1,3 @@
-// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.PSharp.DataFlowAnalysis;
 

--- a/Source/StaticAnalysis/Summarization/StateMachines/OnEventGotoMachineAction.cs
+++ b/Source/StaticAnalysis/Summarization/StateMachines/OnEventGotoMachineAction.cs
@@ -1,8 +1,3 @@
-// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.PSharp.DataFlowAnalysis;
 

--- a/Source/StaticAnalysis/Summarization/StateMachines/OnEventPushMachineAction.cs
+++ b/Source/StaticAnalysis/Summarization/StateMachines/OnEventPushMachineAction.cs
@@ -1,8 +1,3 @@
-// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.PSharp.DataFlowAnalysis;
 

--- a/Source/StaticAnalysis/Summarization/StateMachines/OnExitMachineAction.cs
+++ b/Source/StaticAnalysis/Summarization/StateMachines/OnExitMachineAction.cs
@@ -1,8 +1,3 @@
-// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.PSharp.DataFlowAnalysis;
 

--- a/Source/StaticAnalysis/Summarization/StateMachines/StateMachine.cs
+++ b/Source/StaticAnalysis/Summarization/StateMachines/StateMachine.cs
@@ -1,8 +1,3 @@
-// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Source/StaticAnalysis/Summarization/StateMachines/StateTransition.cs
+++ b/Source/StaticAnalysis/Summarization/StateMachines/StateTransition.cs
@@ -1,8 +1,3 @@
-// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
 using Microsoft.PSharp.DataFlowAnalysis;
 
 namespace Microsoft.PSharp.StaticAnalysis

--- a/Source/StaticAnalysis/Tracing/CallTraceStep.cs
+++ b/Source/StaticAnalysis/Tracing/CallTraceStep.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.CodeAnalysis.CSharp.Syntax;
+﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Microsoft.PSharp.StaticAnalysis
 {

--- a/Source/StaticAnalysis/Tracing/ErrorTraceStep.cs
+++ b/Source/StaticAnalysis/Tracing/ErrorTraceStep.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.StaticAnalysis
+﻿namespace Microsoft.PSharp.StaticAnalysis
 {
     /// <summary>
     /// Class implementing an error trace step.

--- a/Source/StaticAnalysis/Tracing/TraceInfo.cs
+++ b/Source/StaticAnalysis/Tracing/TraceInfo.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;

--- a/Source/StaticAnalysis/Utilities/ErrorReporter.cs
+++ b/Source/StaticAnalysis/Utilities/ErrorReporter.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 

--- a/Source/TestingServices/Engines/AbstractTestingEngine.cs
+++ b/Source/TestingServices/Engines/AbstractTestingEngine.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 #if NET46
 using System.Configuration;

--- a/Source/TestingServices/Engines/BugFindingEngine.cs
+++ b/Source/TestingServices/Engines/BugFindingEngine.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;

--- a/Source/TestingServices/Engines/ITestingEngine.cs
+++ b/Source/TestingServices/Engines/ITestingEngine.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 namespace Microsoft.PSharp.TestingServices
 {

--- a/Source/TestingServices/Engines/ReplayEngine.cs
+++ b/Source/TestingServices/Engines/ReplayEngine.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
 using System.Text;

--- a/Source/TestingServices/Engines/TestingEngineFactory.cs
+++ b/Source/TestingServices/Engines/TestingEngineFactory.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Reflection;
 
 namespace Microsoft.PSharp.TestingServices

--- a/Source/TestingServices/Events/QuiescentEvent.cs
+++ b/Source/TestingServices/Events/QuiescentEvent.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Runtime.Serialization;
 
 namespace Microsoft.PSharp

--- a/Source/TestingServices/Properties/InternalsVisibleTo.cs
+++ b/Source/TestingServices/Properties/InternalsVisibleTo.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 
 // Libraries
 [assembly: InternalsVisibleTo("Microsoft.PSharp.SharedObjects,PublicKey=" +

--- a/Source/TestingServices/Properties/codeanalysis.ruleset
+++ b/Source/TestingServices/Properties/codeanalysis.ruleset
@@ -140,7 +140,7 @@
     <Rule Id="SA1626" Action="Error" />
     <Rule Id="SA1628" Action="Error" />
     <Rule Id="SA1629" Action="Error" />
-    <Rule Id="SA1633" Action="Error" />
+    <Rule Id="SA1633" Action="None" />
     <Rule Id="SA1642" Action="Error" />
     <Rule Id="SA1649" Action="None" />
     <Rule Id="SA1652" Action="None" />

--- a/Source/TestingServices/Properties/stylecop.json
+++ b/Source/TestingServices/Properties/stylecop.json
@@ -2,13 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
   "settings": {
     "documentationRules": {
-      "companyName": "Microsoft Corporation",
-      "copyrightText": "{header}\nCopyright (c) {companyName}. All rights reserved.\n{licenseNameInfo}. {licenseFileInfo}.\n{header}",
-      "variables": {
-        "header": "------------------------------------------------------------------------------------------------",
-        "licenseNameInfo": "Licensed under the MIT License (MIT)",
-        "licenseFileInfo": "See License.txt in the repo root for license information"
-      },
       "xmlHeader": false,
       "documentInterfaces": true,
       "documentExposedElements": true,

--- a/Source/TestingServices/RaceDetection/IRegisterRuntimeOperation.cs
+++ b/Source/TestingServices/RaceDetection/IRegisterRuntimeOperation.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace Microsoft.PSharp.TestingServices

--- a/Source/TestingServices/RaceDetection/InstrumentationState/MachineState.cs
+++ b/Source/TestingServices/RaceDetection/InstrumentationState/MachineState.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.IO;
+﻿using Microsoft.PSharp.IO;
 using Microsoft.PSharp.TestingServices.RaceDetection.Util;
 using static System.Diagnostics.Debug;
 

--- a/Source/TestingServices/RaceDetection/InstrumentationState/VarState.cs
+++ b/Source/TestingServices/RaceDetection/InstrumentationState/VarState.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Microsoft.PSharp.TestingServices.RaceDetection.Util;
 
 namespace Microsoft.PSharp.TestingServices.RaceDetection.InstrumentationState

--- a/Source/TestingServices/RaceDetection/RaceDetectionEngine.cs
+++ b/Source/TestingServices/RaceDetection/RaceDetectionEngine.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 

--- a/Source/TestingServices/RaceDetection/Utilities/Epoch.cs
+++ b/Source/TestingServices/RaceDetection/Utilities/Epoch.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 

--- a/Source/TestingServices/RaceDetection/Utilities/VectorClock.cs
+++ b/Source/TestingServices/RaceDetection/Utilities/VectorClock.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.Text;
 

--- a/Source/TestingServices/Runtime/EventQueues/SerializedMachineEventQueue.cs
+++ b/Source/TestingServices/Runtime/EventQueues/SerializedMachineEventQueue.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/Source/TestingServices/Runtime/MachineTestingRuntime.cs
+++ b/Source/TestingServices/Runtime/MachineTestingRuntime.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;

--- a/Source/TestingServices/Runtime/Machines/MachineTestKit.cs
+++ b/Source/TestingServices/Runtime/Machines/MachineTestKit.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;

--- a/Source/TestingServices/Runtime/Machines/SerializedMachineStateManager.cs
+++ b/Source/TestingServices/Runtime/Machines/SerializedMachineStateManager.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 

--- a/Source/TestingServices/Runtime/Machines/TestHarnessMachine.cs
+++ b/Source/TestingServices/Runtime/Machines/TestHarnessMachine.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Reflection;
 using System.Threading.Tasks;
 

--- a/Source/TestingServices/Runtime/Scheduling/BugFindingScheduler.cs
+++ b/Source/TestingServices/Runtime/Scheduling/BugFindingScheduler.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;

--- a/Source/TestingServices/Runtime/Scheduling/ControlledTaskScheduler.cs
+++ b/Source/TestingServices/Runtime/Scheduling/ControlledTaskScheduler.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;

--- a/Source/TestingServices/Runtime/Scheduling/ISchedulingStrategy.cs
+++ b/Source/TestingServices/Runtime/Scheduling/ISchedulingStrategy.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace Microsoft.PSharp.TestingServices.Scheduling.Strategies
 {

--- a/Source/TestingServices/Runtime/Scheduling/Operations/AsyncOperation.cs
+++ b/Source/TestingServices/Runtime/Scheduling/Operations/AsyncOperation.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Microsoft.PSharp.TestingServices.Scheduling

--- a/Source/TestingServices/Runtime/Scheduling/Operations/AsyncOperationTarget.cs
+++ b/Source/TestingServices/Runtime/Scheduling/Operations/AsyncOperationTarget.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.TestingServices.Scheduling
+﻿namespace Microsoft.PSharp.TestingServices.Scheduling
 {
     /// <summary>
     /// The target of an operation performed by an asynchronous task.

--- a/Source/TestingServices/Runtime/Scheduling/Operations/AsyncOperationType.cs
+++ b/Source/TestingServices/Runtime/Scheduling/Operations/AsyncOperationType.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.TestingServices.Scheduling
+﻿namespace Microsoft.PSharp.TestingServices.Scheduling
 {
     /// <summary>
     /// The type of an operation performed by an asynchronous task.

--- a/Source/TestingServices/Runtime/Scheduling/Operations/IAsyncOperation.cs
+++ b/Source/TestingServices/Runtime/Scheduling/Operations/IAsyncOperation.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.TestingServices.Scheduling
+﻿namespace Microsoft.PSharp.TestingServices.Scheduling
 {
     /// <summary>
     /// Interface of an asynchronous operation that can be scheduled during testing.

--- a/Source/TestingServices/Runtime/Scheduling/RandomNumberGenerators/DefaultRandomNumberGenerator.cs
+++ b/Source/TestingServices/Runtime/Scheduling/RandomNumberGenerators/DefaultRandomNumberGenerator.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 namespace Microsoft.PSharp.TestingServices.Scheduling
 {

--- a/Source/TestingServices/Runtime/Scheduling/RandomNumberGenerators/IRandomNumberGenerator.cs
+++ b/Source/TestingServices/Runtime/Scheduling/RandomNumberGenerators/IRandomNumberGenerator.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.TestingServices.Scheduling
+﻿namespace Microsoft.PSharp.TestingServices.Scheduling
 {
     /// <summary>
     /// Interface for random number generators.

--- a/Source/TestingServices/Runtime/Scheduling/Strategies/DFS/DFSStrategy.cs
+++ b/Source/TestingServices/Runtime/Scheduling/Strategies/DFS/DFSStrategy.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.PSharp.IO;

--- a/Source/TestingServices/Runtime/Scheduling/Strategies/DFS/IterativeDeepeningDFSStrategy.cs
+++ b/Source/TestingServices/Runtime/Scheduling/Strategies/DFS/IterativeDeepeningDFSStrategy.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.IO;
+﻿using Microsoft.PSharp.IO;
 
 namespace Microsoft.PSharp.TestingServices.Scheduling.Strategies
 {

--- a/Source/TestingServices/Runtime/Scheduling/Strategies/DPOR/DPORAlgorithm.cs
+++ b/Source/TestingServices/Runtime/Scheduling/Strategies/DPOR/DPORAlgorithm.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 

--- a/Source/TestingServices/Runtime/Scheduling/Strategies/DPOR/DPORStrategy.cs
+++ b/Source/TestingServices/Runtime/Scheduling/Strategies/DPOR/DPORStrategy.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics;
 
 using Microsoft.PSharp.TestingServices.Scheduling.Strategies.DPOR;

--- a/Source/TestingServices/Runtime/Scheduling/Strategies/DPOR/NonDetChoice.cs
+++ b/Source/TestingServices/Runtime/Scheduling/Strategies/DPOR/NonDetChoice.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.TestingServices.Scheduling.Strategies.DPOR
+﻿namespace Microsoft.PSharp.TestingServices.Scheduling.Strategies.DPOR
 {
     /// <summary>
     /// Stores the outcome of a nondetereminstic (nondet) choice.

--- a/Source/TestingServices/Runtime/Scheduling/Strategies/DPOR/Race.cs
+++ b/Source/TestingServices/Runtime/Scheduling/Strategies/DPOR/Race.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.TestingServices.Scheduling.Strategies.DPOR
+﻿namespace Microsoft.PSharp.TestingServices.Scheduling.Strategies.DPOR
 {
     /// <summary>
     /// Represents a race (two visible operation that are concurrent but dependent)

--- a/Source/TestingServices/Runtime/Scheduling/Strategies/DPOR/SleepSets.cs
+++ b/Source/TestingServices/Runtime/Scheduling/Strategies/DPOR/SleepSets.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.TestingServices.Scheduling.Strategies.DPOR
+﻿namespace Microsoft.PSharp.TestingServices.Scheduling.Strategies.DPOR
 {
     /// <summary>
     /// Sleep sets is a reduction technique that can be in addition to DPOR or on its own.

--- a/Source/TestingServices/Runtime/Scheduling/Strategies/DPOR/Stack.cs
+++ b/Source/TestingServices/Runtime/Scheduling/Strategies/DPOR/Stack.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 

--- a/Source/TestingServices/Runtime/Scheduling/Strategies/DPOR/TaskEntry.cs
+++ b/Source/TestingServices/Runtime/Scheduling/Strategies/DPOR/TaskEntry.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace Microsoft.PSharp.TestingServices.Scheduling.Strategies.DPOR
 {

--- a/Source/TestingServices/Runtime/Scheduling/Strategies/DPOR/TaskEntryList.cs
+++ b/Source/TestingServices/Runtime/Scheduling/Strategies/DPOR/TaskEntryList.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;

--- a/Source/TestingServices/Runtime/Scheduling/Strategies/DPOR/TidForRaceReplay.cs
+++ b/Source/TestingServices/Runtime/Scheduling/Strategies/DPOR/TidForRaceReplay.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace Microsoft.PSharp.TestingServices.Scheduling.Strategies.DPOR
 {

--- a/Source/TestingServices/Runtime/Scheduling/Strategies/DelayBounded/DelayBoundingStrategy.cs
+++ b/Source/TestingServices/Runtime/Scheduling/Strategies/DelayBounded/DelayBoundingStrategy.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Source/TestingServices/Runtime/Scheduling/Strategies/DelayBounded/ExhaustiveDelayBoundingStrategy.cs
+++ b/Source/TestingServices/Runtime/Scheduling/Strategies/DelayBounded/ExhaustiveDelayBoundingStrategy.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Source/TestingServices/Runtime/Scheduling/Strategies/DelayBounded/RandomDelayBoundingStrategy.cs
+++ b/Source/TestingServices/Runtime/Scheduling/Strategies/DelayBounded/RandomDelayBoundingStrategy.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace Microsoft.PSharp.TestingServices.Scheduling.Strategies

--- a/Source/TestingServices/Runtime/Scheduling/Strategies/Liveness/CycleDetectionStrategy.cs
+++ b/Source/TestingServices/Runtime/Scheduling/Strategies/Liveness/CycleDetectionStrategy.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Source/TestingServices/Runtime/Scheduling/Strategies/Liveness/LivenessCheckingStrategy.cs
+++ b/Source/TestingServices/Runtime/Scheduling/Strategies/Liveness/LivenessCheckingStrategy.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace Microsoft.PSharp.TestingServices.Scheduling.Strategies

--- a/Source/TestingServices/Runtime/Scheduling/Strategies/Liveness/TemperatureCheckingStrategy.cs
+++ b/Source/TestingServices/Runtime/Scheduling/Strategies/Liveness/TemperatureCheckingStrategy.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace Microsoft.PSharp.TestingServices.Scheduling.Strategies
 {

--- a/Source/TestingServices/Runtime/Scheduling/Strategies/Probabilistic/PCTStrategy.cs
+++ b/Source/TestingServices/Runtime/Scheduling/Strategies/Probabilistic/PCTStrategy.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Source/TestingServices/Runtime/Scheduling/Strategies/Probabilistic/ProbabilisticRandomStrategy.cs
+++ b/Source/TestingServices/Runtime/Scheduling/Strategies/Probabilistic/ProbabilisticRandomStrategy.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 namespace Microsoft.PSharp.TestingServices.Scheduling.Strategies

--- a/Source/TestingServices/Runtime/Scheduling/Strategies/Probabilistic/RandomStrategy.cs
+++ b/Source/TestingServices/Runtime/Scheduling/Strategies/Probabilistic/RandomStrategy.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Source/TestingServices/Runtime/Scheduling/Strategies/Special/BasicReductionStrategy.cs
+++ b/Source/TestingServices/Runtime/Scheduling/Strategies/Special/BasicReductionStrategy.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Source/TestingServices/Runtime/Scheduling/Strategies/Special/ComboStrategy.cs
+++ b/Source/TestingServices/Runtime/Scheduling/Strategies/Special/ComboStrategy.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace Microsoft.PSharp.TestingServices.Scheduling.Strategies
 {

--- a/Source/TestingServices/Runtime/Scheduling/Strategies/Special/InteractiveStrategy.cs
+++ b/Source/TestingServices/Runtime/Scheduling/Strategies/Special/InteractiveStrategy.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Source/TestingServices/Runtime/Scheduling/Strategies/Special/ReplayStrategy.cs
+++ b/Source/TestingServices/Runtime/Scheduling/Strategies/Special/ReplayStrategy.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Source/TestingServices/Runtime/SystematicTestingRuntime.cs
+++ b/Source/TestingServices/Runtime/SystematicTestingRuntime.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;

--- a/Source/TestingServices/Runtime/Timers/MockMachineTimer.cs
+++ b/Source/TestingServices/Runtime/Timers/MockMachineTimer.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.Timers;
+﻿using Microsoft.PSharp.Timers;
 
 namespace Microsoft.PSharp.TestingServices.Timers
 {

--- a/Source/TestingServices/Runtime/Timers/TimerSetupEvent.cs
+++ b/Source/TestingServices/Runtime/Timers/TimerSetupEvent.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.Timers;
+﻿using Microsoft.PSharp.Timers;
 
 namespace Microsoft.PSharp.TestingServices.Timers
 {

--- a/Source/TestingServices/StateCaching/Fingerprint.cs
+++ b/Source/TestingServices/StateCaching/Fingerprint.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.TestingServices.StateCaching
+﻿namespace Microsoft.PSharp.TestingServices.StateCaching
 {
     /// <summary>
     /// Class implementing a program state fingerprint.

--- a/Source/TestingServices/StateCaching/MonitorStatus.cs
+++ b/Source/TestingServices/StateCaching/MonitorStatus.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.TestingServices.StateCaching
+﻿namespace Microsoft.PSharp.TestingServices.StateCaching
 {
     /// <summary>
     /// Monitor status.

--- a/Source/TestingServices/StateCaching/State.cs
+++ b/Source/TestingServices/StateCaching/State.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 using Microsoft.PSharp.IO;
 

--- a/Source/TestingServices/StateCaching/StateCache.cs
+++ b/Source/TestingServices/StateCaching/StateCache.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 using Microsoft.PSharp.IO;
 using Microsoft.PSharp.TestingServices.Runtime;

--- a/Source/TestingServices/Statistics/Coverage/ActivityCoverageReporter.cs
+++ b/Source/TestingServices/Statistics/Coverage/ActivityCoverageReporter.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;

--- a/Source/TestingServices/Statistics/Coverage/CoverageInfo.cs
+++ b/Source/TestingServices/Statistics/Coverage/CoverageInfo.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 

--- a/Source/TestingServices/Statistics/Coverage/Transition.cs
+++ b/Source/TestingServices/Statistics/Coverage/Transition.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 
 namespace Microsoft.PSharp.TestingServices.Coverage
 {

--- a/Source/TestingServices/Statistics/TestReport.cs
+++ b/Source/TestingServices/Statistics/TestReport.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Runtime.Serialization;
 using System.Text;
 

--- a/Source/TestingServices/Tracing/Error/BugTrace.cs
+++ b/Source/TestingServices/Tracing/Error/BugTrace.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.Serialization;

--- a/Source/TestingServices/Tracing/Error/BugTraceStep.cs
+++ b/Source/TestingServices/Tracing/Error/BugTraceStep.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Reflection;
+﻿using System.Reflection;
 using System.Runtime.Serialization;
 
 namespace Microsoft.PSharp.TestingServices.Tracing.Error

--- a/Source/TestingServices/Tracing/Error/BugTraceStepType.cs
+++ b/Source/TestingServices/Tracing/Error/BugTraceStepType.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 
 namespace Microsoft.PSharp.TestingServices.Tracing.Error
 {

--- a/Source/TestingServices/Tracing/Schedules/ScheduleStep.cs
+++ b/Source/TestingServices/Tracing/Schedules/ScheduleStep.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.TestingServices.StateCaching;
+﻿using Microsoft.PSharp.TestingServices.StateCaching;
 
 namespace Microsoft.PSharp.TestingServices.Tracing.Schedule
 {

--- a/Source/TestingServices/Tracing/Schedules/ScheduleStepType.cs
+++ b/Source/TestingServices/Tracing/Schedules/ScheduleStepType.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.TestingServices.Tracing.Schedule
+﻿namespace Microsoft.PSharp.TestingServices.Tracing.Schedule
 {
     /// <summary>
     /// The schedule step type.

--- a/Source/TestingServices/Tracing/Schedules/ScheduleTrace.cs
+++ b/Source/TestingServices/Tracing/Schedules/ScheduleTrace.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 
 namespace Microsoft.PSharp.TestingServices.Tracing.Schedule

--- a/Tests/Core.Tests/BaseTest.cs
+++ b/Tests/Core.Tests/BaseTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Microsoft.PSharp.IO;
 using Microsoft.PSharp.Tests.Common;

--- a/Tests/Core.Tests/EventQueues/EventQueueStressTest.cs
+++ b/Tests/Core.Tests/EventQueues/EventQueueStressTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Microsoft.PSharp.Runtime;
 using Microsoft.PSharp.Tests.Common;

--- a/Tests/Core.Tests/EventQueues/EventQueueTest.cs
+++ b/Tests/Core.Tests/EventQueues/EventQueueTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Microsoft.PSharp.Runtime;
 using Microsoft.PSharp.Tests.Common;

--- a/Tests/Core.Tests/EventQueues/MockMachineStateManager.cs
+++ b/Tests/Core.Tests/EventQueues/MockMachineStateManager.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.PSharp.IO;

--- a/Tests/Core.Tests/ExceptionPropagation/ExceptionPropagationTest.cs
+++ b/Tests/Core.Tests/ExceptionPropagation/ExceptionPropagationTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Microsoft.PSharp.Runtime;
 using Xunit;

--- a/Tests/Core.Tests/ExceptionPropagation/OnExceptionTest.cs
+++ b/Tests/Core.Tests/ExceptionPropagation/OnExceptionTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Microsoft.PSharp.Runtime;
 using Xunit;

--- a/Tests/Core.Tests/Features/GetOperationGroupIdTest.cs
+++ b/Tests/Core.Tests/Features/GetOperationGroupIdTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;

--- a/Tests/Core.Tests/Features/OnEventDroppedTest.cs
+++ b/Tests/Core.Tests/Features/OnEventDroppedTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;

--- a/Tests/Core.Tests/Features/OnHaltTest.cs
+++ b/Tests/Core.Tests/Features/OnHaltTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;

--- a/Tests/Core.Tests/Features/OperationGroupingTest.cs
+++ b/Tests/Core.Tests/Features/OperationGroupingTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;

--- a/Tests/Core.Tests/Logging/CustomLoggerTest.cs
+++ b/Tests/Core.Tests/Logging/CustomLoggerTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;

--- a/Tests/Core.Tests/Machines/GotoStateTransitionTest.cs
+++ b/Tests/Core.Tests/Machines/GotoStateTransitionTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.PSharp.TestingServices;
 using Xunit;
 using Xunit.Abstractions;

--- a/Tests/Core.Tests/Machines/HandleEventTest.cs
+++ b/Tests/Core.Tests/Machines/HandleEventTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.PSharp.TestingServices;
 using Xunit;
 using Xunit.Abstractions;

--- a/Tests/Core.Tests/Machines/InvokeMethodTest.cs
+++ b/Tests/Core.Tests/Machines/InvokeMethodTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Microsoft.PSharp.TestingServices;
 using Xunit;

--- a/Tests/Core.Tests/Machines/ReceiveEventIntegrationTest.cs
+++ b/Tests/Core.Tests/Machines/ReceiveEventIntegrationTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;

--- a/Tests/Core.Tests/Machines/ReceiveEventStressTest.cs
+++ b/Tests/Core.Tests/Machines/ReceiveEventStressTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;

--- a/Tests/Core.Tests/Machines/ReceiveEventTest.cs
+++ b/Tests/Core.Tests/Machines/ReceiveEventTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Microsoft.PSharp.Runtime;
 using Microsoft.PSharp.TestingServices;

--- a/Tests/Core.Tests/Machines/Timers/TimerStressTest.cs
+++ b/Tests/Core.Tests/Machines/Timers/TimerStressTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.PSharp.Timers;

--- a/Tests/Core.Tests/Machines/Timers/TimerTest.cs
+++ b/Tests/Core.Tests/Machines/Timers/TimerTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Microsoft.PSharp.Runtime;
 using Microsoft.PSharp.Timers;

--- a/Tests/Core.Tests/MemoryLeak/NoMemoryLeakAfterHaltTest.cs
+++ b/Tests/Core.Tests/MemoryLeak/NoMemoryLeakAfterHaltTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Microsoft.PSharp.Runtime;
 using Xunit;

--- a/Tests/Core.Tests/MemoryLeak/NoMemoryLeakInEventSendingTest.cs
+++ b/Tests/Core.Tests/MemoryLeak/NoMemoryLeakInEventSendingTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Microsoft.PSharp.Runtime;
 using Xunit;

--- a/Tests/Core.Tests/Properties/codeanalysis.ruleset
+++ b/Tests/Core.Tests/Properties/codeanalysis.ruleset
@@ -140,7 +140,7 @@
     <Rule Id="SA1626" Action="Error" />
     <Rule Id="SA1628" Action="Error" />
     <Rule Id="SA1629" Action="Error" />
-    <Rule Id="SA1633" Action="Error" />
+    <Rule Id="SA1633" Action="None" />
     <Rule Id="SA1642" Action="Error" />
     <Rule Id="SA1649" Action="None" />
     <Rule Id="SA1652" Action="None" />

--- a/Tests/Core.Tests/Properties/stylecop.json
+++ b/Tests/Core.Tests/Properties/stylecop.json
@@ -2,13 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
   "settings": {
     "documentationRules": {
-      "companyName": "Microsoft Corporation",
-      "copyrightText": "{header}\nCopyright (c) {companyName}. All rights reserved.\n{licenseNameInfo}. {licenseFileInfo}.\n{header}",
-      "variables": {
-        "header": "------------------------------------------------------------------------------------------------",
-        "licenseNameInfo": "Licensed under the MIT License (MIT)",
-        "licenseFileInfo": "See License.txt in the repo root for license information"
-      },
       "xmlHeader": false,
       "documentInterfaces": true,
       "documentExposedElements": true,

--- a/Tests/Core.Tests/RuntimeInterface/CreateMachineIdFromNameTest.cs
+++ b/Tests/Core.Tests/RuntimeInterface/CreateMachineIdFromNameTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;

--- a/Tests/Core.Tests/RuntimeInterface/SendAndExecuteTest.cs
+++ b/Tests/Core.Tests/RuntimeInterface/SendAndExecuteTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Microsoft.PSharp.Runtime;
 using Xunit;

--- a/Tests/LanguageServices.Tests/Declarations/EventInheritanceTests.cs
+++ b/Tests/LanguageServices.Tests/Declarations/EventInheritanceTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Xunit;
+﻿using Xunit;
 
 namespace Microsoft.PSharp.LanguageServices.Tests
 {

--- a/Tests/LanguageServices.Tests/Declarations/EventTests.cs
+++ b/Tests/LanguageServices.Tests/Declarations/EventTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Xunit;
+﻿using Xunit;
 
 namespace Microsoft.PSharp.LanguageServices.Tests
 {

--- a/Tests/LanguageServices.Tests/Declarations/FieldTests.cs
+++ b/Tests/LanguageServices.Tests/Declarations/FieldTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Xunit;
+﻿using Xunit;
 
 namespace Microsoft.PSharp.LanguageServices.Tests
 {

--- a/Tests/LanguageServices.Tests/Declarations/MachineStateInheritanceTests.cs
+++ b/Tests/LanguageServices.Tests/Declarations/MachineStateInheritanceTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Xunit;
+﻿using Xunit;
 
 namespace Microsoft.PSharp.LanguageServices.Tests
 {

--- a/Tests/LanguageServices.Tests/Declarations/MachineTests.cs
+++ b/Tests/LanguageServices.Tests/Declarations/MachineTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.CodeAnalysis.CSharp;
+﻿using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.PSharp.LanguageServices.Parsing;
 
 using Xunit;

--- a/Tests/LanguageServices.Tests/Declarations/MethodTests.cs
+++ b/Tests/LanguageServices.Tests/Declarations/MethodTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Xunit;
+﻿using Xunit;
 
 namespace Microsoft.PSharp.LanguageServices.Tests
 {

--- a/Tests/LanguageServices.Tests/Declarations/MonitorTests.cs
+++ b/Tests/LanguageServices.Tests/Declarations/MonitorTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.CodeAnalysis.CSharp;
+﻿using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.PSharp.LanguageServices.Parsing;
 
 using Xunit;

--- a/Tests/LanguageServices.Tests/Declarations/NameofTests.cs
+++ b/Tests/LanguageServices.Tests/Declarations/NameofTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Xunit;
+﻿using Xunit;
 
 namespace Microsoft.PSharp.LanguageServices.Tests
 {

--- a/Tests/LanguageServices.Tests/Declarations/NamespaceTests.cs
+++ b/Tests/LanguageServices.Tests/Declarations/NamespaceTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Xunit;
+﻿using Xunit;
 
 namespace Microsoft.PSharp.LanguageServices.Tests
 {

--- a/Tests/LanguageServices.Tests/Declarations/RewritingTests.cs
+++ b/Tests/LanguageServices.Tests/Declarations/RewritingTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 using Microsoft.PSharp.LanguageServices.Parsing;
 

--- a/Tests/LanguageServices.Tests/Declarations/StateGroupTests.cs
+++ b/Tests/LanguageServices.Tests/Declarations/StateGroupTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Xunit;
+﻿using Xunit;
 
 namespace Microsoft.PSharp.LanguageServices.Tests
 {

--- a/Tests/LanguageServices.Tests/Declarations/StateTests.cs
+++ b/Tests/LanguageServices.Tests/Declarations/StateTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Xunit;
+﻿using Xunit;
 
 namespace Microsoft.PSharp.LanguageServices.Tests
 {

--- a/Tests/LanguageServices.Tests/Declarations/UsingTests.cs
+++ b/Tests/LanguageServices.Tests/Declarations/UsingTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Xunit;
+﻿using Xunit;
 
 namespace Microsoft.PSharp.LanguageServices.Tests
 {

--- a/Tests/LanguageServices.Tests/LanguageTestUtilities.cs
+++ b/Tests/LanguageServices.Tests/LanguageTestUtilities.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.PSharp.LanguageServices.Compilation;

--- a/Tests/LanguageServices.Tests/Properties/codeanalysis.ruleset
+++ b/Tests/LanguageServices.Tests/Properties/codeanalysis.ruleset
@@ -140,7 +140,7 @@
     <Rule Id="SA1626" Action="Error" />
     <Rule Id="SA1628" Action="Error" />
     <Rule Id="SA1629" Action="Error" />
-    <Rule Id="SA1633" Action="Error" />
+    <Rule Id="SA1633" Action="None" />
     <Rule Id="SA1642" Action="Error" />
     <Rule Id="SA1649" Action="None" />
     <Rule Id="SA1652" Action="None" />

--- a/Tests/LanguageServices.Tests/Properties/stylecop.json
+++ b/Tests/LanguageServices.Tests/Properties/stylecop.json
@@ -2,13 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
   "settings": {
     "documentationRules": {
-      "companyName": "Microsoft Corporation",
-      "copyrightText": "{header}\nCopyright (c) {companyName}. All rights reserved.\n{licenseNameInfo}. {licenseFileInfo}.\n{header}",
-      "variables": {
-        "header": "------------------------------------------------------------------------------------------------",
-        "licenseNameInfo": "Licensed under the MIT License (MIT)",
-        "licenseFileInfo": "See License.txt in the repo root for license information"
-      },
       "xmlHeader": false,
       "documentInterfaces": true,
       "documentExposedElements": true,

--- a/Tests/LanguageServices.Tests/Statements/CreateTests.cs
+++ b/Tests/LanguageServices.Tests/Statements/CreateTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Xunit;
+﻿using Xunit;
 
 namespace Microsoft.PSharp.LanguageServices.Tests
 {

--- a/Tests/LanguageServices.Tests/Statements/GotoStateTests.cs
+++ b/Tests/LanguageServices.Tests/Statements/GotoStateTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Xunit;
+﻿using Xunit;
 
 namespace Microsoft.PSharp.LanguageServices.Tests
 {

--- a/Tests/LanguageServices.Tests/Statements/PushStateTests.cs
+++ b/Tests/LanguageServices.Tests/Statements/PushStateTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Xunit;
+﻿using Xunit;
 
 namespace Microsoft.PSharp.LanguageServices.Tests
 {

--- a/Tests/LanguageServices.Tests/Statements/RaiseTests.cs
+++ b/Tests/LanguageServices.Tests/Statements/RaiseTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Xunit;
+﻿using Xunit;
 
 namespace Microsoft.PSharp.LanguageServices.Tests
 {

--- a/Tests/LanguageServices.Tests/Statements/SendTests.cs
+++ b/Tests/LanguageServices.Tests/Statements/SendTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Xunit;
+﻿using Xunit;
 
 namespace Microsoft.PSharp.LanguageServices.Tests
 {

--- a/Tests/SharedObjects.Tests/BaseTest.cs
+++ b/Tests/SharedObjects.Tests/BaseTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;

--- a/Tests/SharedObjects.Tests/ProductionSharedObjectsTest.cs
+++ b/Tests/SharedObjects.Tests/ProductionSharedObjectsTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/SharedObjects.Tests/Properties/codeanalysis.ruleset
+++ b/Tests/SharedObjects.Tests/Properties/codeanalysis.ruleset
@@ -140,7 +140,7 @@
     <Rule Id="SA1626" Action="Error" />
     <Rule Id="SA1628" Action="Error" />
     <Rule Id="SA1629" Action="Error" />
-    <Rule Id="SA1633" Action="Error" />
+    <Rule Id="SA1633" Action="None" />
     <Rule Id="SA1642" Action="Error" />
     <Rule Id="SA1649" Action="None" />
     <Rule Id="SA1652" Action="None" />

--- a/Tests/SharedObjects.Tests/Properties/stylecop.json
+++ b/Tests/SharedObjects.Tests/Properties/stylecop.json
@@ -2,13 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
   "settings": {
     "documentationRules": {
-      "companyName": "Microsoft Corporation",
-      "copyrightText": "{header}\nCopyright (c) {companyName}. All rights reserved.\n{licenseNameInfo}. {licenseFileInfo}.\n{header}",
-      "variables": {
-        "header": "------------------------------------------------------------------------------------------------",
-        "licenseNameInfo": "Licensed under the MIT License (MIT)",
-        "licenseFileInfo": "See License.txt in the repo root for license information"
-      },
       "xmlHeader": false,
       "documentInterfaces": true,
       "documentExposedElements": true,

--- a/Tests/SharedObjects.Tests/SharedCounter/MockSharedCounterTest.cs
+++ b/Tests/SharedObjects.Tests/SharedCounter/MockSharedCounterTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/SharedObjects.Tests/SharedCounter/ProductionSharedCounterTest.cs
+++ b/Tests/SharedObjects.Tests/SharedCounter/ProductionSharedCounterTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/SharedObjects.Tests/SharedDictionary/MockSharedDictionaryTest.cs
+++ b/Tests/SharedObjects.Tests/SharedDictionary/MockSharedDictionaryTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/SharedObjects.Tests/SharedDictionary/ProductionSharedDictionaryTest.cs
+++ b/Tests/SharedObjects.Tests/SharedDictionary/ProductionSharedDictionaryTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/SharedObjects.Tests/SharedRegister/MockSharedRegisterTest.cs
+++ b/Tests/SharedObjects.Tests/SharedRegister/MockSharedRegisterTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/SharedObjects.Tests/SharedRegister/ProductionSharedRegisterTest.cs
+++ b/Tests/SharedObjects.Tests/SharedRegister/ProductionSharedRegisterTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/StaticAnalysis.Tests/AccessChecking/AccessAfterCreateMachineTests.cs
+++ b/Tests/StaticAnalysis.Tests/AccessChecking/AccessAfterCreateMachineTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.Tests.Common;
+﻿using Microsoft.PSharp.Tests.Common;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/StaticAnalysis.Tests/AccessChecking/AccessAfterSendTests.cs
+++ b/Tests/StaticAnalysis.Tests/AccessChecking/AccessAfterSendTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.Tests.Common;
+﻿using Microsoft.PSharp.Tests.Common;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/StaticAnalysis.Tests/AccessChecking/AccessBeforeCreateMachineTests.cs
+++ b/Tests/StaticAnalysis.Tests/AccessChecking/AccessBeforeCreateMachineTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.Tests.Common;
+﻿using Microsoft.PSharp.Tests.Common;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/StaticAnalysis.Tests/AccessChecking/AccessBeforeSendTests.cs
+++ b/Tests/StaticAnalysis.Tests/AccessChecking/AccessBeforeSendTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.Tests.Common;
+﻿using Microsoft.PSharp.Tests.Common;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/StaticAnalysis.Tests/AccessChecking/AliasAccessAfterSendTests.cs
+++ b/Tests/StaticAnalysis.Tests/AccessChecking/AliasAccessAfterSendTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.Tests.Common;
+﻿using Microsoft.PSharp.Tests.Common;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/StaticAnalysis.Tests/AccessChecking/ReadAccessAfterSendTests.cs
+++ b/Tests/StaticAnalysis.Tests/AccessChecking/ReadAccessAfterSendTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.Tests.Common;
+﻿using Microsoft.PSharp.Tests.Common;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/StaticAnalysis.Tests/AccessChecking/ResetAfterSendTests.cs
+++ b/Tests/StaticAnalysis.Tests/AccessChecking/ResetAfterSendTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.Tests.Common;
+﻿using Microsoft.PSharp.Tests.Common;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/StaticAnalysis.Tests/AccessChecking/WriteAccessAfterSendTests.cs
+++ b/Tests/StaticAnalysis.Tests/AccessChecking/WriteAccessAfterSendTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.Tests.Common;
+﻿using Microsoft.PSharp.Tests.Common;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/StaticAnalysis.Tests/Advanced/ComplexAccessesInCallTests.cs
+++ b/Tests/StaticAnalysis.Tests/Advanced/ComplexAccessesInCallTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.Tests.Common;
+﻿using Microsoft.PSharp.Tests.Common;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/StaticAnalysis.Tests/Advanced/DuplicateSendsTests.cs
+++ b/Tests/StaticAnalysis.Tests/Advanced/DuplicateSendsTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.Tests.Common;
+﻿using Microsoft.PSharp.Tests.Common;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/StaticAnalysis.Tests/Advanced/ExternalLibraryCallTests.cs
+++ b/Tests/StaticAnalysis.Tests/Advanced/ExternalLibraryCallTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.Tests.Common;
+﻿using Microsoft.PSharp.Tests.Common;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/StaticAnalysis.Tests/Advanced/NestedAccessesInCallTests.cs
+++ b/Tests/StaticAnalysis.Tests/Advanced/NestedAccessesInCallTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.Tests.Common;
+﻿using Microsoft.PSharp.Tests.Common;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/StaticAnalysis.Tests/Advanced/ReturnAliasAccessTests.cs
+++ b/Tests/StaticAnalysis.Tests/Advanced/ReturnAliasAccessTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.Tests.Common;
+﻿using Microsoft.PSharp.Tests.Common;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/StaticAnalysis.Tests/Assert.cs
+++ b/Tests/StaticAnalysis.Tests/Assert.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 using Microsoft.PSharp.IO;
 using Microsoft.PSharp.LanguageServices.Compilation;

--- a/Tests/StaticAnalysis.Tests/ControlFlow/AccessInLoopTests.cs
+++ b/Tests/StaticAnalysis.Tests/ControlFlow/AccessInLoopTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.Tests.Common;
+﻿using Microsoft.PSharp.Tests.Common;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/StaticAnalysis.Tests/ControlFlow/BasicLoopTest.cs
+++ b/Tests/StaticAnalysis.Tests/ControlFlow/BasicLoopTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.Tests.Common;
+﻿using Microsoft.PSharp.Tests.Common;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/StaticAnalysis.Tests/ControlFlow/IfStatementTests.cs
+++ b/Tests/StaticAnalysis.Tests/ControlFlow/IfStatementTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.Tests.Common;
+﻿using Microsoft.PSharp.Tests.Common;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/StaticAnalysis.Tests/ControlFlow/NoStatementsTest.cs
+++ b/Tests/StaticAnalysis.Tests/ControlFlow/NoStatementsTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.Tests.Common;
+﻿using Microsoft.PSharp.Tests.Common;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/StaticAnalysis.Tests/ControlFlow/NoStatementsWithLoopTest.cs
+++ b/Tests/StaticAnalysis.Tests/ControlFlow/NoStatementsWithLoopTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.Tests.Common;
+﻿using Microsoft.PSharp.Tests.Common;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/StaticAnalysis.Tests/ControlFlow/SwitchStatementTests.cs
+++ b/Tests/StaticAnalysis.Tests/ControlFlow/SwitchStatementTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.Tests.Common;
+﻿using Microsoft.PSharp.Tests.Common;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/StaticAnalysis.Tests/ControlFlow/UsingStatementTests.cs
+++ b/Tests/StaticAnalysis.Tests/ControlFlow/UsingStatementTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.Tests.Common;
+﻿using Microsoft.PSharp.Tests.Common;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/StaticAnalysis.Tests/DirectAccess/MemberVisibilityTests.cs
+++ b/Tests/StaticAnalysis.Tests/DirectAccess/MemberVisibilityTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.Tests.Common;
+﻿using Microsoft.PSharp.Tests.Common;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/StaticAnalysis.Tests/FieldOwnership/FieldAliasAccessAfterSendTests.cs
+++ b/Tests/StaticAnalysis.Tests/FieldOwnership/FieldAliasAccessAfterSendTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.Tests.Common;
+﻿using Microsoft.PSharp.Tests.Common;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/StaticAnalysis.Tests/FieldOwnership/FieldGivenUpOwnershipTests.cs
+++ b/Tests/StaticAnalysis.Tests/FieldOwnership/FieldGivenUpOwnershipTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.Tests.Common;
+﻿using Microsoft.PSharp.Tests.Common;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/StaticAnalysis.Tests/FieldOwnership/FieldSendAliasTests.cs
+++ b/Tests/StaticAnalysis.Tests/FieldOwnership/FieldSendAliasTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.Tests.Common;
+﻿using Microsoft.PSharp.Tests.Common;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/StaticAnalysis.Tests/FieldOwnership/FieldSendingTests.cs
+++ b/Tests/StaticAnalysis.Tests/FieldOwnership/FieldSendingTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.Tests.Common;
+﻿using Microsoft.PSharp.Tests.Common;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/StaticAnalysis.Tests/Inheritance/AccessInVirtualMethodTests.cs
+++ b/Tests/StaticAnalysis.Tests/Inheritance/AccessInVirtualMethodTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.Tests.Common;
+﻿using Microsoft.PSharp.Tests.Common;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/StaticAnalysis.Tests/Properties/codeanalysis.ruleset
+++ b/Tests/StaticAnalysis.Tests/Properties/codeanalysis.ruleset
@@ -140,7 +140,7 @@
     <Rule Id="SA1626" Action="Error" />
     <Rule Id="SA1628" Action="Error" />
     <Rule Id="SA1629" Action="Error" />
-    <Rule Id="SA1633" Action="Error" />
+    <Rule Id="SA1633" Action="None" />
     <Rule Id="SA1642" Action="Error" />
     <Rule Id="SA1649" Action="None" />
     <Rule Id="SA1652" Action="None" />

--- a/Tests/StaticAnalysis.Tests/Properties/stylecop.json
+++ b/Tests/StaticAnalysis.Tests/Properties/stylecop.json
@@ -2,13 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
   "settings": {
     "documentationRules": {
-      "companyName": "Microsoft Corporation",
-      "copyrightText": "{header}\nCopyright (c) {companyName}. All rights reserved.\n{licenseNameInfo}. {licenseFileInfo}.\n{header}",
-      "variables": {
-        "header": "------------------------------------------------------------------------------------------------",
-        "licenseNameInfo": "Licensed under the MIT License (MIT)",
-        "licenseFileInfo": "See License.txt in the repo root for license information"
-      },
       "xmlHeader": false,
       "documentInterfaces": true,
       "documentExposedElements": true,

--- a/Tests/StaticAnalysis.Tests/Setup.cs
+++ b/Tests/StaticAnalysis.Tests/Setup.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.StaticAnalysis.Tests
+﻿namespace Microsoft.PSharp.StaticAnalysis.Tests
 {
     internal static class Setup
     {

--- a/Tests/TestingServices.Tests/BaseTest.cs
+++ b/Tests/TestingServices.Tests/BaseTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;

--- a/Tests/TestingServices.Tests/Coverage/ActivityCoverageTest.cs
+++ b/Tests/TestingServices.Tests/Coverage/ActivityCoverageTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.IO;
+﻿using System.IO;
 using Microsoft.PSharp.TestingServices.Coverage;
 using Xunit;
 using Xunit.Abstractions;

--- a/Tests/TestingServices.Tests/EntryPoint/EntryPointEventSendingTest.cs
+++ b/Tests/TestingServices.Tests/EntryPoint/EntryPointEventSendingTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/TestingServices.Tests/EntryPoint/EntryPointMachineCreationTest.cs
+++ b/Tests/TestingServices.Tests/EntryPoint/EntryPointMachineCreationTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/TestingServices.Tests/EntryPoint/EntryPointMachineExecutionTest.cs
+++ b/Tests/TestingServices.Tests/EntryPoint/EntryPointMachineExecutionTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/TestingServices.Tests/EntryPoint/EntryPointRandomChoiceTest.cs
+++ b/Tests/TestingServices.Tests/EntryPoint/EntryPointRandomChoiceTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/TestingServices.Tests/EntryPoint/EntryPointThrowExceptionTest.cs
+++ b/Tests/TestingServices.Tests/EntryPoint/EntryPointThrowExceptionTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/TestingServices.Tests/Liveness/CycleDetection/CycleDetectionBasicTest.cs
+++ b/Tests/TestingServices.Tests/Liveness/CycleDetection/CycleDetectionBasicTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/TestingServices.Tests/Liveness/CycleDetection/CycleDetectionCounterTest.cs
+++ b/Tests/TestingServices.Tests/Liveness/CycleDetection/CycleDetectionCounterTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/TestingServices.Tests/Liveness/CycleDetection/CycleDetectionDefaultHandlerTest.cs
+++ b/Tests/TestingServices.Tests/Liveness/CycleDetection/CycleDetectionDefaultHandlerTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/TestingServices.Tests/Liveness/CycleDetection/CycleDetectionRandomChoiceTest.cs
+++ b/Tests/TestingServices.Tests/Liveness/CycleDetection/CycleDetectionRandomChoiceTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/TestingServices.Tests/Liveness/CycleDetection/CycleDetectionRingOfNodesTest.cs
+++ b/Tests/TestingServices.Tests/Liveness/CycleDetection/CycleDetectionRingOfNodesTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/TestingServices.Tests/Liveness/CycleDetection/FairNondet1Test.cs
+++ b/Tests/TestingServices.Tests/Liveness/CycleDetection/FairNondet1Test.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp.Utilities;
 using Xunit;
 using Xunit.Abstractions;

--- a/Tests/TestingServices.Tests/Liveness/CycleDetection/Liveness2Test.cs
+++ b/Tests/TestingServices.Tests/Liveness/CycleDetection/Liveness2Test.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp.Utilities;
 using Xunit;
 using Xunit.Abstractions;

--- a/Tests/TestingServices.Tests/Liveness/CycleDetection/Liveness3Test.cs
+++ b/Tests/TestingServices.Tests/Liveness/CycleDetection/Liveness3Test.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/TestingServices.Tests/Liveness/CycleDetection/Nondet1Test.cs
+++ b/Tests/TestingServices.Tests/Liveness/CycleDetection/Nondet1Test.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp.Utilities;
 using Xunit;
 using Xunit.Abstractions;

--- a/Tests/TestingServices.Tests/Liveness/CycleDetection/WarmStateBugTest.cs
+++ b/Tests/TestingServices.Tests/Liveness/CycleDetection/WarmStateBugTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp.Utilities;
 using Xunit;
 using Xunit.Abstractions;

--- a/Tests/TestingServices.Tests/Liveness/HotStateTest.cs
+++ b/Tests/TestingServices.Tests/Liveness/HotStateTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Microsoft.PSharp.Utilities;
 using Xunit;

--- a/Tests/TestingServices.Tests/Liveness/Liveness1Test.cs
+++ b/Tests/TestingServices.Tests/Liveness/Liveness1Test.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp.Utilities;
 using Xunit;
 using Xunit.Abstractions;

--- a/Tests/TestingServices.Tests/Liveness/Liveness2BugFoundTest.cs
+++ b/Tests/TestingServices.Tests/Liveness/Liveness2BugFoundTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp.Utilities;
 using Xunit;
 using Xunit.Abstractions;

--- a/Tests/TestingServices.Tests/Liveness/Liveness2LoopMachineTest.cs
+++ b/Tests/TestingServices.Tests/Liveness/Liveness2LoopMachineTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/TestingServices.Tests/Liveness/UnfairExecutionTest.cs
+++ b/Tests/TestingServices.Tests/Liveness/UnfairExecutionTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp.Utilities;
 using Xunit;
 using Xunit.Abstractions;

--- a/Tests/TestingServices.Tests/Liveness/WarmStateTest.cs
+++ b/Tests/TestingServices.Tests/Liveness/WarmStateTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp.Utilities;
 using Xunit;
 using Xunit.Abstractions;

--- a/Tests/TestingServices.Tests/Machines/EventHandling/ActionsFailTest.cs
+++ b/Tests/TestingServices.Tests/Machines/EventHandling/ActionsFailTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp.Utilities;
 using Xunit;
 using Xunit.Abstractions;

--- a/Tests/TestingServices.Tests/Machines/EventHandling/IgnoreEvent/IgnoreRaisedTest.cs
+++ b/Tests/TestingServices.Tests/Machines/EventHandling/IgnoreEvent/IgnoreRaisedTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;

--- a/Tests/TestingServices.Tests/Machines/EventHandling/MaxEventInstancesTest.cs
+++ b/Tests/TestingServices.Tests/Machines/EventHandling/MaxEventInstancesTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp.Utilities;
 using Xunit;
 using Xunit.Abstractions;

--- a/Tests/TestingServices.Tests/Machines/EventHandling/ReceiveEvent/ReceiveEventFailTest.cs
+++ b/Tests/TestingServices.Tests/Machines/EventHandling/ReceiveEvent/ReceiveEventFailTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Microsoft.PSharp.Utilities;
 using Xunit;

--- a/Tests/TestingServices.Tests/Machines/EventHandling/ReceiveEvent/ReceiveEventTest.cs
+++ b/Tests/TestingServices.Tests/Machines/EventHandling/ReceiveEvent/ReceiveEventTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Microsoft.PSharp.Utilities;
 using Xunit;

--- a/Tests/TestingServices.Tests/Machines/EventHandling/Wildcard/WildCardEventTest.cs
+++ b/Tests/TestingServices.Tests/Machines/EventHandling/Wildcard/WildCardEventTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/TestingServices.Tests/Machines/ExternalConcurrencyTest.cs
+++ b/Tests/TestingServices.Tests/Machines/ExternalConcurrencyTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/TestingServices.Tests/Machines/Features/AmbiguousEventHandlerTest.cs
+++ b/Tests/TestingServices.Tests/Machines/Features/AmbiguousEventHandlerTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/TestingServices.Tests/Machines/Features/CurrentStateTest.cs
+++ b/Tests/TestingServices.Tests/Machines/Features/CurrentStateTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp.Utilities;
 using Xunit;
 using Xunit.Abstractions;

--- a/Tests/TestingServices.Tests/Machines/Features/DuplicateEventHandlersTest.cs
+++ b/Tests/TestingServices.Tests/Machines/Features/DuplicateEventHandlersTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/TestingServices.Tests/Machines/Features/EventInheritanceTest.cs
+++ b/Tests/TestingServices.Tests/Machines/Features/EventInheritanceTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.PSharp.Runtime;
 using Xunit;
 using Xunit.Abstractions;

--- a/Tests/TestingServices.Tests/Machines/Features/GroupStateTest.cs
+++ b/Tests/TestingServices.Tests/Machines/Features/GroupStateTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/TestingServices.Tests/Machines/Features/MachineStateInheritanceTest.cs
+++ b/Tests/TestingServices.Tests/Machines/Features/MachineStateInheritanceTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/TestingServices.Tests/Machines/Features/MethodCallTest.cs
+++ b/Tests/TestingServices.Tests/Machines/Features/MethodCallTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/TestingServices.Tests/Machines/Features/NameofTest.cs
+++ b/Tests/TestingServices.Tests/Machines/Features/NameofTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Xunit;
+﻿using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.PSharp.TestingServices.Tests

--- a/Tests/TestingServices.Tests/Machines/Features/PopTest.cs
+++ b/Tests/TestingServices.Tests/Machines/Features/PopTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/TestingServices.Tests/Machines/Features/ReceiveTest.cs
+++ b/Tests/TestingServices.Tests/Machines/Features/ReceiveTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;

--- a/Tests/TestingServices.Tests/Machines/GenericMachineTest.cs
+++ b/Tests/TestingServices.Tests/Machines/GenericMachineTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/TestingServices.Tests/Machines/Integration/BubbleSortAlgorithmTest.cs
+++ b/Tests/TestingServices.Tests/Machines/Integration/BubbleSortAlgorithmTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;

--- a/Tests/TestingServices.Tests/Machines/Integration/ChainReplicationTest.cs
+++ b/Tests/TestingServices.Tests/Machines/Integration/ChainReplicationTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Xunit;
 using Xunit.Abstractions;

--- a/Tests/TestingServices.Tests/Machines/Integration/ChordTest.cs
+++ b/Tests/TestingServices.Tests/Machines/Integration/ChordTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;

--- a/Tests/TestingServices.Tests/Machines/Integration/DiningPhilosophersTest.cs
+++ b/Tests/TestingServices.Tests/Machines/Integration/DiningPhilosophersTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xunit;

--- a/Tests/TestingServices.Tests/Machines/Integration/FailureDetectorTest.cs
+++ b/Tests/TestingServices.Tests/Machines/Integration/FailureDetectorTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Xunit;
 using Xunit.Abstractions;

--- a/Tests/TestingServices.Tests/Machines/Integration/OneMachineIntegrationTests.cs
+++ b/Tests/TestingServices.Tests/Machines/Integration/OneMachineIntegrationTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/TestingServices.Tests/Machines/Integration/ProcessSchedulerTest.cs
+++ b/Tests/TestingServices.Tests/Machines/Integration/ProcessSchedulerTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xunit;

--- a/Tests/TestingServices.Tests/Machines/Integration/RaftTest.cs
+++ b/Tests/TestingServices.Tests/Machines/Integration/RaftTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Xunit;
 using Xunit.Abstractions;

--- a/Tests/TestingServices.Tests/Machines/Integration/ReplicatingStorageTest.cs
+++ b/Tests/TestingServices.Tests/Machines/Integration/ReplicatingStorageTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;

--- a/Tests/TestingServices.Tests/Machines/Integration/SendInterleavingsTest.cs
+++ b/Tests/TestingServices.Tests/Machines/Integration/SendInterleavingsTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 using Microsoft.PSharp.Utilities;
 

--- a/Tests/TestingServices.Tests/Machines/Integration/TwoMachineIntegrationTests.cs
+++ b/Tests/TestingServices.Tests/Machines/Integration/TwoMachineIntegrationTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp.Utilities;
 using Xunit;
 using Xunit.Abstractions;

--- a/Tests/TestingServices.Tests/Machines/MachineAsynchronyTest.cs
+++ b/Tests/TestingServices.Tests/Machines/MachineAsynchronyTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/TestingServices.Tests/Machines/SingleStateMachineTest.cs
+++ b/Tests/TestingServices.Tests/Machines/SingleStateMachineTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;

--- a/Tests/TestingServices.Tests/Machines/Transitions/GotoStateExitFailTest.cs
+++ b/Tests/TestingServices.Tests/Machines/Transitions/GotoStateExitFailTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/TestingServices.Tests/Machines/Transitions/GotoStateFailTest.cs
+++ b/Tests/TestingServices.Tests/Machines/Transitions/GotoStateFailTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/TestingServices.Tests/Machines/Transitions/GotoStateMultipleInActionFailTest.cs
+++ b/Tests/TestingServices.Tests/Machines/Transitions/GotoStateMultipleInActionFailTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/TestingServices.Tests/Machines/Transitions/GotoStateTest.cs
+++ b/Tests/TestingServices.Tests/Machines/Transitions/GotoStateTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Xunit;
+﻿using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.PSharp.TestingServices.Tests

--- a/Tests/TestingServices.Tests/Machines/Transitions/PushApiTest.cs
+++ b/Tests/TestingServices.Tests/Machines/Transitions/PushApiTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/TestingServices.Tests/Machines/Transitions/PushStateTest.cs
+++ b/Tests/TestingServices.Tests/Machines/Transitions/PushStateTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/TestingServices.Tests/Properties/codeanalysis.ruleset
+++ b/Tests/TestingServices.Tests/Properties/codeanalysis.ruleset
@@ -140,7 +140,7 @@
     <Rule Id="SA1626" Action="Error" />
     <Rule Id="SA1628" Action="Error" />
     <Rule Id="SA1629" Action="Error" />
-    <Rule Id="SA1633" Action="Error" />
+    <Rule Id="SA1633" Action="None" />
     <Rule Id="SA1642" Action="Error" />
     <Rule Id="SA1649" Action="None" />
     <Rule Id="SA1652" Action="None" />

--- a/Tests/TestingServices.Tests/Properties/stylecop.json
+++ b/Tests/TestingServices.Tests/Properties/stylecop.json
@@ -2,13 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
   "settings": {
     "documentationRules": {
-      "companyName": "Microsoft Corporation",
-      "copyrightText": "{header}\nCopyright (c) {companyName}. All rights reserved.\n{licenseNameInfo}. {licenseFileInfo}.\n{header}",
-      "variables": {
-        "header": "------------------------------------------------------------------------------------------------",
-        "licenseNameInfo": "Licensed under the MIT License (MIT)",
-        "licenseFileInfo": "See License.txt in the repo root for license information"
-      },
       "xmlHeader": false,
       "documentInterfaces": true,
       "documentExposedElements": true,

--- a/Tests/TestingServices.Tests/Runtime/CompletenessTest.cs
+++ b/Tests/TestingServices.Tests/Runtime/CompletenessTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/TestingServices.Tests/Runtime/CreateMachineIdFromNameTest.cs
+++ b/Tests/TestingServices.Tests/Runtime/CreateMachineIdFromNameTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/TestingServices.Tests/Runtime/CreateMachineWithIdTest.cs
+++ b/Tests/TestingServices.Tests/Runtime/CreateMachineWithIdTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Xunit;
+﻿using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.PSharp.TestingServices.Tests

--- a/Tests/TestingServices.Tests/Runtime/FairRandomTest.cs
+++ b/Tests/TestingServices.Tests/Runtime/FairRandomTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/TestingServices.Tests/Runtime/GetOperationGroupIdTest.cs
+++ b/Tests/TestingServices.Tests/Runtime/GetOperationGroupIdTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/TestingServices.Tests/Runtime/MustHandleEventTest.cs
+++ b/Tests/TestingServices.Tests/Runtime/MustHandleEventTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Xunit;
 using Xunit.Abstractions;

--- a/Tests/TestingServices.Tests/Runtime/OnEventDequeueOrHandledTest.cs
+++ b/Tests/TestingServices.Tests/Runtime/OnEventDequeueOrHandledTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Microsoft.PSharp.Runtime;
 using Xunit;

--- a/Tests/TestingServices.Tests/Runtime/OnEventDroppedTest.cs
+++ b/Tests/TestingServices.Tests/Runtime/OnEventDroppedTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/TestingServices.Tests/Runtime/OnEventUnhandledTest.cs
+++ b/Tests/TestingServices.Tests/Runtime/OnEventUnhandledTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Microsoft.PSharp.Runtime;
 using Xunit;

--- a/Tests/TestingServices.Tests/Runtime/OnExceptionTest.cs
+++ b/Tests/TestingServices.Tests/Runtime/OnExceptionTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Microsoft.PSharp.Runtime;
 using Xunit;

--- a/Tests/TestingServices.Tests/Runtime/OnHaltTest.cs
+++ b/Tests/TestingServices.Tests/Runtime/OnHaltTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/TestingServices.Tests/Runtime/OperationGroupingTest.cs
+++ b/Tests/TestingServices.Tests/Runtime/OperationGroupingTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;

--- a/Tests/TestingServices.Tests/Runtime/ReceivingExternalEventTest.cs
+++ b/Tests/TestingServices.Tests/Runtime/ReceivingExternalEventTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/TestingServices.Tests/Runtime/SendAndExecuteTest.cs
+++ b/Tests/TestingServices.Tests/Runtime/SendAndExecuteTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Microsoft.PSharp.Runtime;
 using Xunit;

--- a/Tests/TestingServices.Tests/SchedulingStrategies/DPORTest.cs
+++ b/Tests/TestingServices.Tests/SchedulingStrategies/DPORTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Microsoft.PSharp.Utilities;
 

--- a/Tests/TestingServices.Tests/Specifications/Monitors/GenericMonitorTest.cs
+++ b/Tests/TestingServices.Tests/Specifications/Monitors/GenericMonitorTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Xunit;
+﻿using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.PSharp.TestingServices.Tests

--- a/Tests/TestingServices.Tests/Specifications/Monitors/IdempotentRegisterMonitorTest.cs
+++ b/Tests/TestingServices.Tests/Specifications/Monitors/IdempotentRegisterMonitorTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/TestingServices.Tests/Specifications/Monitors/MachineMonitorIntegrationTests.cs
+++ b/Tests/TestingServices.Tests/Specifications/Monitors/MachineMonitorIntegrationTests.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp.Utilities;
 using Xunit;
 using Xunit.Abstractions;

--- a/Tests/TestingServices.Tests/Specifications/Monitors/MonitorStateInheritanceTest.cs
+++ b/Tests/TestingServices.Tests/Specifications/Monitors/MonitorStateInheritanceTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Xunit;
+﻿using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.PSharp.TestingServices.Tests

--- a/Tests/TestingServices.Tests/Specifications/Monitors/MonitorWildCardEventTest.cs
+++ b/Tests/TestingServices.Tests/Specifications/Monitors/MonitorWildCardEventTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Xunit;
+﻿using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.PSharp.TestingServices.Tests

--- a/Tests/TestingServices.Tests/Timers/BasicTimerTest.cs
+++ b/Tests/TestingServices.Tests/Timers/BasicTimerTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp.Timers;
 using Xunit;
 using Xunit.Abstractions;

--- a/Tests/TestingServices.Tests/Timers/StartStopTimerTest.cs
+++ b/Tests/TestingServices.Tests/Timers/StartStopTimerTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Microsoft.PSharp.Timers;
 using Xunit;

--- a/Tests/TestingServices.Tests/Timers/TimerLivenessTest.cs
+++ b/Tests/TestingServices.Tests/Timers/TimerLivenessTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp.Timers;
 using Xunit;
 using Xunit.Abstractions;

--- a/Tests/Tests.Common/BaseTest.cs
+++ b/Tests/Tests.Common/BaseTest.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;

--- a/Tests/Tests.Common/Properties/codeanalysis.ruleset
+++ b/Tests/Tests.Common/Properties/codeanalysis.ruleset
@@ -140,7 +140,7 @@
     <Rule Id="SA1626" Action="Error" />
     <Rule Id="SA1628" Action="Error" />
     <Rule Id="SA1629" Action="Error" />
-    <Rule Id="SA1633" Action="Error" />
+    <Rule Id="SA1633" Action="None" />
     <Rule Id="SA1642" Action="Error" />
     <Rule Id="SA1649" Action="None" />
     <Rule Id="SA1652" Action="None" />

--- a/Tests/Tests.Common/Properties/stylecop.json
+++ b/Tests/Tests.Common/Properties/stylecop.json
@@ -2,13 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
   "settings": {
     "documentationRules": {
-      "companyName": "Microsoft Corporation",
-      "copyrightText": "{header}\nCopyright (c) {companyName}. All rights reserved.\n{licenseNameInfo}. {licenseFileInfo}.\n{header}",
-      "variables": {
-        "header": "------------------------------------------------------------------------------------------------",
-        "licenseNameInfo": "Licensed under the MIT License (MIT)",
-        "licenseFileInfo": "See License.txt in the repo root for license information"
-      },
       "xmlHeader": false,
       "documentInterfaces": true,
       "documentExposedElements": true,

--- a/Tests/Tests.Common/TestConsoleLogger.cs
+++ b/Tests/Tests.Common/TestConsoleLogger.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp.IO;
 using Xunit.Abstractions;
 

--- a/Tests/Tests.Common/TestOutputLogger.cs
+++ b/Tests/Tests.Common/TestOutputLogger.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.IO;
+﻿using Microsoft.PSharp.IO;
 using Xunit.Abstractions;
 
 namespace Microsoft.PSharp.Tests.Common

--- a/Tests/Tests.Launcher/Program.cs
+++ b/Tests/Tests.Launcher/Program.cs
@@ -1,8 +1,3 @@
-// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/Tests/Tests.Launcher/Properties/codeanalysis.ruleset
+++ b/Tests/Tests.Launcher/Properties/codeanalysis.ruleset
@@ -140,7 +140,7 @@
     <Rule Id="SA1626" Action="Error" />
     <Rule Id="SA1628" Action="Error" />
     <Rule Id="SA1629" Action="Error" />
-    <Rule Id="SA1633" Action="Error" />
+    <Rule Id="SA1633" Action="None" />
     <Rule Id="SA1642" Action="Error" />
     <Rule Id="SA1649" Action="None" />
     <Rule Id="SA1652" Action="None" />

--- a/Tests/Tests.Launcher/Properties/stylecop.json
+++ b/Tests/Tests.Launcher/Properties/stylecop.json
@@ -2,13 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
   "settings": {
     "documentationRules": {
-      "companyName": "Microsoft Corporation",
-      "copyrightText": "{header}\nCopyright (c) {companyName}. All rights reserved.\n{licenseNameInfo}. {licenseFileInfo}.\n{header}",
-      "variables": {
-        "header": "------------------------------------------------------------------------------------------------",
-        "licenseNameInfo": "Licensed under the MIT License (MIT)",
-        "licenseFileInfo": "See License.txt in the repo root for license information"
-      },
       "xmlHeader": false,
       "documentInterfaces": true,
       "documentExposedElements": true,

--- a/Tools/Benchmarking/PSharpBenchmarkRunner/Program.cs
+++ b/Tools/Benchmarking/PSharpBenchmarkRunner/Program.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using BenchmarkDotNet.Running;
+﻿using BenchmarkDotNet.Running;
 using Microsoft.PSharp.Benchmarking.Creation;
 using Microsoft.PSharp.Benchmarking.Messaging;
 

--- a/Tools/Benchmarking/PSharpBenchmarkRunner/Properties/codeanalysis.ruleset
+++ b/Tools/Benchmarking/PSharpBenchmarkRunner/Properties/codeanalysis.ruleset
@@ -140,7 +140,7 @@
     <Rule Id="SA1626" Action="Error" />
     <Rule Id="SA1628" Action="Error" />
     <Rule Id="SA1629" Action="Error" />
-    <Rule Id="SA1633" Action="Error" />
+    <Rule Id="SA1633" Action="None" />
     <Rule Id="SA1642" Action="Error" />
     <Rule Id="SA1649" Action="None" />
     <Rule Id="SA1652" Action="None" />

--- a/Tools/Benchmarking/PSharpBenchmarkRunner/Properties/stylecop.json
+++ b/Tools/Benchmarking/PSharpBenchmarkRunner/Properties/stylecop.json
@@ -2,13 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
   "settings": {
     "documentationRules": {
-      "companyName": "Microsoft Corporation",
-      "copyrightText": "{header}\nCopyright (c) {companyName}. All rights reserved.\n{licenseNameInfo}. {licenseFileInfo}.\n{header}",
-      "variables": {
-        "header": "------------------------------------------------------------------------------------------------",
-        "licenseNameInfo": "Licensed under the MIT License (MIT)",
-        "licenseFileInfo": "See License.txt in the repo root for license information"
-      },
       "xmlHeader": false,
       "documentInterfaces": true,
       "documentExposedElements": true,

--- a/Tools/Benchmarking/PSharpBenchmarkRunner/Tests/Creation/MachineCreationThroughputBenchmark.cs
+++ b/Tools/Benchmarking/PSharpBenchmarkRunner/Tests/Creation/MachineCreationThroughputBenchmark.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Microsoft.PSharp.Runtime;

--- a/Tools/Benchmarking/PSharpBenchmarkRunner/Tests/Messaging/DequeueEventThroughputBenchmark.cs
+++ b/Tools/Benchmarking/PSharpBenchmarkRunner/Tests/Messaging/DequeueEventThroughputBenchmark.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Microsoft.PSharp.Runtime;
 

--- a/Tools/Benchmarking/PSharpBenchmarkRunner/Tests/Messaging/ExchangeEventLatencyBenchmark.cs
+++ b/Tools/Benchmarking/PSharpBenchmarkRunner/Tests/Messaging/ExchangeEventLatencyBenchmark.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Microsoft.PSharp.Runtime;
 

--- a/Tools/Benchmarking/PSharpBenchmarkRunner/Tests/Messaging/SendEventThroughputBenchmark.cs
+++ b/Tools/Benchmarking/PSharpBenchmarkRunner/Tests/Messaging/SendEventThroughputBenchmark.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Microsoft.PSharp.Runtime;

--- a/Tools/Compilation/Compiler/CompilationProcess.cs
+++ b/Tools/Compilation/Compiler/CompilationProcess.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.IO;
+﻿using Microsoft.PSharp.IO;
 using Microsoft.PSharp.LanguageServices.Compilation;
 using Microsoft.PSharp.Utilities;
 

--- a/Tools/Compilation/Compiler/ParsingProcess.cs
+++ b/Tools/Compilation/Compiler/ParsingProcess.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.IO;
+﻿using Microsoft.PSharp.IO;
 using Microsoft.PSharp.LanguageServices.Compilation;
 using Microsoft.PSharp.LanguageServices.Parsing;
 

--- a/Tools/Compilation/Compiler/Program.cs
+++ b/Tools/Compilation/Compiler/Program.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Reflection;
 
 using Microsoft.PSharp.IO;

--- a/Tools/Compilation/Compiler/Properties/codeanalysis.ruleset
+++ b/Tools/Compilation/Compiler/Properties/codeanalysis.ruleset
@@ -140,7 +140,7 @@
     <Rule Id="SA1626" Action="Error" />
     <Rule Id="SA1628" Action="Error" />
     <Rule Id="SA1629" Action="Error" />
-    <Rule Id="SA1633" Action="Error" />
+    <Rule Id="SA1633" Action="None" />
     <Rule Id="SA1642" Action="Error" />
     <Rule Id="SA1649" Action="None" />
     <Rule Id="SA1652" Action="None" />

--- a/Tools/Compilation/Compiler/Properties/stylecop.json
+++ b/Tools/Compilation/Compiler/Properties/stylecop.json
@@ -2,13 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
   "settings": {
     "documentationRules": {
-      "companyName": "Microsoft Corporation",
-      "copyrightText": "{header}\nCopyright (c) {companyName}. All rights reserved.\n{licenseNameInfo}. {licenseFileInfo}.\n{header}",
-      "variables": {
-        "header": "------------------------------------------------------------------------------------------------",
-        "licenseNameInfo": "Licensed under the MIT License (MIT)",
-        "licenseFileInfo": "See License.txt in the repo root for license information"
-      },
       "xmlHeader": false,
       "documentInterfaces": true,
       "documentExposedElements": true,

--- a/Tools/Compilation/Compiler/RewritingProcess.cs
+++ b/Tools/Compilation/Compiler/RewritingProcess.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.IO;
+﻿using Microsoft.PSharp.IO;
 using Microsoft.PSharp.LanguageServices.Compilation;
 using Microsoft.PSharp.LanguageServices.Parsing;
 

--- a/Tools/Compilation/Compiler/StaticAnalysisProcess.cs
+++ b/Tools/Compilation/Compiler/StaticAnalysisProcess.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.IO;
+﻿using Microsoft.PSharp.IO;
 using Microsoft.PSharp.LanguageServices.Compilation;
 using Microsoft.PSharp.StaticAnalysis;
 

--- a/Tools/Compilation/Compiler/Utilities/CompilerCommandLineOptions.cs
+++ b/Tools/Compilation/Compiler/Utilities/CompilerCommandLineOptions.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.IO;
+﻿using Microsoft.PSharp.IO;
 
 namespace Microsoft.PSharp.Utilities
 {

--- a/Tools/Compilation/SyntaxRewriter/Program.cs
+++ b/Tools/Compilation/SyntaxRewriter/Program.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.IO;
 
 using Microsoft.Build.Framework;

--- a/Tools/Compilation/SyntaxRewriter/Properties/codeanalysis.ruleset
+++ b/Tools/Compilation/SyntaxRewriter/Properties/codeanalysis.ruleset
@@ -140,7 +140,7 @@
     <Rule Id="SA1626" Action="Error" />
     <Rule Id="SA1628" Action="Error" />
     <Rule Id="SA1629" Action="Error" />
-    <Rule Id="SA1633" Action="Error" />
+    <Rule Id="SA1633" Action="None" />
     <Rule Id="SA1642" Action="Error" />
     <Rule Id="SA1649" Action="None" />
     <Rule Id="SA1652" Action="None" />

--- a/Tools/Compilation/SyntaxRewriter/Properties/stylecop.json
+++ b/Tools/Compilation/SyntaxRewriter/Properties/stylecop.json
@@ -2,13 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
   "settings": {
     "documentationRules": {
-      "companyName": "Microsoft Corporation",
-      "copyrightText": "{header}\nCopyright (c) {companyName}. All rights reserved.\n{licenseNameInfo}. {licenseFileInfo}.\n{header}",
-      "variables": {
-        "header": "------------------------------------------------------------------------------------------------",
-        "licenseNameInfo": "Licensed under the MIT License (MIT)",
-        "licenseFileInfo": "See License.txt in the repo root for license information"
-      },
       "xmlHeader": false,
       "documentInterfaces": true,
       "documentExposedElements": true,

--- a/Tools/Compilation/SyntaxRewriter/Rewriter.cs
+++ b/Tools/Compilation/SyntaxRewriter/Rewriter.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.IO;
 
 using Microsoft.Build.Framework;

--- a/Tools/Compilation/SyntaxRewriterProcess/Program.cs
+++ b/Tools/Compilation/SyntaxRewriterProcess/Program.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.IO;
+﻿using Microsoft.PSharp.IO;
 using Microsoft.PSharp.LanguageServices;
 using Microsoft.PSharp.LanguageServices.Compilation;
 using Microsoft.PSharp.LanguageServices.Parsing;

--- a/Tools/Compilation/SyntaxRewriterProcess/Properties/codeanalysis.ruleset
+++ b/Tools/Compilation/SyntaxRewriterProcess/Properties/codeanalysis.ruleset
@@ -140,7 +140,7 @@
     <Rule Id="SA1626" Action="Error" />
     <Rule Id="SA1628" Action="Error" />
     <Rule Id="SA1629" Action="Error" />
-    <Rule Id="SA1633" Action="Error" />
+    <Rule Id="SA1633" Action="None" />
     <Rule Id="SA1642" Action="Error" />
     <Rule Id="SA1649" Action="None" />
     <Rule Id="SA1652" Action="None" />

--- a/Tools/Compilation/SyntaxRewriterProcess/Properties/stylecop.json
+++ b/Tools/Compilation/SyntaxRewriterProcess/Properties/stylecop.json
@@ -2,13 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
   "settings": {
     "documentationRules": {
-      "companyName": "Microsoft Corporation",
-      "copyrightText": "{header}\nCopyright (c) {companyName}. All rights reserved.\n{licenseNameInfo}. {licenseFileInfo}.\n{header}",
-      "variables": {
-        "header": "------------------------------------------------------------------------------------------------",
-        "licenseNameInfo": "Licensed under the MIT License (MIT)",
-        "licenseFileInfo": "See License.txt in the repo root for license information"
-      },
       "xmlHeader": false,
       "documentInterfaces": true,
       "documentExposedElements": true,

--- a/Tools/Compilation/SyntaxRewriterProcess/RewriterAsSeparateProcess.cs
+++ b/Tools/Compilation/SyntaxRewriterProcess/RewriterAsSeparateProcess.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Diagnostics;
+﻿using System.Diagnostics;
 
 using Microsoft.Build.Framework;
 using Microsoft.PSharp.IO;

--- a/Tools/Testing/CoverageReportMerger/Program.cs
+++ b/Tools/Testing/CoverageReportMerger/Program.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.Serialization;

--- a/Tools/Testing/CoverageReportMerger/Properties/codeanalysis.ruleset
+++ b/Tools/Testing/CoverageReportMerger/Properties/codeanalysis.ruleset
@@ -140,7 +140,7 @@
     <Rule Id="SA1626" Action="Error" />
     <Rule Id="SA1628" Action="Error" />
     <Rule Id="SA1629" Action="Error" />
-    <Rule Id="SA1633" Action="Error" />
+    <Rule Id="SA1633" Action="None" />
     <Rule Id="SA1642" Action="Error" />
     <Rule Id="SA1649" Action="None" />
     <Rule Id="SA1652" Action="None" />

--- a/Tools/Testing/CoverageReportMerger/Properties/stylecop.json
+++ b/Tools/Testing/CoverageReportMerger/Properties/stylecop.json
@@ -2,13 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
   "settings": {
     "documentationRules": {
-      "companyName": "Microsoft Corporation",
-      "copyrightText": "{header}\nCopyright (c) {companyName}. All rights reserved.\n{licenseNameInfo}. {licenseFileInfo}.\n{header}",
-      "variables": {
-        "header": "------------------------------------------------------------------------------------------------",
-        "licenseNameInfo": "Licensed under the MIT License (MIT)",
-        "licenseFileInfo": "See License.txt in the repo root for license information"
-      },
       "xmlHeader": false,
       "documentInterfaces": true,
       "documentExposedElements": true,

--- a/Tools/Testing/Replayer/Program.cs
+++ b/Tools/Testing/Replayer/Program.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 using Microsoft.PSharp.IO;
 using Microsoft.PSharp.Utilities;

--- a/Tools/Testing/Replayer/Properties/codeanalysis.ruleset
+++ b/Tools/Testing/Replayer/Properties/codeanalysis.ruleset
@@ -140,7 +140,7 @@
     <Rule Id="SA1626" Action="Error" />
     <Rule Id="SA1628" Action="Error" />
     <Rule Id="SA1629" Action="Error" />
-    <Rule Id="SA1633" Action="Error" />
+    <Rule Id="SA1633" Action="None" />
     <Rule Id="SA1642" Action="Error" />
     <Rule Id="SA1649" Action="None" />
     <Rule Id="SA1652" Action="None" />

--- a/Tools/Testing/Replayer/Properties/stylecop.json
+++ b/Tools/Testing/Replayer/Properties/stylecop.json
@@ -2,13 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
   "settings": {
     "documentationRules": {
-      "companyName": "Microsoft Corporation",
-      "copyrightText": "{header}\nCopyright (c) {companyName}. All rights reserved.\n{licenseNameInfo}. {licenseFileInfo}.\n{header}",
-      "variables": {
-        "header": "------------------------------------------------------------------------------------------------",
-        "licenseNameInfo": "Licensed under the MIT License (MIT)",
-        "licenseFileInfo": "See License.txt in the repo root for license information"
-      },
       "xmlHeader": false,
       "documentInterfaces": true,
       "documentExposedElements": true,

--- a/Tools/Testing/Replayer/ReplayingProcess.cs
+++ b/Tools/Testing/Replayer/ReplayingProcess.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.IO;
+﻿using Microsoft.PSharp.IO;
 using Microsoft.PSharp.TestingServices;
 
 namespace Microsoft.PSharp

--- a/Tools/Testing/Replayer/Utilities/ReplayerCommandLineOptions.cs
+++ b/Tools/Testing/Replayer/Utilities/ReplayerCommandLineOptions.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.IO;
+﻿using Microsoft.PSharp.IO;
 
 namespace Microsoft.PSharp.Utilities
 {

--- a/Tools/Testing/Tester/Instrumentation/CodeCoverageInstrumentation.cs
+++ b/Tools/Testing/Tester/Instrumentation/CodeCoverageInstrumentation.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-#if NET46
+﻿#if NET46
 using System;
 using System.Collections.Generic;
 using System.Configuration;

--- a/Tools/Testing/Tester/Interfaces/ITestingProcess.cs
+++ b/Tools/Testing/Tester/Interfaces/ITestingProcess.cs
@@ -1,11 +1,5 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-#if NET46
+﻿#if NET46
 using System.ServiceModel;
-
 using Microsoft.PSharp.TestingServices.Coverage;
 #endif
 

--- a/Tools/Testing/Tester/Interfaces/ITestingProcessScheduler.cs
+++ b/Tools/Testing/Tester/Interfaces/ITestingProcessScheduler.cs
@@ -1,11 +1,5 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-#if NET46
+﻿#if NET46
 using System.ServiceModel;
-
 using Microsoft.PSharp.TestingServices.Coverage;
 #endif
 

--- a/Tools/Testing/Tester/Monitoring/CodeCoverageMonitor.cs
+++ b/Tools/Testing/Tester/Monitoring/CodeCoverageMonitor.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-#if NET46
+﻿#if NET46
 using System;
 using System.Diagnostics;
 using System.IO;

--- a/Tools/Testing/Tester/Program.cs
+++ b/Tools/Testing/Tester/Program.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 using Microsoft.PSharp.IO;
 using Microsoft.PSharp.TestingServices;

--- a/Tools/Testing/Tester/Properties/codeanalysis.ruleset
+++ b/Tools/Testing/Tester/Properties/codeanalysis.ruleset
@@ -140,7 +140,7 @@
     <Rule Id="SA1626" Action="Error" />
     <Rule Id="SA1628" Action="Error" />
     <Rule Id="SA1629" Action="Error" />
-    <Rule Id="SA1633" Action="Error" />
+    <Rule Id="SA1633" Action="None" />
     <Rule Id="SA1642" Action="Error" />
     <Rule Id="SA1649" Action="None" />
     <Rule Id="SA1652" Action="None" />

--- a/Tools/Testing/Tester/Properties/stylecop.json
+++ b/Tools/Testing/Tester/Properties/stylecop.json
@@ -2,13 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
   "settings": {
     "documentationRules": {
-      "companyName": "Microsoft Corporation",
-      "copyrightText": "{header}\nCopyright (c) {companyName}. All rights reserved.\n{licenseNameInfo}. {licenseFileInfo}.\n{header}",
-      "variables": {
-        "header": "------------------------------------------------------------------------------------------------",
-        "licenseNameInfo": "Licensed under the MIT License (MIT)",
-        "licenseFileInfo": "See License.txt in the repo root for license information"
-      },
       "xmlHeader": false,
       "documentInterfaces": true,
       "documentExposedElements": true,

--- a/Tools/Testing/Tester/Scheduling/TestingProcessScheduler.cs
+++ b/Tools/Testing/Tester/Scheduling/TestingProcessScheduler.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/Tools/Testing/Tester/Testing/TestingPortfolio.cs
+++ b/Tools/Testing/Tester/Testing/TestingPortfolio.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.Utilities;
+﻿using Microsoft.PSharp.Utilities;
 
 namespace Microsoft.PSharp.TestingServices
 {

--- a/Tools/Testing/Tester/Testing/TestingProcess.cs
+++ b/Tools/Testing/Tester/Testing/TestingProcess.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;

--- a/Tools/Testing/Tester/Testing/TestingProcessFactory.cs
+++ b/Tools/Testing/Tester/Testing/TestingProcessFactory.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Reflection;
 using System.Text;
 

--- a/Tools/Testing/Tester/Utilities/DependencyGraph.cs
+++ b/Tools/Testing/Tester/Utilities/DependencyGraph.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-#if NET46
+﻿#if NET46
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Tools/Testing/Tester/Utilities/DependentAssemblyLoader.cs
+++ b/Tools/Testing/Tester/Utilities/DependentAssemblyLoader.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-#if NET46
+﻿#if NET46
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/Tools/Testing/Tester/Utilities/ExitCode.cs
+++ b/Tools/Testing/Tester/Utilities/ExitCode.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.TestingServices
+﻿namespace Microsoft.PSharp.TestingServices
 {
     /// <summary>
     /// The exit code returned by the tester.

--- a/Tools/Testing/Tester/Utilities/Reporter.cs
+++ b/Tools/Testing/Tester/Utilities/Reporter.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.IO;
+﻿using System.IO;
 using System.Runtime.Serialization;
 
 using Microsoft.PSharp.IO;

--- a/Tools/Testing/Tester/Utilities/TesterCommandLineOptions.cs
+++ b/Tools/Testing/Tester/Utilities/TesterCommandLineOptions.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using Microsoft.PSharp.IO;
 
 namespace Microsoft.PSharp.Utilities

--- a/Tools/VSCode/msr-vscode-psharp/src/hoverProvider.ts
+++ b/Tools/VSCode/msr-vscode-psharp/src/hoverProvider.ts
@@ -1,7 +1,3 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
-
 'use strict';
 
 import vscode = require('vscode');

--- a/Tools/VSCode/msr-vscode-psharp/src/main.ts
+++ b/Tools/VSCode/msr-vscode-psharp/src/main.ts
@@ -1,7 +1,3 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
-
 'use strict';
 
 import vscode = require('vscode');

--- a/Tools/VSCode/msr-vscode-psharp/src/utils.ts
+++ b/Tools/VSCode/msr-vscode-psharp/src/utils.ts
@@ -1,7 +1,3 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
-
 import vscode = require('vscode');
 import { errorDiagnosticCollection, warningDiagnosticCollection } from './main';
 

--- a/Tools/VisualStudio/ClassLibraryProjectTemplate/AssemblyInfo.cs
+++ b/Tools/VisualStudio/ClassLibraryProjectTemplate/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("$registeredorganization$")]
 [assembly: AssemblyProduct("$projectname$")]
-[assembly: AssemblyCopyright("Copyright © $registeredorganization$ $year$")]
+[assembly: AssemblyCopyright("Copyright © Microsoft Corporation. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Tools/VisualStudio/ClassLibraryProjectTemplate/Properties/AssemblyInfo.cs
+++ b/Tools/VisualStudio/ClassLibraryProjectTemplate/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("ClassLibraryProjectTemplate")]
-[assembly: AssemblyCopyright("Copyright © Microsoft 2017")]
+[assembly: AssemblyCopyright("Copyright © Microsoft Corporation. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Tools/VisualStudio/ConsoleAppProjectTemplate/AssemblyInfo.cs
+++ b/Tools/VisualStudio/ConsoleAppProjectTemplate/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("$registeredorganization$")]
 [assembly: AssemblyProduct("$projectname$")]
-[assembly: AssemblyCopyright("Copyright © $registeredorganization$ $year$")]
+[assembly: AssemblyCopyright("Copyright © Microsoft Corporation. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Tools/VisualStudio/ConsoleAppProjectTemplate/Properties/AssemblyInfo.cs
+++ b/Tools/VisualStudio/ConsoleAppProjectTemplate/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("ConsoleAppProjectTemplate")]
-[assembly: AssemblyCopyright("Copyright © Microsoft 2017")]
+[assembly: AssemblyCopyright("Copyright © Microsoft Corporation. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Tools/VisualStudio/MachineFileItemTemplate/Properties/AssemblyInfo.cs
+++ b/Tools/VisualStudio/MachineFileItemTemplate/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("MachineFileItemTemplate")]
-[assembly: AssemblyCopyright("Copyright © Microsoft 2017")]
+[assembly: AssemblyCopyright("Copyright © Microsoft Corporation. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Tools/VisualStudio/VisualStudio/BraceMatching/BraceMatchingTagger.cs
+++ b/Tools/VisualStudio/VisualStudio/BraceMatching/BraceMatchingTagger.cs
@@ -1,9 +1,12 @@
 ﻿using System;
 using System.Linq;
 using System.Collections.Generic;
+using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Tagging;
+using Microsoft.VisualStudio.Utilities;
 using Microsoft.PSharp.VisualStudio.Outlining;
 
 namespace Microsoft.PSharp.VisualStudio
@@ -55,8 +58,8 @@ namespace Microsoft.PSharp.VisualStudio
 
         public IEnumerable<ITagSpan<TextMarkerTag>> GetTags(NormalizedSnapshotSpanCollection spans)
         {
-            // Do nothing if there is no content in the buffer, the current SnapshotPoint is not initialized, or we're at the end of the buffer.
-            if (spans.Count == 0 || !CurrentChar.HasValue || CurrentChar.Value.Position >= CurrentChar.Value.Snapshot.Length)
+            // Do nothing if there is no content in the buffer, the current SnapshotPoint is not initialized
+            if (spans.Count == 0 || !CurrentChar.HasValue)
             {
                 yield break;
             }
@@ -67,7 +70,11 @@ namespace Microsoft.PSharp.VisualStudio
                 : CurrentChar.Value.TranslateTo(spans[0].Snapshot, PointTrackingMode.Positive);
 
             // If the current char is an opening char, stay on it. Otherwise, back up one to see if the previous char is the close char.
-            char currentChar = currentCharPoint.GetChar();
+            char currentChar = '\0';
+            if (CurrentChar.Value.Position < CurrentChar.Value.Snapshot.Length)
+            {
+                currentChar = currentCharPoint.GetChar();
+            }
             var currentLine = currentCharPoint.GetContainingLine();
 
             bool isBoundaryChar(out bool isOpen)
@@ -124,12 +131,24 @@ namespace Microsoft.PSharp.VisualStudio
                 TagSpan<TextMarkerTag> getTag(int lineNumber, int offset)
                 {
                     var line = currentCharPoint.Snapshot.GetLineFromLineNumber(lineNumber);
-                    return new TagSpan<TextMarkerTag>(new SnapshotSpan(line.Start + offset, 1), new TextMarkerTag("blue"));
+                    return new TagSpan<TextMarkerTag>(new SnapshotSpan(line.Start + offset, 1), BraceHighlightTag);
                 }
 
                 yield return getTag(foundRegion.StartLineNumber, foundRegion.StartOffset);
                 yield return getTag(foundRegion.EndLineNumber, foundRegion.EndOffset - 1); // -1 here because EndOffset is after the close char
             }
         }
+
+        public static readonly TextMarkerTag BraceHighlightTag = new TextMarkerTag(ClassificationTypeDefinitions.BraceMatchingName);
+    }
+
+    internal sealed class ClassificationTypeDefinitions
+    {
+        public const string BraceMatchingName = "brace matching";
+
+        [Export]
+        [Name(BraceMatchingName)]
+        [BaseDefinition("formal language")]
+        internal readonly ClassificationTypeDefinition BraceMatching;
     }
 }

--- a/Tools/VisualStudio/VisualStudio/BraceMatching/BraceMatchingTagger.cs
+++ b/Tools/VisualStudio/VisualStudio/BraceMatching/BraceMatchingTagger.cs
@@ -142,13 +142,4 @@ namespace Microsoft.PSharp.VisualStudio
         public static readonly TextMarkerTag BraceHighlightTag = new TextMarkerTag(ClassificationTypeDefinitions.BraceMatchingName);
     }
 
-    internal sealed class ClassificationTypeDefinitions
-    {
-        public const string BraceMatchingName = "brace matching";
-
-        [Export]
-        [Name(BraceMatchingName)]
-        [BaseDefinition("formal language")]
-        internal readonly ClassificationTypeDefinition BraceMatching;
-    }
 }

--- a/Tools/VisualStudio/VisualStudio/BraceMatching/BraceMatchingTagger.cs
+++ b/Tools/VisualStudio/VisualStudio/BraceMatching/BraceMatchingTagger.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Linq;
 using System.Collections.Generic;
 using Microsoft.VisualStudio.Text;

--- a/Tools/VisualStudio/VisualStudio/BraceMatching/BraceMatchingTaggerProvider.cs
+++ b/Tools/VisualStudio/VisualStudio/BraceMatching/BraceMatchingTaggerProvider.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.VisualStudio.Text;
+﻿using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Tagging;
 using Microsoft.VisualStudio.Utilities;

--- a/Tools/VisualStudio/VisualStudio/Classification/ClassificationFormats.cs
+++ b/Tools/VisualStudio/VisualStudio/Classification/ClassificationFormats.cs
@@ -1,56 +1,48 @@
 ﻿using System.ComponentModel.Composition;
 using System.Windows.Media;
-
+using Microsoft.CodeAnalysis.Classification;
+using Microsoft.VisualStudio.Language.StandardClassification;
 using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.PSharp.VisualStudio
 {
-    [Export(typeof(EditorFormatDefinition))]
-    [ClassificationType(ClassificationTypeNames = "PSharp.Keyword")]
-    [Name("PSharp.Keyword")]
-    [UserVisible(true)]
-    internal sealed class PSharpKeywordFormat : ClassificationFormatDefinition
+    internal sealed class ClassificationTypeDefinitions
     {
-        public PSharpKeywordFormat()
-        {
-            this.ForegroundColor = Colors.CornflowerBlue;
-        }
-    }
+        [Export]
+        [ClassificationType(ClassificationTypeNames = "PSharp.Keyword")]
+        [Name("PSharp.Keyword")]
+        [UserVisible(true)]
+        [BaseDefinition(PredefinedClassificationTypeNames.Keyword)]
+        internal readonly ClassificationTypeDefinition PSharpKeywordFormat;
 
-    [Export(typeof(EditorFormatDefinition))]
-    [ClassificationType(ClassificationTypeNames = "PSharp.TypeIdentifier")]
-    [Name("PSharp.TypeIdentifier")]
-    [UserVisible(true)]
-    internal sealed class PSharpTypeIdentifierFormat : ClassificationFormatDefinition
-    {
-        public PSharpTypeIdentifierFormat()
-        {
-            this.ForegroundColor = Colors.MediumAquamarine;
-        }
-    }
+        [Export]
+        [ClassificationType(ClassificationTypeNames = "PSharp.TypeIdentifier")]
+        [Name("PSharp.TypeIdentifier")]
+        [UserVisible(true)]
+        [BaseDefinition(PredefinedClassificationTypeNames.Identifier)]
+        internal readonly ClassificationTypeDefinition PSharpTypeIdentifierFormat;
 
-    [Export(typeof(EditorFormatDefinition))]
-    [ClassificationType(ClassificationTypeNames = "PSharp.Comment")]
-    [Name("PSharp.Comment")]
-    [UserVisible(true)]
-    internal sealed class PSharpCommentFormat : ClassificationFormatDefinition
-    {
-        public PSharpCommentFormat()
-        {
-            this.ForegroundColor = Colors.SeaGreen;
-        }
-    }
+        [Export]
+        [ClassificationType(ClassificationTypeNames = "PSharp.Comment")]
+        [Name("PSharp.Comment")]
+        [UserVisible(true)]
+        [BaseDefinition(PredefinedClassificationTypeNames.Comment)]
+        internal readonly ClassificationTypeDefinition PSharpCommentFormat;
 
-    [Export(typeof(EditorFormatDefinition))]
-    [ClassificationType(ClassificationTypeNames = "PSharp.QuotedString")]
-    [Name("PSharp.QuotedString")]
-    [UserVisible(true)]
-    internal sealed class PSharpQuotedStringFormat : ClassificationFormatDefinition
-    {
-        public PSharpQuotedStringFormat()
-        {
-            this.ForegroundColor = Colors.Brown;
-        }
+        [Export]
+        [ClassificationType(ClassificationTypeNames = "PSharp.QuotedString")]
+        [Name("PSharp.QuotedString")]
+        [UserVisible(true)]
+        [BaseDefinition(PredefinedClassificationTypeNames.String)]
+        internal readonly ClassificationTypeDefinition PSharpQuotedStringFormat;
+        
+        [Export]
+        [Name(BraceMatchingName)]
+        [BaseDefinition(PredefinedClassificationTypeNames.FormalLanguage)]
+        internal readonly ClassificationTypeDefinition BraceMatching;
+
+
+        internal const string BraceMatchingName = "brace matching";
     }
 }

--- a/Tools/VisualStudio/VisualStudio/Classification/ClassificationFormats.cs
+++ b/Tools/VisualStudio/VisualStudio/Classification/ClassificationFormats.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.ComponentModel.Composition;
+﻿using System.ComponentModel.Composition;
 using System.Windows.Media;
 
 using Microsoft.VisualStudio.Text.Classification;

--- a/Tools/VisualStudio/VisualStudio/Classification/ClassificationTypes.cs
+++ b/Tools/VisualStudio/VisualStudio/Classification/ClassificationTypes.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.ComponentModel.Composition;
+﻿using System.ComponentModel.Composition;
 
 using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.Utilities;

--- a/Tools/VisualStudio/VisualStudio/Classification/PSharpClassifier.cs
+++ b/Tools/VisualStudio/VisualStudio/Classification/PSharpClassifier.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 using Microsoft.VisualStudio.Text;

--- a/Tools/VisualStudio/VisualStudio/Classification/PSharpClassifierProvider.cs
+++ b/Tools/VisualStudio/VisualStudio/Classification/PSharpClassifierProvider.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.ComponentModel.Composition;
+﻿using System.ComponentModel.Composition;
 
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Classification;

--- a/Tools/VisualStudio/VisualStudio/ContentTypeDefinitions.cs
+++ b/Tools/VisualStudio/VisualStudio/ContentTypeDefinitions.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.ComponentModel.Composition;
+﻿using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.PSharp.VisualStudio

--- a/Tools/VisualStudio/VisualStudio/Indentation/Indent.cs
+++ b/Tools/VisualStudio/VisualStudio/Indentation/Indent.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;

--- a/Tools/VisualStudio/VisualStudio/Indentation/SmartIndentProvider.cs
+++ b/Tools/VisualStudio/VisualStudio/Indentation/SmartIndentProvider.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.ComponentModel.Composition;
+﻿using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Utilities;
 

--- a/Tools/VisualStudio/VisualStudio/Intellisense/CompletionCommandHandler.cs
+++ b/Tools/VisualStudio/VisualStudio/Intellisense/CompletionCommandHandler.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Language.Intellisense;

--- a/Tools/VisualStudio/VisualStudio/Intellisense/CompletionHandlerProvider.cs
+++ b/Tools/VisualStudio/VisualStudio/Intellisense/CompletionHandlerProvider.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.ComponentModel.Composition;
+﻿using System.ComponentModel.Composition;
 
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.Language.Intellisense;

--- a/Tools/VisualStudio/VisualStudio/Intellisense/CompletionSource.cs
+++ b/Tools/VisualStudio/VisualStudio/Intellisense/CompletionSource.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Tools/VisualStudio/VisualStudio/Intellisense/CompletionSourceProvider.cs
+++ b/Tools/VisualStudio/VisualStudio/Intellisense/CompletionSourceProvider.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.ComponentModel.Composition;
+﻿using System.ComponentModel.Composition;
 
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;

--- a/Tools/VisualStudio/VisualStudio/Intellisense/ErrorFixSuggestedAction.cs
+++ b/Tools/VisualStudio/VisualStudio/Intellisense/ErrorFixSuggestedAction.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Tools/VisualStudio/VisualStudio/Intellisense/Keywords.cs
+++ b/Tools/VisualStudio/VisualStudio/Intellisense/Keywords.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 

--- a/Tools/VisualStudio/VisualStudio/Intellisense/SuggestedActionsSource.cs
+++ b/Tools/VisualStudio/VisualStudio/Intellisense/SuggestedActionsSource.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;

--- a/Tools/VisualStudio/VisualStudio/Intellisense/SuggestedActionsSourceProvider.cs
+++ b/Tools/VisualStudio/VisualStudio/Intellisense/SuggestedActionsSourceProvider.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.ComponentModel.Composition;
+﻿using System.ComponentModel.Composition;
 
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;

--- a/Tools/VisualStudio/VisualStudio/Properties/AssemblyInfo.cs
+++ b/Tools/VisualStudio/VisualStudio/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Microsoft.PSharp.VisualStudio")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright © Microsoft Corporation. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Tools/VisualStudio/VisualStudio/RegionParser.cs
+++ b/Tools/VisualStudio/VisualStudio/RegionParser.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.VisualStudio.Text;
+﻿using Microsoft.VisualStudio.Text;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/Tools/VisualStudio/VisualStudio/Tagging/PSharpTagProvider.cs
+++ b/Tools/VisualStudio/VisualStudio/Tagging/PSharpTagProvider.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.ComponentModel.Composition;
 
 using Microsoft.VisualStudio.Text;

--- a/Tools/VisualStudio/VisualStudio/Tagging/PSharpTokenTag.cs
+++ b/Tools/VisualStudio/VisualStudio/Tagging/PSharpTokenTag.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using Microsoft.PSharp.LanguageServices.Parsing;
+﻿using Microsoft.PSharp.LanguageServices.Parsing;
 using Microsoft.VisualStudio.Text.Tagging;
 
 namespace Microsoft.PSharp.VisualStudio

--- a/Tools/VisualStudio/VisualStudio/Tagging/PSharpTokenTagger.cs
+++ b/Tools/VisualStudio/VisualStudio/Tagging/PSharpTokenTagger.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Tools/Visualization/TraceViewer/Controls/SearchTextBox.cs
+++ b/Tools/Visualization/TraceViewer/Controls/SearchTextBox.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;

--- a/Tools/Visualization/TraceViewer/Properties/AssemblyInfo.cs
+++ b/Tools/Visualization/TraceViewer/Properties/AssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Windows;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft Corporation")]
 [assembly: AssemblyProduct("PSharpTraceViewer")]
-[assembly: AssemblyCopyright("Copyright © 2018 Microsoft Corporation")]
+[assembly: AssemblyCopyright("Copyright © Microsoft Corporation. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Tools/Visualization/TraceViewer/Tracing/BugTraceObject.cs
+++ b/Tools/Visualization/TraceViewer/Tracing/BugTraceObject.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-namespace Microsoft.PSharp.Visualization
+﻿namespace Microsoft.PSharp.Visualization
 {
     /// <summary>
     /// Class implementing a bug trace object.

--- a/Tools/Visualization/TraceViewer/Utilities/IO.cs
+++ b/Tools/Visualization/TraceViewer/Utilities/IO.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System.IO;
+﻿using System.IO;
 using System.Runtime.Serialization;
 using System.Windows;
 

--- a/Tools/Visualization/TraceViewer/Windows/TraceWindow.xaml.cs
+++ b/Tools/Visualization/TraceViewer/Windows/TraceWindow.xaml.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Windows;

--- a/Tools/Visualization/TraceViewer/Windows/VisualizeWindow.xaml.cs
+++ b/Tools/Visualization/TraceViewer/Windows/VisualizeWindow.xaml.cs
@@ -1,9 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
-// ------------------------------------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;


### PR DESCRIPTION
Fix brace matching at end of file specifically.  Also switched to using standard colors so that the "light" theme looks nice.  

Currently the P# language service defined custom colors with hard coded defaults that are not sensitive to the theme.  The colors chosen look good on dark theme but not the light theme.  These colors show up here in the Environment/Fonts and colors dialog so user can change them.

![image](https://user-images.githubusercontent.com/18707114/63621838-dda16e80-c5a9-11e9-95d1-6d2ab133d395.png)

But is it important for users to be able to change the colors for P# tokens specifically?  The downside with hard coded colors is that they look washed out when you switch to the light theme.  Here the P# colors do not match C# code, they look washed out:

![image](https://user-images.githubusercontent.com/18707114/63621815-d37f7000-c5a9-11e9-9692-192bfb5c1ea6.png)

This is because our colors are not "theme sensitive".  But if we switch to using standard colors then the light and dark themes work equally as well, the colors match C# and the only downside is there are no separately configurable colors for P#.  This is what it looks like with this fix:

![image](https://user-images.githubusercontent.com/18707114/63621807-cb273500-c5a9-11e9-9537-1f5a9efd9344.png)




