### PR TITLE
fix bug in brace matching and colors

### DIFF
--- a/Tests/TestingServices.Tests/Runtime/MustHandleEventTest.cs
+++ b/Tests/TestingServices.Tests/Runtime/MustHandleEventTest.cs
@@ -121,7 +121,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
                 var m = r.CreateMachine(typeof(M1));
                 r.SendEvent(m, new E(), options: new SendOptions(mustHandle: true));
             },
-            configuration: Configuration.Create().WithNumberOfIterations(100),
+            configuration: Configuration.Create().WithNumberOfIterations(500),
             expectedErrors: new string[]
                 {
                     "A must-handle event 'E' was sent to the halted machine 'M1()'.",
@@ -139,7 +139,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
                 r.SendEvent(m, new E());
                 r.SendEvent(m, new E(), options: new SendOptions(mustHandle: true));
             },
-            configuration: Configuration.Create().WithNumberOfIterations(100),
+            configuration: Configuration.Create().WithNumberOfIterations(500),
             expectedErrors: new string[]
                 {
                     "A must-handle event 'E' was sent to the halted machine 'M2()'.",
@@ -172,7 +172,7 @@ namespace Microsoft.PSharp.TestingServices.Tests
                 r.SendEvent(m, new E(), options: new SendOptions(mustHandle: true));
                 r.SendEvent(m, new Halt());
             },
-            configuration: Configuration.Create().WithNumberOfIterations(100));
+            configuration: Configuration.Create().WithNumberOfIterations(500));
         }
 
         [Fact(Timeout=5000)]

--- a/Tools/VisualStudio/VisualStudio/BraceMatching/BraceMatchingTagger.cs
+++ b/Tools/VisualStudio/VisualStudio/BraceMatching/BraceMatchingTagger.cs
@@ -147,13 +147,4 @@ namespace Microsoft.PSharp.VisualStudio
         public static readonly TextMarkerTag BraceHighlightTag = new TextMarkerTag(ClassificationTypeDefinitions.BraceMatchingName);
     }
 
-    internal sealed class ClassificationTypeDefinitions
-    {
-        public const string BraceMatchingName = "brace matching";
-
-        [Export]
-        [Name(BraceMatchingName)]
-        [BaseDefinition("formal language")]
-        internal readonly ClassificationTypeDefinition BraceMatching;
-    }
 }

--- a/Tools/VisualStudio/VisualStudio/BraceMatching/BraceMatchingTagger.cs
+++ b/Tools/VisualStudio/VisualStudio/BraceMatching/BraceMatchingTagger.cs
@@ -6,9 +6,12 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Tagging;
+using Microsoft.VisualStudio.Utilities;
 using Microsoft.PSharp.VisualStudio.Outlining;
 
 namespace Microsoft.PSharp.VisualStudio
@@ -60,8 +63,8 @@ namespace Microsoft.PSharp.VisualStudio
 
         public IEnumerable<ITagSpan<TextMarkerTag>> GetTags(NormalizedSnapshotSpanCollection spans)
         {
-            // Do nothing if there is no content in the buffer, the current SnapshotPoint is not initialized, or we're at the end of the buffer.
-            if (spans.Count == 0 || !CurrentChar.HasValue || CurrentChar.Value.Position >= CurrentChar.Value.Snapshot.Length)
+            // Do nothing if there is no content in the buffer, the current SnapshotPoint is not initialized
+            if (spans.Count == 0 || !CurrentChar.HasValue)
             {
                 yield break;
             }
@@ -72,7 +75,11 @@ namespace Microsoft.PSharp.VisualStudio
                 : CurrentChar.Value.TranslateTo(spans[0].Snapshot, PointTrackingMode.Positive);
 
             // If the current char is an opening char, stay on it. Otherwise, back up one to see if the previous char is the close char.
-            char currentChar = currentCharPoint.GetChar();
+            char currentChar = '\0';
+            if (CurrentChar.Value.Position < CurrentChar.Value.Snapshot.Length)
+            {
+                currentChar = currentCharPoint.GetChar();
+            }
             var currentLine = currentCharPoint.GetContainingLine();
 
             bool isBoundaryChar(out bool isOpen)
@@ -129,12 +136,24 @@ namespace Microsoft.PSharp.VisualStudio
                 TagSpan<TextMarkerTag> getTag(int lineNumber, int offset)
                 {
                     var line = currentCharPoint.Snapshot.GetLineFromLineNumber(lineNumber);
-                    return new TagSpan<TextMarkerTag>(new SnapshotSpan(line.Start + offset, 1), new TextMarkerTag("blue"));
+                    return new TagSpan<TextMarkerTag>(new SnapshotSpan(line.Start + offset, 1), BraceHighlightTag);
                 }
 
                 yield return getTag(foundRegion.StartLineNumber, foundRegion.StartOffset);
                 yield return getTag(foundRegion.EndLineNumber, foundRegion.EndOffset - 1); // -1 here because EndOffset is after the close char
             }
         }
+
+        public static readonly TextMarkerTag BraceHighlightTag = new TextMarkerTag(ClassificationTypeDefinitions.BraceMatchingName);
+    }
+
+    internal sealed class ClassificationTypeDefinitions
+    {
+        public const string BraceMatchingName = "brace matching";
+
+        [Export]
+        [Name(BraceMatchingName)]
+        [BaseDefinition("formal language")]
+        internal readonly ClassificationTypeDefinition BraceMatching;
     }
 }

--- a/Tools/VisualStudio/VisualStudio/Classification/ClassificationFormats.cs
+++ b/Tools/VisualStudio/VisualStudio/Classification/ClassificationFormats.cs
@@ -5,57 +5,49 @@
 
 using System.ComponentModel.Composition;
 using System.Windows.Media;
-
+using Microsoft.CodeAnalysis.Classification;
+using Microsoft.VisualStudio.Language.StandardClassification;
 using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.PSharp.VisualStudio
 {
-    [Export(typeof(EditorFormatDefinition))]
-    [ClassificationType(ClassificationTypeNames = "PSharp.Keyword")]
-    [Name("PSharp.Keyword")]
-    [UserVisible(true)]
-    internal sealed class PSharpKeywordFormat : ClassificationFormatDefinition
+    internal sealed class ClassificationTypeDefinitions
     {
-        public PSharpKeywordFormat()
-        {
-            this.ForegroundColor = Colors.CornflowerBlue;
-        }
-    }
+        [Export]
+        [ClassificationType(ClassificationTypeNames = "PSharp.Keyword")]
+        [Name("PSharp.Keyword")]
+        [UserVisible(true)]
+        [BaseDefinition(PredefinedClassificationTypeNames.Keyword)]
+        internal readonly ClassificationTypeDefinition PSharpKeywordFormat;
 
-    [Export(typeof(EditorFormatDefinition))]
-    [ClassificationType(ClassificationTypeNames = "PSharp.TypeIdentifier")]
-    [Name("PSharp.TypeIdentifier")]
-    [UserVisible(true)]
-    internal sealed class PSharpTypeIdentifierFormat : ClassificationFormatDefinition
-    {
-        public PSharpTypeIdentifierFormat()
-        {
-            this.ForegroundColor = Colors.MediumAquamarine;
-        }
-    }
+        [Export]
+        [ClassificationType(ClassificationTypeNames = "PSharp.TypeIdentifier")]
+        [Name("PSharp.TypeIdentifier")]
+        [UserVisible(true)]
+        [BaseDefinition(PredefinedClassificationTypeNames.Identifier)]
+        internal readonly ClassificationTypeDefinition PSharpTypeIdentifierFormat;
 
-    [Export(typeof(EditorFormatDefinition))]
-    [ClassificationType(ClassificationTypeNames = "PSharp.Comment")]
-    [Name("PSharp.Comment")]
-    [UserVisible(true)]
-    internal sealed class PSharpCommentFormat : ClassificationFormatDefinition
-    {
-        public PSharpCommentFormat()
-        {
-            this.ForegroundColor = Colors.SeaGreen;
-        }
-    }
+        [Export]
+        [ClassificationType(ClassificationTypeNames = "PSharp.Comment")]
+        [Name("PSharp.Comment")]
+        [UserVisible(true)]
+        [BaseDefinition(PredefinedClassificationTypeNames.Comment)]
+        internal readonly ClassificationTypeDefinition PSharpCommentFormat;
 
-    [Export(typeof(EditorFormatDefinition))]
-    [ClassificationType(ClassificationTypeNames = "PSharp.QuotedString")]
-    [Name("PSharp.QuotedString")]
-    [UserVisible(true)]
-    internal sealed class PSharpQuotedStringFormat : ClassificationFormatDefinition
-    {
-        public PSharpQuotedStringFormat()
-        {
-            this.ForegroundColor = Colors.Brown;
-        }
+        [Export]
+        [ClassificationType(ClassificationTypeNames = "PSharp.QuotedString")]
+        [Name("PSharp.QuotedString")]
+        [UserVisible(true)]
+        [BaseDefinition(PredefinedClassificationTypeNames.String)]
+        internal readonly ClassificationTypeDefinition PSharpQuotedStringFormat;
+        
+        [Export]
+        [Name(BraceMatchingName)]
+        [BaseDefinition(PredefinedClassificationTypeNames.FormalLanguage)]
+        internal readonly ClassificationTypeDefinition BraceMatching;
+
+
+        internal const string BraceMatchingName = "brace matching";
     }
 }


### PR DESCRIPTION
Fix brace matching at end of file specifically. Also switched to using standard colors so that the "light" theme looks nice.

Currently the P# language service defined custom colors with hard coded defaults that are not sensitive to the theme. The colors chosen look good on dark theme but not the light theme. These colors show up here in the Environment/Fonts and colors dialog so user can change them.

![image](https://user-images.githubusercontent.com/18707114/63978924-73d30a00-ca6c-11e9-910e-8826d0eb6819.png)

But is it important for users to be able to change the colors for P# tokens specifically? The downside with hard coded colors is that they look washed out when you switch to the light theme. Here the P# colors do not match C# code, they look washed out:

![image](https://user-images.githubusercontent.com/18707114/63978964-9107d880-ca6c-11e9-8180-a69692819b7b.png)

This is because our colors are not "theme sensitive". But if we switch to using standard colors then the light and dark themes work equally as well, the colors match C# and the only downside is there are no separately configurable colors for P#. This is what it looks like with this fix:

![image](https://user-images.githubusercontent.com/18707114/63978982-9d8c3100-ca6c-11e9-8153-e91884c70334.png)

